### PR TITLE
fix: remove inputs context from issue-resolver concurrency group

### DIFF
--- a/.github/workflows/issue-resolver.yml
+++ b/.github/workflows/issue-resolver.yml
@@ -46,7 +46,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: issue-resolver-${{ github.repository }}-${{ inputs.issue_number != 0 && inputs.issue_number || github.event.issue.number || github.run_id }}
+  group: issue-resolver-${{ github.repository }}-${{ github.event.issue.number || github.run_id }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Summary
- Remove `inputs.issue_number` from the concurrency group expression in `issue-resolver.yml`
- Replace with `github.event.issue.number || github.run_id`

## Root Cause
The `inputs` context in a reusable workflow's `concurrency:` block causes `startup_failure` (0 jobs, 3-second completion). GitHub Actions cannot evaluate `inputs` during concurrency group resolution for `workflow_call` workflows. This was the **only** reusable workflow using `inputs` in its concurrency block — all others use `github.event.*` or `github.repository`.

## Behavior Change
- **Issues trigger**: Uses `github.event.issue.number` for deduplication (same as before)
- **Manual dispatch**: Falls back to `github.run_id` (unique per invocation, no cross-run dedup — acceptable since manual dispatch implies intent)

## Test Plan
1. Merge this PR and release v0.2.4
2. Update nix `issue-pipeline.yml` to `@v0.2.4`
3. Run `gh workflow run issue-pipeline.yml -f issue_number=659`
4. Verify jobs appear (eligibility-check + resolve) instead of startup_failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix concurrency group in `issue-resolver.yml` by replacing `inputs.issue_number` with `github.event.issue.number || github.run_id`.
> 
>   - **Concurrency Group Change**:
>     - In `issue-resolver.yml`, replace `inputs.issue_number` with `github.event.issue.number || github.run_id` in the `concurrency` group.
>   - **Behavior**:
>     - For issues trigger, uses `github.event.issue.number` for deduplication.
>     - For manual dispatch, uses `github.run_id` to ensure unique runs without cross-run deduplication.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fai-workflows&utm_source=github&utm_medium=referral)<sup> for 6f9eeec137c9fb7603b7fdb21200fc9712080d10. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->