### PR TITLE
fix: migrate claude-code-action inputs and bump action versions

### DIFF
--- a/.github/workflows/best-practices.yml
+++ b/.github/workflows/best-practices.yml
@@ -31,7 +31,7 @@ jobs:
       should_run: ${{ steps.check.outputs.should_run }}
     steps:
       - name: Checkout ai-workflows scripts
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: JacobPEvans/ai-workflows
           sparse-checkout: .github/scripts
@@ -39,7 +39,7 @@ jobs:
 
       - name: Check for human commits since last recommendation
         id: check
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const run = require('./.ai-workflows/.github/scripts/best-practices/check-recent-activity.js');
@@ -57,10 +57,10 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Checkout ai-workflows
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: JacobPEvans/ai-workflows
           sparse-checkout: |
@@ -82,7 +82,7 @@ jobs:
           anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_env: |
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          model: claude-sonnet-4-5-20250929
+          model: claude-sonnet-4-6
           mcp_config: /tmp/mcp-config/mcp-servers.json
           prompt_file: .ai-workflows/.github/prompts/best-practices.md
           timeout_minutes: "5"

--- a/.github/workflows/ci-fix.yml
+++ b/.github/workflows/ci-fix.yml
@@ -30,6 +30,7 @@ on:
 permissions:
   actions: read
   contents: write
+  id-token: write
   issues: write
   pull-requests: write
 
@@ -51,7 +52,7 @@ jobs:
       attempt: ${{ steps.check-attempts.outputs.attempt }}
     steps:
       - name: Checkout ai-workflows scripts
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: JacobPEvans/ai-workflows
           sparse-checkout: .github/scripts
@@ -59,7 +60,7 @@ jobs:
 
       - name: Find associated PR
         id: find-pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const run = require('./.ai-workflows/.github/scripts/ci-fix/find-pr.js');
@@ -68,7 +69,7 @@ jobs:
       - name: Check attempt count
         id: check-attempts
         if: steps.find-pr.outputs.pr_number != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           PR_NUMBER: ${{ steps.find-pr.outputs.pr_number }}
         with:
@@ -88,14 +89,14 @@ jobs:
       issues: write
     steps:
       - name: Checkout ai-workflows scripts
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: JacobPEvans/ai-workflows
           sparse-checkout: .github/scripts
           path: .ai-workflows
 
       - name: Post tracking comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           PR_NUMBER: ${{ needs.should-fix.outputs.pr_number }}
           ATTEMPT: ${{ needs.should-fix.outputs.attempt }}
@@ -117,7 +118,7 @@ jobs:
       failure_logs: ${{ steps.get-logs.outputs.logs }}
     steps:
       - name: Checkout ai-workflows scripts
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: JacobPEvans/ai-workflows
           sparse-checkout: .github/scripts
@@ -125,7 +126,7 @@ jobs:
 
       - name: Download failure logs
         id: get-logs
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const run = require('./.ai-workflows/.github/scripts/ci-fix/get-failure-logs.js');
@@ -139,18 +140,18 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
       pull-requests: write
     timeout-minutes: 15
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.workflow_run.head_branch }}
           fetch-depth: 0
-          token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
       - name: Checkout ai-workflows prompts
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: JacobPEvans/ai-workflows
           sparse-checkout: |
@@ -171,5 +172,6 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          direct_prompt: ${{ steps.prompt.outputs.content }}
-          allowed_tools: "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git:*)${{ inputs.extra_tools != '' && format(',{0}', inputs.extra_tools) || '' }}"
+          prompt: ${{ steps.prompt.outputs.content }}
+          claude_args: >-
+            --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git:*)${{ inputs.extra_tools != '' && format(',{0}', inputs.extra_tools) || '' }}"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -47,12 +47,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
       - name: Checkout ai-workflows prompts
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: JacobPEvans/ai-workflows
           sparse-checkout: |
@@ -91,7 +91,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run Claude Interactive
         uses: anthropics/claude-code-action@v1

--- a/.github/workflows/code-simplifier.yml
+++ b/.github/workflows/code-simplifier.yml
@@ -31,10 +31,10 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Checkout ai-workflows
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: JacobPEvans/ai-workflows
           sparse-checkout: |
@@ -53,7 +53,7 @@ jobs:
         uses: anthropics/claude-code-base-action@v0.0.63
         with:
           anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          model: claude-sonnet-4-5-20250929
