### PR TITLE
fix(e2e): use technitium_dns README as test issue topic

### DIFF
--- a/.github/scripts/verification/e2e-test.sh
+++ b/.github/scripts/verification/e2e-test.sh
@@ -107,17 +107,17 @@ cmd_issue_lifecycle() {
   local start_time
   start_time=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
-  # Use a unique title (timestamp suffix) to prevent triage from flagging as duplicate
+  # Use a unique title to prevent triage from flagging as duplicate across test runs
   local ts
   ts=$(date +%s)
-  local issue_title="chore: add descriptive comment to site.yml (${ts})"
+  local issue_title="chore: add README.md to technitium_dns role (${ts})"
 
   info "Creating test issue in $repo..."
   local issue_url
   issue_url=$(gh issue create \
     --repo "$repo" \
     --title "$issue_title" \
-    --body "The site.yml file lacks a header comment explaining its purpose and scope. Add a brief descriptive comment at the top of site.yml." \
+    --body "The technitium_dns role is missing a README.md file. Add a standard role README documenting variables, requirements, and example usage." \
     2>/dev/null || true)
   local issue_num
   issue_num=$(echo "$issue_url" | grep -oE '[0-9]+$')


### PR DESCRIPTION
## Summary

- Changes `cmd_issue_lifecycle()` test issue title from "add descriptive comment to site.yml" to "add README.md to technitium_dns role"
- Previous test issues (#60, #62, #63) all used site.yml-related topics and got flagged as duplicates of each other by the triage AI
- The technitium_dns role genuinely lacks a README.md in the repo, so this is a real, non-duplicate chore task

## Why this matters

The `duplicate` label triggers Gate 5 in `check-eligibility.js`, blocking the issue-resolver from creating a draft PR. The e2e verification test only passes when a draft PR is actually created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Changes test issue title in `cmd_issue_lifecycle()` to avoid duplicate flagging, ensuring draft PR creation and e2e test success.
> 
>   - **Behavior**:
>     - Changes test issue title in `cmd_issue_lifecycle()` in `e2e-test.sh` from "add descriptive comment to site.yml" to "add README.md to technitium_dns role".
>     - Prevents triage AI from flagging test issues as duplicates, which previously blocked draft PR creation.
>   - **Why**:
>     - The `duplicate` label triggered Gate 5 in `check-eligibility.js`, blocking draft PR creation, causing e2e test failures.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fai-workflows&utm_source=github&utm_medium=referral)<sup> for 1d9a68afc280036a0fe113ab4cd34f7d3061ade1. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->