### PR TITLE
fix: add allowed_bots to all claude-code-action steps

### DIFF
--- a/.github/workflows/best-practices.yml
+++ b/.github/workflows/best-practices.yml
@@ -78,6 +78,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: "github-actions"
           prompt: ${{ steps.prompt.outputs.content }}
           claude_args: >-
             --allowedTools "Read,Glob,Grep,LS,Bash(gh issue:*),Bash(gh api:*),Bash(gh search:*)"

--- a/.github/workflows/ci-fix.yml
+++ b/.github/workflows/ci-fix.yml
@@ -172,6 +172,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: "github-actions"
           use_commit_signing: "true"
           prompt: ${{ steps.prompt.outputs.content }}
           claude_args: >-

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -93,6 +93,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: "github-actions"
           track_progress: true
           prompt: ${{ steps.prompt.outputs.content }}
           claude_args: |
@@ -118,5 +119,6 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: "github-actions"
           claude_args: |
             --allowedTools "Read,Glob,Grep,LS,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh issue comment:*)"

--- a/.github/workflows/code-simplifier.yml
+++ b/.github/workflows/code-simplifier.yml
@@ -52,6 +52,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: "github-actions"
           use_commit_signing: "true"
           prompt: ${{ steps.prompt.outputs.content }}
           claude_args: >-

--- a/.github/workflows/final-pr-review.yml
+++ b/.github/workflows/final-pr-review.yml
@@ -86,6 +86,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: "github-actions"
           prompt: ${{ steps.prompt.outputs.content }}
           claude_args: >-
             --model claude-sonnet-4-6

--- a/.github/workflows/issue-hygiene.yml
+++ b/.github/workflows/issue-hygiene.yml
@@ -54,6 +54,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: "github-actions"
           prompt: ${{ steps.prompt.outputs.content }}
           claude_args: >-
             --allowedTools "Read,Glob,Grep,LS,Bash(gh issue:*),Bash(gh pr:*),Bash(gh search:*)"

--- a/.github/workflows/issue-resolver.yml
+++ b/.github/workflows/issue-resolver.yml
@@ -133,6 +133,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: "github-actions"
           use_commit_signing: "true"
           prompt: ${{ steps.prompt.outputs.content }}
           claude_args: >-

--- a/.github/workflows/issue-sweeper.yml
+++ b/.github/workflows/issue-sweeper.yml
@@ -53,6 +53,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: "github-actions"
           prompt: ${{ steps.prompt.outputs.content }}
           claude_args: >-
             --allowedTools "Read,Glob,Grep,LS,Bash(gh issue:*),Bash(gh pr:*),Bash(gh search:*),Bash(gh api:*)"

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -52,6 +52,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: "github-actions"
           prompt: ${{ steps.prompt.outputs.content }}
           claude_args: >-
             --allowedTools "Read,Glob,Grep,LS,Bash(gh issue:*),Bash(gh search:*)"

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -45,6 +45,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: "github-actions"
           prompt: ${{ steps.prompt.outputs.content }}
           claude_args: >-
             --allowedTools "Read,Glob,Grep,LS,Bash(gh label:*),Bash(gh search:*),Bash(gh api:*)"

--- a/.github/workflows/next-steps.yml
+++ b/.github/workflows/next-steps.yml
@@ -54,6 +54,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: "github-actions"
           use_commit_signing: "true"
           prompt: ${{ steps.prompt.outputs.content }}
           claude_args: >-

--- a/.github/workflows/post-merge-docs-review.yml
+++ b/.github/workflows/post-merge-docs-review.yml
@@ -88,6 +88,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: "github-actions"
           use_commit_signing: "true"
           prompt: ${{ steps.prompt.outputs.content }}
           claude_args: >-

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -86,6 +86,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: "github-actions"
           use_commit_signing: "true"
           prompt: ${{ steps.prompt.outputs.content }}
           claude_args: >-

--- a/.github/workflows/project-router.yml
+++ b/.github/workflows/project-router.yml
@@ -47,6 +47,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: "github-actions"
           prompt: ${{ steps.prompt.outputs.content }}
           claude_args: >-
             --allowedTools "Read,Glob,Grep,LS,Bash(gh issue:*),Bash(gh pr:*)"

