### PR TITLE
fix(e2e): correct repo name from nix-config to nix

### DIFF
--- a/.github/scripts/verification/e2e-test.sh
+++ b/.github/scripts/verification/e2e-test.sh
@@ -12,7 +12,7 @@
 #   e2e-test.sh cleanup <repo>           Close test issues/PRs created by verification
 #
 # Environment variables:
-#   REPOS        Space-separated list (default: JacobPEvans/nix-config JacobPEvans/terraform-proxmox JacobPEvans/ansible-proxmox-apps)
+#   REPOS        Space-separated list (default: JacobPEvans/nix JacobPEvans/terraform-proxmox JacobPEvans/ansible-proxmox-apps)
 #   POLL_INTERVAL  Seconds between status checks (default: 30)
 #   MAX_WAIT     Max seconds to wait for workflow completion (default: 600)
 #
@@ -20,7 +20,7 @@
 
 set -euo pipefail
 
-REPOS="${REPOS:-JacobPEvans/nix-config JacobPEvans/terraform-proxmox JacobPEvans/ansible-proxmox-apps}"
+REPOS="${REPOS:-JacobPEvans/nix JacobPEvans/terraform-proxmox JacobPEvans/ansible-proxmox-apps}"
 POLL_INTERVAL="${POLL_INTERVAL:-30}"
 MAX_WAIT="${MAX_WAIT:-600}"
 STATE_FILE="/tmp/e2e-test-state.json"


### PR DESCRIPTION
## Summary

- REPOS default was `JacobPEvans/nix-config` but the actual repository is `JacobPEvans/nix`
- This caused `check-scheduled` to silently report "no runs yet" for all nix workflows instead of checking the real repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Corrects default repository name in `e2e-test.sh` from `JacobPEvans/nix-config` to `JacobPEvans/nix` to ensure proper workflow checks.
> 
>   - **Behavior**:
>     - Corrects default `REPOS` value in `e2e-test.sh` from `JacobPEvans/nix-config` to `JacobPEvans/nix`.
>     - Fixes issue where `check-scheduled` reported "no runs yet" for nix workflows by checking the correct repository.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fai-workflows&utm_source=github&utm_medium=referral)<sup> for e622eb5130673daead5ab6e878c0d318982f6b3f. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->