### PR TITLE
fix: switch to SSH commit signing for agent-mode workflows

### DIFF
--- a/.github/workflows/ci-fix.yml
+++ b/.github/workflows/ci-fix.yml
@@ -172,7 +172,9 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          use_commit_signing: true
+          ssh_signing_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          bot_name: "jacobpevans-github-actions[bot]"
+          bot_id: "251056911"
           prompt: ${{ steps.prompt.outputs.content }}
           claude_args: >-
             --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git:*)${{ inputs.extra_tools != '' && format(',{0}', inputs.extra_tools) || '' }}"

--- a/.github/workflows/issue-resolver.yml
+++ b/.github/workflows/issue-resolver.yml
@@ -128,7 +128,9 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          use_commit_signing: true
+          ssh_signing_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          bot_name: "jacobpevans-github-actions[bot]"
+          bot_id: "251056911"
           prompt: ${{ steps.prompt.outputs.content }}
           claude_args: >-
             --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git:*),Bash(gh pr create:*),Bash(gh issue comment:*)${{ inputs.extra_tools != '' && format(',{0}', inputs.extra_tools) || '' }}"


### PR DESCRIPTION
## Summary
- Replace `use_commit_signing: true` (API mode) with `ssh_signing_key` (SSH mode) on issue-resolver and ci-fix
- API mode doesn't work in agent mode: the action skips `configureGitAuth()` entirely, leaving Claude with no git auth
- SSH mode configures `gpg.format ssh` + `commit.gpgsign true`, producing verified commits via git CLI
- Uses `GH_APP_PRIVATE_KEY` secret (jacobpevans-github-actions bot, ID 251056911)

## Test plan
- [ ] After secret is synced to nix-config, re-run issue resolver on issue #679
- [ ] Verify push succeeds and draft PR is created with verified commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Switches commit signing from API mode to SSH mode in `ci-fix.yml` and `issue-resolver.yml` for verified commits using SSH keys.
> 
>   - **Behavior**:
>     - Replace `use_commit_signing: true` with `ssh_signing_key` in `ci-fix.yml` and `issue-resolver.yml` to switch from API mode to SSH mode for commit signing.
>     - SSH mode configures `gpg.format ssh` and `commit.gpgsign true` for verified commits.
>     - Uses `GH_APP_PRIVATE_KEY` for SSH key, associated with `jacobpevans-github-actions` bot.
>   - **Files**:
>     - Updates in `ci-fix.yml` and `issue-resolver.yml` to reflect new SSH signing configuration.
>   - **Misc**:
>     - Adds `bot_name` and `bot_id` parameters for the GitHub Actions bot in both workflows.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fai-workflows&utm_source=github&utm_medium=referral)<sup> for ca2e6f9a83242fffcec1cb2cf557ef22eeb2b881. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->