### PR TITLE
fix(post-merge): add dispatch pattern and bot guard

### DIFF
--- a/.github/scripts/post-merge-docs-review/check-docs-relevance.js
+++ b/.github/scripts/post-merge-docs-review/check-docs-relevance.js
@@ -1,7 +1,7 @@
 module.exports = async ({ github, context, core }) => {
   const owner = context.repo.owner;
   const repo = context.repo.repo;
-  const sha = context.sha;
+  const sha = process.env.OVERRIDE_SHA || context.sha;
 
   // Get the commit to find changed files
   const { data: commit } = await github.rest.repos.getCommit({

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   triage:
+    if: github.event.sender.type != 'Bot'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/post-merge-docs-review.yml
+++ b/.github/workflows/post-merge-docs-review.yml
@@ -10,6 +10,11 @@ name: Post-Merge Docs Review
 
 on:
   workflow_call:
+    inputs:
+      commit_sha:
+        description: 'Override commit SHA for workflow_dispatch callers'
+        required: false
+        type: string
   workflow_dispatch:
 
 # Workflow-level permissions set the maximum for all jobs.
@@ -42,6 +47,8 @@ jobs:
       - name: Check if changes are doc-relevant
         id: check
         uses: actions/github-script@v8
+        env:
+          OVERRIDE_SHA: ${{ inputs.commit_sha || '' }}
         with:
           script: |
             const run = require('./.ai-workflows/.github/scripts/post-merge-docs-review/check-docs-relevance.js');
@@ -73,7 +80,7 @@ jobs:
       - name: Render prompt
         id: prompt
         env:
-          COMMIT_SHA: ${{ github.sha }}
+          COMMIT_SHA: ${{ inputs.commit_sha || github.sha }}
           REPO_NAME: ${{ github.repository }}
         run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/post-merge-docs-review.md COMMIT_SHA REPO_NAME
 

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -10,6 +10,11 @@ name: Post-Merge Tests
 
 on:
   workflow_call:
+    inputs:
+      commit_sha:
+        description: 'Override commit SHA for workflow_dispatch callers'
+        required: false
+        type: string
   workflow_dispatch:
 
 # Workflow-level permissions set the maximum for all jobs.
@@ -73,7 +78,7 @@ jobs:
       - name: Render prompt
         id: prompt
         env:
-          MERGE_SHA: ${{ github.sha }}
+          MERGE_SHA: ${{ inputs.commit_sha || github.sha }}
           REPO_FULL_NAME: ${{ github.repository }}
         run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/post-merge-tests.md MERGE_SHA REPO_FULL_NAME
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,10 @@ This repo is the single source of truth for CI/CD automation workflows. Each wor
 - Dynamic prompts (ci-fix, post-merge-tests, post-merge-docs-review): `render-prompt.sh` with named env vars
 - Write workflows (code-simplifier, next-steps, post-merge-*, ci-fix, issue-resolver): add `ssh_signing_key: ${{ secrets.GH_CLAUDE_SSH_SIGNING_KEY }}`
 
+**Supported event types**: `issues`, `issue_comment`, `pull_request`, `pull_request_review`, `pull_request_review_comment`, `workflow_dispatch`, `repository_dispatch`, `schedule`, `workflow_run`. `push` is NOT supported — post-merge workflows use the dispatch pattern (see `docs/PATTERNS.md`).
+
+**Bot guard**: Any workflow triggered by `issues:` events must include `if: github.event.sender.type != 'Bot'` on the job — both in the reusable workflow and in the consumer caller — to prevent bot-created issues from triggering Claude runs.
+
 ### Consumer Repo Caller Pattern
 
 ```yaml
@@ -47,7 +51,7 @@ permissions:
   pull-requests: read
 jobs:
   sweep:
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-sweeper.yml@v0.3.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-sweeper.yml@v0.3.3
     secrets: inherit
 ```
 


### PR DESCRIPTION
## Summary

- **Issue 1 (post-merge push event)**: Added `commit_sha` input to `post-merge-tests` and `post-merge-docs-review` reusable workflows. Consumer callers will use a two-job dispatch pattern: re-trigger as `workflow_dispatch` on `push`, then call the reusable workflow with the SHA. Updated `check-docs-relevance.js` to use `OVERRIDE_SHA` env var.
- **Issue 3 (bot-triggered triage)**: Added `if: github.event.sender.type != 'Bot'` to the `triage` job in `issue-triage.yml`, preventing failures when Next Steps or other bots create issues.
- **Docs**: Updated `CLAUDE.md` (supported events, bot guard note, version bump), `PATTERNS.md` (new Post-Merge Dispatch and Bot Guard patterns), `VERIFICATION.md` (fix nix-config→nix, update version, timestamp issue titles, update Test C).

## Test plan

- [ ] After merge, release-please will cut v0.3.3
- [ ] Create consumer repo PRs (3 repos) with dispatch pattern + v0.3.3 bump
- [ ] Verify: merge a PR into any consumer repo → dispatch job runs → workflow_dispatch review run succeeds
- [ ] Verify: bot creates an issue → issue-triage shows `skipped` not `failure`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduces dispatch pattern for post-merge workflows and bot guard for issue triage, with documentation updates.
> 
>   - **Behavior**:
>     - Added `commit_sha` input to `post-merge-tests` and `post-merge-docs-review` workflows for dispatch pattern.
>     - Updated `check-docs-relevance.js` to use `OVERRIDE_SHA` env var.
>     - Added `if: github.event.sender.type != 'Bot'` to `triage` job in `issue-triage.yml`.
>   - **Docs**:
>     - Updated `CLAUDE.md` with supported events, bot guard note, version bump.
>     - Updated `PATTERNS.md` with Post-Merge Dispatch and Bot Guard patterns.
>     - Updated `VERIFICATION.md` for version bump, timestamp issue titles, update Test C.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fai-workflows&utm_source=github&utm_medium=referral)<sup> for 50e804745ec53c815f5aad4deeed9e845d95fdf3. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->