### PR TITLE
fix: replace permissions: {} with explicit permissions on all reusable workflows

### DIFF
--- a/.github/workflows/best-practices.yml
+++ b/.github/workflows/best-practices.yml
@@ -9,7 +9,12 @@ on:
   workflow_call:
   workflow_dispatch:
 
-permissions: {}
+# Workflow-level permissions set the maximum for all jobs.
+# permissions: {} silently skips all jobs in cross-repo calls.
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
 
 concurrency:
   group: best-practices-${{ github.repository }}

--- a/.github/workflows/ci-fix.yml
+++ b/.github/workflows/ci-fix.yml
@@ -25,7 +25,13 @@ on:
         default: ""
   workflow_dispatch:
 
-permissions: {}
+# Workflow-level permissions set the maximum for all jobs.
+# permissions: {} silently skips all jobs in cross-repo calls.
+permissions:
+  actions: read
+  contents: write
+  issues: write
+  pull-requests: write
 
 concurrency:
   group: ci-fix-${{ github.repository }}-${{ github.event.workflow_run.head_branch || github.ref }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -17,7 +17,14 @@ on:
         default: ""
   workflow_dispatch:
 
-permissions: {}
+# Workflow-level permissions set the maximum for all jobs.
+# permissions: {} silently skips all jobs in cross-repo calls.
+permissions:
+  actions: read
+  contents: read
+  id-token: write
+  issues: write
+  pull-requests: write
 
 concurrency:
   group: claude-review-${{ github.repository }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}

--- a/.github/workflows/code-simplifier.yml
+++ b/.github/workflows/code-simplifier.yml
@@ -11,7 +11,11 @@ on:
   workflow_call:
   workflow_dispatch:
 
-permissions: {}
+# Workflow-level permissions set the maximum for all jobs.
+# permissions: {} silently skips all jobs in cross-repo calls.
+permissions:
+  contents: write
+  pull-requests: write
 
 concurrency:
   group: code-simplifier-${{ github.repository }}

--- a/.github/workflows/final-pr-review.yml
+++ b/.github/workflows/final-pr-review.yml
@@ -10,7 +10,13 @@ on:
   workflow_call:
   workflow_dispatch:
 
-permissions: {}
+# Workflow-level permissions set the maximum for all jobs.
+# permissions: {} silently skips all jobs in cross-repo calls.
+permissions:
+  checks: read
+  contents: read
+  issues: write
+  pull-requests: write
 
 concurrency:
   group: final-pr-review-${{ github.repository }}-${{ github.event.pull_request.number || github.event.check_suite.pull_requests[0].number || github.run_id }}

--- a/.github/workflows/issue-hygiene.yml
+++ b/.github/workflows/issue-hygiene.yml
@@ -11,7 +11,12 @@ on:
   workflow_call:
   workflow_dispatch:
 
-permissions: {}
+# Workflow-level permissions set the maximum for all jobs.
+# permissions: {} silently skips all jobs in cross-repo calls.
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
 
 concurrency:
   group: issue-hygiene-${{ github.repository }}

--- a/.github/workflows/issue-sweeper.yml
+++ b/.github/workflows/issue-sweeper.yml
@@ -10,7 +10,12 @@ on:
   workflow_call:
   workflow_dispatch:
 
-permissions: {}
+# Workflow-level permissions set the maximum for all jobs.
+# permissions: {} silently skips all jobs in cross-repo calls.
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
 
 concurrency:
   group: issue-sweeper-${{ github.repository }}

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -5,7 +5,11 @@ on:
   workflow_call:
   workflow_dispatch:
 
-permissions: {}
+# Workflow-level permissions set the maximum for all jobs.
+# permissions: {} silently skips all jobs in cross-repo calls.
+permissions:
+  contents: read
+  issues: write
 
 concurrency:
   group: label-sync-${{ github.repository }}

--- a/.github/workflows/next-steps.yml
+++ b/.github/workflows/next-steps.yml
@@ -11,7 +11,11 @@ on:
   workflow_call:
   workflow_dispatch:
 
-permissions: {}
+# Workflow-level permissions set the maximum for all jobs.
+# permissions: {} silently skips all jobs in cross-repo calls.
+permissions:
+  contents: read
+  issues: write
 
 concurrency:
   group: next-steps-${{ github.repository }}

--- a/.github/workflows/post-merge-docs-review.yml
+++ b/.github/workflows/post-merge-docs-review.yml
@@ -12,7 +12,11 @@ on:
   workflow_call:
   workflow_dispatch:
 
-permissions: {}
+# Workflow-level permissions set the maximum for all jobs.
+# permissions: {} silently skips all jobs in cross-repo calls.
+permissions:
+  contents: write
+  pull-requests: write
 
 concurrency:
   group: post-merge-docs-${{ github.repository }}

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -12,7 +12,11 @@ on:
   workflow_call:
   workflow_dispatch:
 
-permissions: {}
+# Workflow-level permissions set the maximum for all jobs.
+# permissions: {} silently skips all jobs in cross-repo calls.
+permissions:
+  contents: write
+  pull-requests: write
 
 concurrency:
   group: post-merge-tests-${{ github.repository }}

--- a/.github/workflows/project-router.yml
+++ b/.github/workflows/project-router.yml
@@ -5,7 +5,12 @@ on:
   workflow_call:
   workflow_dispatch:
 
-permissions: {}
+# Workflow-level permissions set the maximum for all jobs.
+# permissions: {} silently skips all jobs in cross-repo calls.
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
 
 concurrency:
   group: project-router-${{ github.repository }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches: [main]
 
-permissions: {}
+# Workflow-level permissions set the maximum for all jobs.
+# permissions: {} silently skips all jobs in cross-repo calls.
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   release-please:

--- a/.github/workflows/repo-orchestrator.yml
+++ b/.github/workflows/repo-orchestrator.yml
@@ -5,7 +5,11 @@ on:
   workflow_call:
   workflow_dispatch:
 
-permissions: {}
+# Workflow-level permissions set the maximum for all jobs.
+# permissions: {} silently skips all jobs in cross-repo calls.
+permissions:
+  actions: write
+  contents: read
 
 concurrency:
   group: repo-orchestrator-${{ github.repository }}

--- a/.github/workflows/update-version-tags.yml
+++ b/.github/workflows/update-version-tags.yml
@@ -4,7 +4,10 @@ on:
   release:
     types: [published]
 
-permissions: {}
+# Workflow-level permissions set the maximum for all jobs.
+# permissions: {} silently skips all jobs in cross-repo calls.
+permissions:
+  contents: write
 
 jobs:
   update-tags:


### PR DESCRIPTION
## Summary

- **Root cause**: `permissions: {}` at workflow level sets GITHUB_TOKEN scope to nothing, causing `startup_failure` for all cross-repo reusable workflow calls. This was fixed for `issue-triage.yml` and `issue-resolver.yml` in #24 but the remaining 15 workflows were not updated.
- **Impact**: Every consumer repo (nix, terraform-proxmox, ansible-proxmox-apps) gets `startup_failure` on every PR event, push to main, issue comment, and review — generating massive notification spam (5+ failure notifications per PR)
- **Fix**: Replace `permissions: {}` with the union of all job-level permissions for each workflow, following the pattern from #24

### Affected workflows (13 reusable + 2 internal)

| Workflow | Permissions Added |
|----------|------------------|
| `claude-review.yml` | actions:r, contents:r, id-token:w, issues:w, pull-requests:w |
| `final-pr-review.yml` | checks:r, contents:r, issues:w, pull-requests:w |
| `ci-fix.yml` | actions:r, contents:w, issues:w, pull-requests:w |
| `post-merge-tests.yml` | contents:w, pull-requests:w |
| `post-merge-docs-review.yml` | contents:w, pull-requests:w |
| `best-practices.yml` | contents:r, issues:w, pull-requests:r |
| `code-simplifier.yml` | contents:w, pull-requests:w |
| `issue-hygiene.yml` | contents:r, issues:w, pull-requests:r |
| `issue-sweeper.yml` | contents:r, issues:w, pull-requests:r |
| `next-steps.yml` | contents:r, issues:w |
| `label-sync.yml` | contents:r, issues:w |
| `project-router.yml` | contents:r, issues:w, pull-requests:r |
| `repo-orchestrator.yml` | actions:w, contents:r |
| `release-please.yml` | contents:w, pull-requests:w |
| `update-version-tags.yml` | contents:w |

## Test plan

- [ ] Merge this PR and tag a new release (v0.3.0)
- [ ] Verify `startup_failure` stops on consumer repos
- [ ] Consumer repos need callers updated to match (separate PRs after version bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaces `permissions: {}` with explicit permissions in 15 workflows to prevent `startup_failure` in cross-repo calls.
> 
>   - **Behavior**:
>     - Replaces `permissions: {}` with explicit permissions in 15 workflows to prevent `startup_failure` in cross-repo calls.
>     - Affected workflows include `claude-review.yml`, `final-pr-review.yml`, `ci-fix.yml`, and 12 others.
>   - **Permissions**:
>     - `claude-review.yml`: `actions:r, contents:r, id-token:w, issues:w, pull-requests:w`
>     - `final-pr-review.yml`: `checks:r, contents:r, issues:w, pull-requests:w`
>     - `ci-fix.yml`: `actions:r, contents:w, issues:w, pull-requests:w`
>     - `post-merge-tests.yml`: `contents:w, pull-requests:w`
>     - `post-merge-docs-review.yml`: `contents:w, pull-requests:w`
>     - `best-practices.yml`: `contents:r, issues:w, pull-requests:r`
>     - `code-simplifier.yml`: `contents:w, pull-requests:w`
>     - `issue-hygiene.yml`: `contents:r, issues:w, pull-requests:r`
>     - `issue-sweeper.yml`: `contents:r, issues:w, pull-requests:r`
>     - `next-steps.yml`: `contents:r, issues:w`
>     - `label-sync.yml`: `contents:r, issues:w`
>     - `project-router.yml`: `contents:r, issues:w, pull-requests:r`
>     - `repo-orchestrator.yml`: `actions:w, contents:r`
>     - `release-please.yml`: `contents:w, pull-requests:w`
>     - `update-version-tags.yml`: `contents:w`
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fai-workflows&utm_source=github&utm_medium=referral)<sup> for c951a8ebfefe9574af5e4e2c3a5988206c176601. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->