+          model: claude-sonnet-4-6
           prompt_file: .ai-workflows/.github/prompts/code-simplifier.md
           mcp_config: /tmp/mcp-config/mcp-servers.json
           allowed_tools: Glob,Grep,LS,NotebookRead,Read,Bash(git:*),Edit,MultiEdit,Write,mcp__github__list_commits,mcp__github__list_pull_requests,mcp__github__get_pull_request,mcp__github__get_pull_request_files,mcp__github__get_file_contents,mcp__github__create_pull_request

--- a/.github/workflows/final-pr-review.yml
+++ b/.github/workflows/final-pr-review.yml
@@ -15,6 +15,7 @@ on:
 permissions:
   checks: read
   contents: read
+  id-token: write
   issues: write
   pull-requests: write
 
@@ -36,7 +37,7 @@ jobs:
       pr_number: ${{ steps.gate.outputs.pr_number }}
     steps:
       - name: Checkout ai-workflows scripts
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: JacobPEvans/ai-workflows
           sparse-checkout: .github/scripts
@@ -44,7 +45,7 @@ jobs:
 
       - name: Check gate conditions
         id: gate
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const run = require('./.ai-workflows/.github/scripts/final-pr-review/check-gate.js');
@@ -56,17 +57,18 @@ jobs:
     if: needs.gate-check.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: write
-      issues: read
       checks: read
+      contents: read
+      id-token: write
+      issues: read
+      pull-requests: write
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Checkout ai-workflows prompts
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: JacobPEvans/ai-workflows
           sparse-checkout: |
@@ -84,9 +86,10 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          model: claude-sonnet-4-5-20250929
-          direct_prompt: ${{ steps.prompt.outputs.content }}
-          allowed_tools: "Read,Glob,Grep,LS,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*)"
+          prompt: ${{ steps.prompt.outputs.content }}
+          claude_args: >-
+            --model claude-sonnet-4-6
+            --allowedTools "Read,Glob,Grep,LS,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*)"
 
   add-label:
     name: Mark as reviewed
@@ -98,14 +101,14 @@ jobs:
       issues: write
     steps:
       - name: Checkout ai-workflows scripts
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: JacobPEvans/ai-workflows
           sparse-checkout: .github/scripts
           path: .ai-workflows
 
       - name: Add ai:reviewed label
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           PR_NUMBER: ${{ needs.gate-check.outputs.pr_number }}
         with:

--- a/.github/workflows/issue-hygiene.yml
+++ b/.github/workflows/issue-hygiene.yml
@@ -33,10 +33,10 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Checkout ai-workflows
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: JacobPEvans/ai-workflows
           sparse-checkout: |
@@ -55,7 +55,7 @@ jobs:
         uses: anthropics/claude-code-base-action@v0.0.63
         with:
           anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          model: claude-sonnet-4-5-20250929
+          model: claude-sonnet-4-6
           prompt_file: .ai-workflows/.github/prompts/issue-hygiene.md
           mcp_config: /tmp/mcp-config/mcp-servers.json
           allowed_tools: Glob,Grep,LS,NotebookRead,Read,Task,mcp__github__add_issue_comment,mcp__github__get_issue,mcp__github__get_pull_request,mcp__github__list_issue_comments,mcp__github__list_issues,mcp__github__list_pull_requests,mcp__github__search_issues

--- a/.github/workflows/issue-resolver.yml
+++ b/.github/workflows/issue-resolver.yml
@@ -42,6 +42,7 @@ on:
 # permissions: {} silently skips all jobs in cross-repo calls.
 permissions:
   contents: write
+  id-token: write
   issues: write
   pull-requests: write
 
@@ -66,7 +67,7 @@ jobs:
       max_attempts: ${{ inputs.max_attempts }}
     steps:
       - name: Checkout ai-workflows scripts
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: JacobPEvans/ai-workflows
           sparse-checkout: .github/scripts
@@ -79,7 +80,7 @@ jobs:
           MAX_ATTEMPTS: ${{ inputs.max_attempts }}
           ISSUE_NUMBER: ${{ inputs.issue_number }}
           ALLOWED_AUTHORS: ${{ inputs.allowed_authors }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const run = require('./.ai-workflows/.github/scripts/issue-resolver/check-eligibility.js');
@@ -92,18 +93,18 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pull-requests: write
+      id-token: write
       issues: write
+      pull-requests: write
     timeout-minutes: 15
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
       - name: Checkout ai-workflows
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: JacobPEvans/ai-workflows
           sparse-checkout: |
@@ -127,6 +128,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          direct_prompt: ${{ steps.prompt.outputs.content }}
-          allowed_tools: "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git:*),Bash(gh pr create:*),Bash(gh issue comment:*)${{ inputs.extra_tools != '' && format(',{0}', inputs.extra_tools) || '' }}"
-          model: ${{ inputs.model }}
+          prompt: ${{ steps.prompt.outputs.content }}
+          claude_args: >-
+            --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git:*),Bash(gh pr create:*),Bash(gh issue comment:*)${{ inputs.extra_tools != '' && format(',{0}', inputs.extra_tools) || '' }}"
+            ${{ inputs.model != '' && format('--model {0}', inputs.model) || '' }}

