### PR TITLE
feat(renovate): extend shared preset, remove duplicated rules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
+  "extends": [
+    "config:recommended",
+    "local>JacobPEvans/.github:renovate-presets"
+  ],
   "packageRules": [
     {
       "matchPackageNames": ["anthropics/claude-code-base-action"],


### PR DESCRIPTION
## Summary

- Extends `local>JacobPEvans/.github:renovate-presets` to inherit org-wide auto-merge rules
- Removes local packageRules now covered by shared preset
- Retains claude-code-base-action grouping rule (repo-specific)

## Why

Centralizes Renovate auto-merge configuration in the `.github` repo preset, eliminating duplication.

## Test plan

- [ ] Merge `.github` PR #69 first (preset must be on main before Renovate runs)
- [ ] Verify next Renovate PR gets auto-merge enabled at creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Extends `renovate.json` with shared preset and removes duplicate rules, retaining specific package rule.
> 
>   - **Configuration**:
>     - Extends `renovate.json` with `local>JacobPEvans/.github:renovate-presets` for org-wide auto-merge rules.
>     - Removes local `packageRules` now covered by the shared preset.
>     - Retains `claude-code-base-action` grouping rule in `renovate.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fai-workflows&utm_source=github&utm_medium=referral)<sup> for 0345c5463145d476af88d0ab9e6cc3eae3c256ef. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->