### PR TITLE
fix: replace permissions: {} with explicit permissions on issue workflows

### DIFF
--- a/.github/workflows/issue-resolver.yml
+++ b/.github/workflows/issue-resolver.yml
@@ -38,7 +38,12 @@ on:
         type: string
         default: "OWNER,MEMBER,COLLABORATOR,CONTRIBUTOR"
 
-permissions: {}
+# Workflow-level permissions set the maximum for all jobs.
+# permissions: {} silently skips all jobs in cross-repo calls.
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
 
 concurrency:
   group: issue-resolver-${{ github.repository }}-${{ inputs.issue_number != 0 && inputs.issue_number || github.event.issue.number || github.run_id }}

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -5,7 +5,11 @@ on:
   workflow_call:
   workflow_dispatch:
 
-permissions: {}
+# Workflow-level permissions set the maximum for all jobs.
+# permissions: {} silently skips all jobs in cross-repo calls.
+permissions:
+  contents: read
+  issues: write
 
 concurrency:
   group: issue-triage-${{ github.repository }}


### PR DESCRIPTION
## Summary
- `permissions: {}` on reusable workflows sets the max token scope to nothing, silently skipping all jobs in cross-repo calls
- Even though jobs declare their own permissions, they cannot exceed the workflow-level maximum
- Replaces with explicit workflow-level permissions matching the union of all job-level permissions
- Fixes issue-resolver.yml and issue-triage.yml (other workflows to follow)

## Context
The issue-pipeline in nix-config calls these reusable workflows. With `permissions: {}`:
1. Caller `permissions: {}` → `startup_failure` (fixed in nix PR #663)
2. Called workflow `permissions: {}` → silent job skip (this PR)

## Test plan
- [ ] Trigger `workflow_dispatch` on nix Issue Pipeline → resolve job starts (was being skipped)
- [ ] Open an issue in nix → triage runs (was getting startup_failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes silent job skips in cross-repo calls by setting explicit workflow-level permissions in `issue-resolver.yml` and `issue-triage.yml`.
> 
>   - **Behavior**:
>     - Replaces `permissions: {}` with explicit permissions in `issue-resolver.yml` and `issue-triage.yml` to prevent silent job skips in cross-repo calls.
>     - Sets workflow-level permissions to the union of all job-level permissions.
>   - **Files**:
>     - `issue-resolver.yml`: Sets `contents: write`, `issues: write`, `pull-requests: write`.
>     - `issue-triage.yml`: Sets `contents: read`, `issues: write`.
>   - **Test Plan**:
>     - Trigger `workflow_dispatch` on nix Issue Pipeline to verify resolve job starts.
>     - Open an issue in nix to ensure triage runs without startup failure.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fai-workflows&utm_source=github&utm_medium=referral)<sup> for f56339de2a2e263c25ef4b17b525cb8414b666ea. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->