### PR TITLE
fix: change issue-resolver inputs from type:number to type:string

### DIFF
--- a/.github/workflows/issue-resolver.yml
+++ b/.github/workflows/issue-resolver.yml
@@ -27,12 +27,12 @@ on:
         default: "type:security,type:feature,type:breaking,size:l,size:xl"
       max_attempts:
         description: "Max resolution attempts per issue"
-        type: number
-        default: 1
+        type: string
+        default: "1"
       issue_number:
         description: "Issue number to resolve (overrides event payload; enables manual dispatch)"
-        type: number
-        default: 0
+        type: string
+        default: "0"
       allowed_authors:
         description: "Comma-separated author_association values allowed to trigger resolution"
         type: string


### PR DESCRIPTION
## Summary
- Change `max_attempts` and `issue_number` from `type: number` to `type: string`
- Update default values to strings ("1" and "0")

## Root Cause
`workflow_call` inputs with `type: number` cause `startup_failure` (0 jobs) when callers pass string expressions from `workflow_dispatch` (e.g., `${{ github.event.inputs.issue_number || 0 }}`). GitHub's string-to-number coercion fails silently during workflow graph construction.

**Evidence**: The `issues: [opened]` trigger path works (doesn't pass `issue_number`, uses default `0`). Only the `workflow_dispatch` path fails (passes string "659" to `type: number` input).

## No Script Changes Needed
`check-eligibility.js` already uses `parseInt()` for all numeric values, so it handles string inputs natively.

## Test Plan
1. Release v0.2.5
2. Update nix `issue-pipeline.yml` to `@v0.2.5`
3. `gh workflow run issue-pipeline.yml -f issue_number=659`
4. Expect: jobs appear (eligibility-check + resolve)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change `max_attempts` and `issue_number` inputs from `number` to `string` in `issue-resolver.yml` to fix startup failures.
> 
>   - **Behavior**:
>     - Change `max_attempts` and `issue_number` from `type: number` to `type: string` in `issue-resolver.yml`.
>     - Update default values to strings: `max_attempts` to "1" and `issue_number` to "0".
>   - **Root Cause**:
>     - Fixes `startup_failure` when `workflow_dispatch` passes string expressions to `number` inputs.
>     - GitHub's string-to-number coercion fails silently during workflow graph construction.
>   - **No Script Changes Needed**:
>     - `check-eligibility.js` already uses `parseInt()` for numeric values, handling string inputs natively.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fai-workflows&utm_source=github&utm_medium=referral)<sup> for 8f948d934cd5e16b29082c65aca77b30f2319e8f. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->