--- a/.github/workflows/issue-sweeper.yml
+++ b/.github/workflows/issue-sweeper.yml
@@ -32,10 +32,10 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Checkout ai-workflows
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: JacobPEvans/ai-workflows
           sparse-checkout: |
@@ -54,7 +54,7 @@ jobs:
         uses: anthropics/claude-code-base-action@v0.0.63
         with:
           anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          model: claude-sonnet-4-5-20250929
+          model: claude-sonnet-4-6
           prompt_file: .ai-workflows/.github/prompts/issue-sweeper.md
           mcp_config: /tmp/mcp-config/mcp-servers.json
           allowed_tools: Glob,Grep,LS,NotebookRead,Read,Task,mcp__github__list_issues,mcp__github__get_issue,mcp__github__list_pull_requests,mcp__github__search_issues,mcp__github__list_branches,mcp__github__list_commits,mcp__github__update_issue,mcp__github__add_issue_comment,mcp__github__list_issue_comments

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -23,10 +23,10 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Checkout ai-workflows
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: JacobPEvans/ai-workflows
           sparse-checkout: |
@@ -48,7 +48,7 @@ jobs:
           anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_env: |
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          model: claude-sonnet-4-5-20250929
+          model: claude-sonnet-4-6
           mcp_config: /tmp/mcp-config/mcp-servers.json
           prompt_file: .ai-workflows/.github/prompts/issue-triage.md
           timeout_minutes: "5"

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -24,10 +24,10 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Checkout ai-workflows
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: JacobPEvans/ai-workflows
           sparse-checkout: |
@@ -49,7 +49,7 @@ jobs:
           anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_env: |
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          model: claude-sonnet-4-5-20250929
+          model: claude-sonnet-4-6
           mcp_config: /tmp/mcp-config/mcp-servers.json
           prompt_file: .ai-workflows/.github/prompts/label-sync.md
           timeout_minutes: "5"

--- a/.github/workflows/next-steps.yml
+++ b/.github/workflows/next-steps.yml
@@ -31,10 +31,10 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Checkout ai-workflows
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: JacobPEvans/ai-workflows
           sparse-checkout: |
@@ -53,7 +53,7 @@ jobs:
         uses: anthropics/claude-code-base-action@v0.0.63
         with:
           anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          model: claude-sonnet-4-5-20250929
+          model: claude-sonnet-4-6
           prompt_file: .ai-workflows/.github/prompts/next-steps.md
           mcp_config: /tmp/mcp-config/mcp-servers.json
           allowed_tools: Glob,Grep,LS,NotebookRead,Read,Task,mcp__github__list_commits,mcp__github__list_pull_requests,mcp__github__get_pull_request,mcp__github__get_pull_request_files,mcp__github__list_issues,mcp__github__search_issues,mcp__github__create_issue,mcp__github__create_pull_request

--- a/.github/workflows/post-merge-docs-review.yml
+++ b/.github/workflows/post-merge-docs-review.yml
@@ -32,7 +32,7 @@ jobs:
       is_relevant: ${{ steps.check.outputs.is_relevant }}
     steps:
       - name: Checkout ai-workflows scripts
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: JacobPEvans/ai-workflows
           sparse-checkout: .github/scripts
@@ -40,7 +40,7 @@ jobs:
 
       - name: Check if changes are doc-relevant
         id: check
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const run = require('./.ai-workflows/.github/scripts/post-merge-docs-review/check-docs-relevance.js');
@@ -57,10 +57,10 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Checkout ai-workflows
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: JacobPEvans/ai-workflows
           sparse-checkout: |
@@ -88,7 +88,7 @@ jobs:
           anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_env: |
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          model: claude-sonnet-4-5-20250929
+          model: claude-sonnet-4-6
           mcp_config: /tmp/mcp-config/mcp-servers.json
           prompt_file: /tmp/prompt.md
           timeout_minutes: "10"

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -32,7 +32,7 @@ jobs:
       has_tests: ${{ steps.check.outputs.has_tests }}
     steps:
       - name: Checkout ai-workflows scripts
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: JacobPEvans/ai-workflows
           sparse-checkout: .github/scripts
