### PR TITLE
fix: use Claude SSH signing key and default bot identity

### DIFF
--- a/.github/workflows/ci-fix.yml
+++ b/.github/workflows/ci-fix.yml
@@ -172,9 +172,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          ssh_signing_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          bot_name: "jacobpevans-github-actions[bot]"
-          bot_id: "251056911"
+          ssh_signing_key: ${{ secrets.GH_CLAUDE_SSH_SIGNING_KEY }}
           prompt: ${{ steps.prompt.outputs.content }}
           claude_args: >-
             --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git:*)${{ inputs.extra_tools != '' && format(',{0}', inputs.extra_tools) || '' }}"

--- a/.github/workflows/issue-resolver.yml
+++ b/.github/workflows/issue-resolver.yml
@@ -128,9 +128,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          ssh_signing_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          bot_name: "jacobpevans-github-actions[bot]"
-          bot_id: "251056911"
+          ssh_signing_key: ${{ secrets.GH_CLAUDE_SSH_SIGNING_KEY }}
           prompt: ${{ steps.prompt.outputs.content }}
           claude_args: >-
             --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git:*),Bash(gh pr create:*),Bash(gh issue comment:*)${{ inputs.extra_tools != '' && format(',{0}', inputs.extra_tools) || '' }}"


### PR DESCRIPTION
## Summary
- Switch secret from `GH_APP_PRIVATE_KEY` to `GH_CLAUDE_SSH_SIGNING_KEY`
- Remove hardcoded `bot_name` and `bot_id` — action defaults to `claude[bot]` (ID 41898282)
- Affects issue-resolver and ci-fix workflows

## Test plan
- [ ] After secret sync completes, re-test issue resolver on nix-config issue #679

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Switches to `GH_CLAUDE_SSH_SIGNING_KEY` and defaults to `claude[bot]` identity in GitHub Actions workflows.
> 
>   - **Security**:
>     - Switches from `GH_APP_PRIVATE_KEY` to `GH_CLAUDE_SSH_SIGNING_KEY` in `ci-fix.yml` and `issue-resolver.yml`.
>   - **Identity**:
>     - Removes hardcoded `bot_name` and `bot_id`, defaults to `claude[bot]` (ID 41898282) in both workflows.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fai-workflows&utm_source=github&utm_medium=referral)<sup> for 3d6e6017a35502931379eec5a0ca425dab03de02. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->