### PR TITLE
fix: rename release-please config file and enhance config

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -1,5 +1,0 @@
-{
-  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "release-type": "simple",
-  "version-file": "VERSION"
-}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "release-type": "simple",
+  "version-file": "VERSION",
+  "bump-minor-pre-major": true,
+  "include-v-in-tag": true,
+  "changelog-sections": [
+    {"type": "feat", "section": "Features"},
+    {"type": "fix", "section": "Bug Fixes"},
+    {"type": "perf", "section": "Performance"},
+    {"type": "docs", "section": "Documentation", "hidden": true},
+    {"type": "chore", "section": "Miscellaneous", "hidden": true},
+    {"type": "refactor", "section": "Refactoring", "hidden": true},
+    {"type": "test", "section": "Tests", "hidden": true},
+    {"type": "ci", "section": "CI", "hidden": true}
+  ]
+}


### PR DESCRIPTION
## Summary

- Renames `.release-please-config.json` → `release-please-config.json` (no leading dot)
  - release-please-action defaults to looking for `release-please-config.json` — the leading dot caused "Missing required manifest config" failures on every push to main
- Adds `bump-minor-pre-major: true` — while at 0.x, `feat:` bumps minor (0.1→0.2) instead of jumping to 1.0.0
- Adds `include-v-in-tag: true` — explicit (already the default, but clear)
- Adds `changelog-sections` — shows Features/Bug Fixes/Performance in changelog, hides docs/chore/refactor/test/ci noise

## Test plan

- [ ] Merge this PR → release-please workflow runs
- [ ] Verify run succeeds (no more "Missing required manifest config" error)
- [ ] Verify v0.1.0 GitHub Release is created
- [ ] Verify rolling tags (v0, v0.1) are created by update-version-tags workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)