--- a/.github/workflows/repo-orchestrator.yml
+++ b/.github/workflows/repo-orchestrator.yml
@@ -45,6 +45,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: "github-actions"
           prompt: ${{ steps.prompt.outputs.content }}
           claude_args: >-
             --allowedTools "Read,Glob,Grep,LS,Bash(gh issue:*),Bash(gh pr:*),Bash(gh run:*),Bash(gh workflow:*),Bash(gh api:*),Bash(gh search:*)"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ This repo is the single source of truth for CI/CD automation workflows. Each wor
 
 **Supported event types**: `issues`, `issue_comment`, `pull_request`, `pull_request_review`, `pull_request_review_comment`, `workflow_dispatch`, `repository_dispatch`, `schedule`, `workflow_run`. `push` is NOT supported — post-merge workflows use the dispatch pattern (see `docs/PATTERNS.md`).
 
-**Bot guard**: `claude-code-action@v1` rejects Bot-type senders for `issues:` events internally. Consumer callers use the AI Dispatch Pattern: all `issues:opened` events dispatch as `workflow_dispatch`, selectively routing AI-created issues (`ai:created` label) with `skip_triage=true`. The reusable `issue-triage.yml` guards direct bot calls via input check: `if: (inputs.issue_number || '0') != '0' || github.event.sender.type != 'Bot'`. See `docs/PATTERNS.md` for the full AI Dispatch Pattern.
+**Bot guard**: `claude-code-action@v1` rejects Bot-type `github.actor` values. All dispatch patterns (AI Dispatch, Post-Merge Dispatch, schedule) set `github.actor` to `github-actions[bot]`, so every `claude-code-action@v1` step MUST include `allowed_bots: "github-actions"`. Consumer callers use the AI Dispatch Pattern for issue workflows. See `docs/PATTERNS.md` for the full Bot Guard and AI Dispatch patterns.
 
 ### Consumer Repo Caller Pattern
 

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -15,7 +15,7 @@ Used by most workflows. Static prompt, read-only tools.
 - `id-token: write` at both workflow-level and job-level permissions
 - Cross-repo checkout of `.github/prompts` and `.github/scripts`
 - `render-prompt.sh` to render the static prompt into a step output
-- `claude-code-action@v1` with `claude_code_oauth_token:` and `prompt:`
+- `claude-code-action@v1` with `claude_code_oauth_token:`, `allowed_bots:`, and `prompt:`
 
 ```yaml
 - name: Render prompt
@@ -26,6 +26,7 @@ Used by most workflows. Static prompt, read-only tools.
   uses: anthropics/claude-code-action@v1
   with:
     claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+    allowed_bots: "github-actions"
     prompt: ${{ steps.prompt.outputs.content }}
     claude_args: >-
       --allowedTools "Read,Glob,Grep,LS,Bash(gh issue:*)"
@@ -48,6 +49,7 @@ Used by workflows that create commits or PRs. Adds `use_commit_signing: "true"` 
   uses: anthropics/claude-code-action@v1
   with:
     claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+    allowed_bots: "github-actions"
     use_commit_signing: "true"
     prompt: ${{ steps.prompt.outputs.content }}
     claude_args: >-
@@ -195,11 +197,13 @@ Note: `actions: write` is required for `gh workflow run` to trigger the same wor
 
 Used by any workflow triggered by `issues:` events to prevent bot-created issues from causing Claude failures.
 
-**Background**: `claude-code-action@v1` internally rejects Bot-type senders for `issues:` events. A simple `if:` condition on the job is insufficient — the action itself fails. The solution is the AI Dispatch Pattern (see below), which re-triggers bot-created issues as `workflow_dispatch`.
+**Background**: `claude-code-action@v1` internally rejects Bot-type `github.actor` values. This affects ALL dispatch patterns (AI Dispatch, Post-Merge Dispatch, schedule triggers) because `gh workflow run` with `GITHUB_TOKEN` sets `github.actor` to `github-actions[bot]`.
 
-**Required on**: issue-triage (reusable workflow job guard)
+**Two-layer defense**:
 
-The reusable `issue-triage.yml` guards against direct bot-triggered calls:
+1. **`allowed_bots: "github-actions"`** — Required on every `claude-code-action@v1` step. Without this, any workflow called via dispatch or schedule will fail with "Workflow initiated by non-human actor." This is the primary fix.
+
+2. **Job-level `if:` guard** — Secondary filter on the reusable workflow job to block direct bot-triggered calls without an explicit issue number:
 
 ```yaml
 jobs:
@@ -207,7 +211,9 @@ jobs:
     if: (inputs.issue_number || '0') != '0' || github.event.sender.type != 'Bot'
 ```
 
-This passes when an `issue_number` is explicitly provided (dispatch pattern) OR when the sender is human. Blocks only direct bot-triggered calls without an issue number.
+**Required on**: All `claude-code-action@v1` steps (for `allowed_bots`), plus issue-triage (for the job guard).
+
+**Why `github-actions` specifically**: The dispatch patterns use `GITHUB_TOKEN` to call `gh workflow run`, which sets the actor to `github-actions[bot]`. This is a trusted internal actor — not external bot spam. The consumer's dispatch job already filters untrusted bots before dispatching.
 
 ---
 
@@ -215,7 +221,7 @@ This passes when an `issue_number` is explicitly provided (dispatch pattern) OR 
 
 Used by consumer `issue-auto-resolve.yml` callers to allow AI-created issues (tagged `ai:created`) to flow through the triage + resolve pipeline while blocking random bot spam.
 
-**Why**: `claude-code-action@v1` rejects Bot-type senders internally. Re-dispatching as `workflow_dispatch` bypasses this restriction.
+**Why**: `claude-code-action@v1` rejects Bot-type `github.actor` values internally. Re-dispatching as `workflow_dispatch` changes the event type but sets `github.actor` to `github-actions[bot]`. The reusable workflows must include `allowed_bots: "github-actions"` on every `claude-code-action@v1` step to allow this actor through.
 
 **Flow**:
 ```


### PR DESCRIPTION
## Summary

- Adds `allowed_bots: "github-actions"` to all 16 `claude-code-action@v1` steps across 15 reusable workflows
- Updates `CLAUDE.md` and `docs/PATTERNS.md` to document this as a mandatory requirement

## Root Cause

All dispatch patterns (`gh workflow run` with `GITHUB_TOKEN`) set `github.actor` to `github-actions[bot]`. The `claude-code-action@v1` has built-in bot protection that rejects Bot-type actors unless `allowed_bots` is configured. Without it, **every workflow called via dispatch, schedule, or post-merge patterns silently fails**.

This affected issue triage, issue resolution, post-merge reviews, scheduled sweeps, and all other dispatch-triggered workflows across all consumer repos.

## Test plan

- [x] All 64 existing `bun test` tests pass
- [x] Every `claude-code-action@v1` step has exactly one `allowed_bots` entry (verified via grep)
- [ ] Re-run Issue Auto-Resolve on nix-darwin issue #757 to confirm triage completes
- [ ] Verify scheduled workflows (issue-sweeper, best-practices) pass on next run

## Affected workflows

All 15: best-practices, ci-fix, claude-review (x2), code-simplifier, final-pr-review, issue-hygiene, issue-resolver, issue-sweeper, issue-triage, label-sync, next-steps, post-merge-docs-review, post-merge-tests, project-router, repo-orchestrator


🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `allowed_bots: "github-actions"` to all `claude-code-action@v1` steps in 15 workflows to prevent failures from bot-triggered events, updating documentation accordingly.
> 
>   - **Behavior**:
>     - Adds `allowed_bots: "github-actions"` to all `claude-code-action@v1` steps in 15 workflows to prevent failures when triggered by bot actors.
>     - Affects workflows: best-practices, ci-fix, claude-review, code-simplifier, final-pr-review, issue-hygiene, issue-resolver, issue-sweeper, issue-triage, label-sync, next-steps, post-merge-docs-review, post-merge-tests, project-router, repo-orchestrator.
>   - **Documentation**:
>     - Updates `CLAUDE.md` and `docs/PATTERNS.md` to document `allowed_bots` as a mandatory configuration for `claude-code-action@v1` steps.
>   - **Root Cause**:
>     - `claude-code-action@v1` rejects Bot-type actors unless `allowed_bots` is configured, causing silent failures in workflows triggered by dispatch, schedule, or post-merge patterns.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fai-workflows&utm_source=github&utm_medium=referral)<sup> for ebf97d698e64ca3d11aac06417caf85237753840. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->