### PR TITLE
fix: skip all workflows when triggered by a bot actor

### DIFF
--- a/.github/workflows/best-practices.yml
+++ b/.github/workflows/best-practices.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   check-recent-activity:
     name: Check for recent human activity
+    if: github.event.sender.type != 'Bot'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ci-fix.yml
+++ b/.github/workflows/ci-fix.yml
@@ -34,6 +34,7 @@ concurrency:
 jobs:
   should-fix:
     name: Check if fix needed
+    if: github.event.sender.type != 'Bot'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -27,6 +27,7 @@ jobs:
   review:
     name: Claude Code Review
     if: >-
+      github.event.sender.type != 'Bot' &&
       github.event.pull_request != null &&
       !contains(github.event.pull_request.labels.*.name, 'ai:skip-review')
     runs-on: ubuntu-latest

--- a/.github/workflows/code-simplifier.yml
+++ b/.github/workflows/code-simplifier.yml
@@ -21,6 +21,7 @@ concurrency:
 
 jobs:
   simplify:
+    if: github.event.sender.type != 'Bot'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/final-pr-review.yml
+++ b/.github/workflows/final-pr-review.yml
@@ -19,6 +19,7 @@ concurrency:
 jobs:
   gate-check:
     name: Check review gate
+    if: github.event.sender.type != 'Bot'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read

--- a/.github/workflows/issue-hygiene.yml
+++ b/.github/workflows/issue-hygiene.yml
@@ -22,6 +22,7 @@ concurrency:
 
 jobs:
   hygiene:
+    if: github.event.sender.type != 'Bot'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/issue-sweeper.yml
+++ b/.github/workflows/issue-sweeper.yml
@@ -21,6 +21,7 @@ concurrency:
 
 jobs:
   sweep:
+    if: github.event.sender.type != 'Bot'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -12,6 +12,7 @@ concurrency:
 
 jobs:
   triage:
+    if: github.event.sender.type != 'Bot'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -12,6 +12,7 @@ concurrency:
 
 jobs:
   sync:
+    if: github.event.sender.type != 'Bot'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/next-steps.yml
+++ b/.github/workflows/next-steps.yml
@@ -22,6 +22,7 @@ concurrency:
 
 jobs:
   analyze:
+    if: github.event.sender.type != 'Bot'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/post-merge-docs-review.yml
+++ b/.github/workflows/post-merge-docs-review.yml
@@ -20,6 +20,7 @@ concurrency:
 jobs:
   check-relevance:
     name: Check doc relevance
+    if: github.event.sender.type != 'Bot'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -20,6 +20,7 @@ concurrency:
 jobs:
   check-test-infra:
     name: Check test infrastructure
+    if: github.event.sender.type != 'Bot'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/project-router.yml
+++ b/.github/workflows/project-router.yml
@@ -12,6 +12,7 @@ concurrency:
 
 jobs:
   route:
+    if: github.event.sender.type != 'Bot'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/repo-orchestrator.yml
+++ b/.github/workflows/repo-orchestrator.yml
@@ -12,6 +12,7 @@ concurrency:
 
 jobs:
   orchestrate:
+    if: github.event.sender.type != 'Bot'
     runs-on: ubuntu-latest
     permissions:
       actions: write


### PR DESCRIPTION
## Summary

- Adds `if: github.event.sender.type != 'Bot'` to the first (gate) job in all 14 reusable workflows
- When a bot (Renovate, Dependabot, Copilot, etc.) triggers a consumer repo's thin caller, the reusable workflow is silently **skipped** rather than running or failing
- The check uses `github.event.sender.type`, the canonical GitHub field for this — `'Bot'` for any GitHub App, `'User'` for humans, empty/null for scheduled runs (so cron jobs are unaffected)

## Behavior

| Trigger actor | Result |
|---|---|
| Human (`sender.type == 'User'`) | Workflow runs normally |
| Bot (`sender.type == 'Bot'`) | First job skipped → entire workflow skipped |
| Scheduled (`sender` null) | First job runs (null != 'Bot') |
| `workflow_dispatch` (human) | First job runs |

## Propagation for cascading workflows

For workflows with gate → main job chains (ci-fix, final-pr-review, best-practices, post-merge-tests, post-merge-docs-review), the guard on the gate job is sufficient. When the gate is skipped, downstream jobs that check `needs.gate.outputs.should_run == 'true'` are also skipped automatically.

## Exception: claude-review interactive job

The `interactive` job in `claude-review.yml` (triggered by `@claude` comments) does **not** get the bot guard — a human typing `@claude` should always be served.

## Potentially useful for bots (noted, not enabled)

`ci-fix` could theoretically auto-fix Renovate PRs that fail CI. Re-enable by removing the guard from that workflow if desired.

## Test plan

- [ ] Verify Renovate/Dependabot PRs in consumer repos no longer trigger failing workflow runs
- [ ] Verify human-authored PRs still trigger all workflows normally
- [ ] Verify scheduled workflows (`issue-sweeper`, `next-steps`, etc.) still run on their cron

Closes #<!-- issue if any -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add condition to skip workflows triggered by bot actors in 14 workflow files, except `interactive` job in `claude-review.yml`.
> 
>   - **Behavior**:
>     - Adds `if: github.event.sender.type != 'Bot'` to the first job in 14 workflow files to skip workflows triggered by bots.
>     - Exception: `interactive` job in `claude-review.yml` is not skipped for bot triggers.
>   - **Workflows**:
>     - Affected workflows include `best-practices.yml`, `ci-fix.yml`, `claude-review.yml`, and 11 others.
>     - Ensures workflows are skipped if triggered by Renovate, Dependabot, Copilot, etc.
>   - **Propagation**:
>     - For workflows with gate → main job chains, skipping the gate job skips downstream jobs automatically.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fai-workflows&utm_source=github&utm_medium=referral)<sup> for 0ddc48a1e14a22a197f647050e5ce927aff91b32. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->