### PR TITLE
fix: add packages key to release-please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,11 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "release-type": "simple",
-  "version-file": "VERSION",
+  "packages": {
+    ".": {
+      "release-type": "simple",
+      "version-file": "VERSION"
+    }
+  },
   "bump-minor-pre-major": true,
   "include-v-in-tag": true,
   "changelog-sections": [


### PR DESCRIPTION
## Summary
- Add `packages` key wrapping the package-specific settings (`release-type`, `version-file`) in `release-please-config.json`
- The manifest strategy requires `packages: { ".": { ... } }` to match the `.release-please-manifest.json` entry
- Without this, release-please was finding 0 commits to release despite 3 unreleased `feat:` and `fix:` commits

## Test plan
- [ ] Merge this PR → release-please should create a release PR for v0.2.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)