@@ -40,7 +40,7 @@ jobs:
 
       - name: Check for test infrastructure
         id: check
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const run = require('./.ai-workflows/.github/scripts/post-merge-tests/check-test-infra.js');
@@ -57,10 +57,10 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Checkout ai-workflows
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: JacobPEvans/ai-workflows
           sparse-checkout: |
@@ -88,7 +88,7 @@ jobs:
           anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_env: |
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          model: claude-sonnet-4-5-20250929
+          model: claude-sonnet-4-6
           mcp_config: /tmp/mcp-config/mcp-servers.json
           prompt_file: /tmp/prompt.md
           timeout_minutes: "10"

--- a/.github/workflows/project-router.yml
+++ b/.github/workflows/project-router.yml
@@ -26,10 +26,10 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Checkout ai-workflows
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: JacobPEvans/ai-workflows
           sparse-checkout: |
@@ -51,7 +51,7 @@ jobs:
           anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_env: |
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          model: claude-sonnet-4-5-20250929
+          model: claude-sonnet-4-6
           mcp_config: /tmp/mcp-config/mcp-servers.json
           prompt_file: .ai-workflows/.github/prompts/project-router.md
           timeout_minutes: "5"

--- a/.github/workflows/repo-orchestrator.yml
+++ b/.github/workflows/repo-orchestrator.yml
@@ -24,10 +24,10 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Checkout ai-workflows
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: JacobPEvans/ai-workflows
           sparse-checkout: |
@@ -49,7 +49,7 @@ jobs:
           anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_env: |
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          model: claude-sonnet-4-5-20250929
+          model: claude-sonnet-4-6
           mcp_config: /tmp/mcp-config/mcp-servers.json
           prompt_file: .ai-workflows/.github/prompts/repo-orchestrator.md
           timeout_minutes: "5"


### PR DESCRIPTION
## Summary

- **Migrate deprecated claude-code-action@v1 inputs** in issue-resolver, ci-fix, and final-pr-review:
  - `direct_prompt` → `prompt`
  - `allowed_tools` → `claude_args: --allowedTools "..."`
  - `model` → `claude_args: --model <model>`
- **Add `id-token: write` permission** at workflow and job level for OIDC token exchange (required for git push auth)
- **Remove explicit checkout token** from issue-resolver and ci-fix (action handles push auth via OIDC)
- **Bump actions/checkout** `@v4` → `@v6` across all 15 reusable workflows
- **Bump actions/github-script** `@v7` → `@v8` across 7 workflows that use it
- **Update model** `claude-sonnet-4-5-20250929` → `claude-sonnet-4-6` across 12 workflows

## Context

The issue-resolver pipeline was failing at checkout with "could not read Username for https://github.com: terminal prompts disabled" because:
1. claude-code-action@v1 removed `direct_prompt`, `allowed_tools`, and `model` inputs — Claude was getting NO prompt
2. Missing `id-token: write` prevented OIDC token exchange for git auth

The working `claude-review.yml` already used the correct pattern (`prompt`, `claude_args`, `id-token: write`).

## Test plan

- [ ] Release v0.3.0 via release-please
- [ ] Update consumer repos (nix, ansible, terraform) to `@v0.3.0` with `id-token: write`
- [ ] Manual dispatch: `gh workflow run issue-pipeline.yml -R JacobPEvans/nix -f issue_number=659`
- [ ] Verify: eligibility passes → Claude Resolve starts → draft PR created

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Migrate deprecated `claude-code-action` inputs, update action versions, and enhance authentication in multiple workflows.
> 
>   - **Inputs Migration**:
>     - Migrate deprecated `claude-code-action@v1` inputs in `issue-resolver`, `ci-fix`, and `final-pr-review`:
>       - `direct_prompt` → `prompt`
>       - `allowed_tools` → `claude_args: --allowedTools "..."`
>       - `model` → `claude_args: --model <model>`
>   - **Permissions**:
>     - Add `id-token: write` permission at workflow and job level for OIDC token exchange.
>     - Remove explicit checkout token from `issue-resolver` and `ci-fix`.
>   - **Action Versions**:
>     - Bump `actions/checkout` `@v4` → `@v6` across all 15 reusable workflows.
>     - Bump `actions/github-script` `@v7` → `@v8` across 7 workflows.
>   - **Model Update**:
>     - Update model `claude-sonnet-4-5-20250929` → `claude-sonnet-4-6` across 12 workflows.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fai-workflows&utm_source=github&utm_medium=referral)<sup> for fa936dd50543fc86d05e5fae8dadc216e43658d5. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->