### PR TITLE
fix: remove sender.type Bot guards and update dispatch patterns

### DIFF
--- a/.github/workflows/best-practices.yml
+++ b/.github/workflows/best-practices.yml
@@ -23,7 +23,6 @@ concurrency:
 jobs:
   check-recent-activity:
     name: Check for recent human activity
-    if: github.event.sender.type != 'Bot'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ci-fix.yml
+++ b/.github/workflows/ci-fix.yml
@@ -41,7 +41,6 @@ concurrency:
 jobs:
   should-fix:
     name: Check if fix needed
-    if: github.event.sender.type != 'Bot'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -42,7 +42,6 @@ jobs:
   review:
     name: Claude Code Review
     if: >-
-      github.event.sender.type != 'Bot' &&
       github.event.pull_request != null &&
       !contains(github.event.pull_request.labels.*.name, 'ai:skip-review')
     runs-on: ubuntu-latest

--- a/.github/workflows/code-simplifier.yml
+++ b/.github/workflows/code-simplifier.yml
@@ -24,7 +24,6 @@ concurrency:
 
 jobs:
   simplify:
-    if: github.event.sender.type != 'Bot'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/final-pr-review.yml
+++ b/.github/workflows/final-pr-review.yml
@@ -26,7 +26,6 @@ concurrency:
 jobs:
   gate-check:
     name: Check review gate
-    if: github.event.sender.type != 'Bot'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read

--- a/.github/workflows/issue-hygiene.yml
+++ b/.github/workflows/issue-hygiene.yml
@@ -25,7 +25,6 @@ concurrency:
 
 jobs:
   hygiene:
-    if: github.event.sender.type != 'Bot'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/issue-sweeper.yml
+++ b/.github/workflows/issue-sweeper.yml
@@ -24,7 +24,6 @@ concurrency:
 
 jobs:
   sweep:
-    if: github.event.sender.type != 'Bot'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -22,7 +22,6 @@ concurrency:
 
 jobs:
   triage:
-    if: (inputs.issue_number || '0') != '0' || github.event.sender.type != 'Bot'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -17,7 +17,6 @@ concurrency:
 
 jobs:
   sync:
-    if: github.event.sender.type != 'Bot'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/next-steps.yml
+++ b/.github/workflows/next-steps.yml
@@ -25,7 +25,6 @@ concurrency:
 
 jobs:
   analyze:
-    if: github.event.sender.type != 'Bot'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/post-merge-docs-review.yml
+++ b/.github/workflows/post-merge-docs-review.yml
@@ -30,7 +30,6 @@ concurrency:
 jobs:
   check-relevance:
     name: Check doc relevance
-    if: github.event.sender.type != 'Bot'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -30,7 +30,6 @@ concurrency:
 jobs:
   check-test-infra:
     name: Check test infrastructure
-    if: github.event.sender.type != 'Bot'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/project-router.yml
+++ b/.github/workflows/project-router.yml
@@ -18,7 +18,6 @@ concurrency:
 
 jobs:
   route:
-    if: github.event.sender.type != 'Bot'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/repo-orchestrator.yml
+++ b/.github/workflows/repo-orchestrator.yml
@@ -17,7 +17,6 @@ concurrency:
 
 jobs:
   orchestrate:
-    if: github.event.sender.type != 'Bot'
     runs-on: ubuntu-latest
     permissions:
       actions: write

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ This repo is the single source of truth for CI/CD automation workflows. Each wor
 
 **Supported event types**: `issues`, `issue_comment`, `pull_request`, `pull_request_review`, `pull_request_review_comment`, `workflow_dispatch`, `repository_dispatch`, `schedule`, `workflow_run`. `push` is NOT supported — post-merge workflows use the dispatch pattern (see `docs/PATTERNS.md`).
 
-**Bot guard**: `claude-code-action@v1` rejects Bot-type `github.actor` values. All dispatch patterns (AI Dispatch, Post-Merge Dispatch, schedule) set `github.actor` to `github-actions[bot]`, so every `claude-code-action@v1` step MUST include `allowed_bots: "github-actions"`. Consumer callers use the AI Dispatch Pattern for issue workflows. See `docs/PATTERNS.md` for the full Bot Guard and AI Dispatch patterns.
+**Bot guard**: All `claude-code-action@v1` steps include `allowed_bots: "github-actions"` to allow dispatch-triggered runs (which set `github.actor` to `github-actions[bot]`). Cost control is handled by consumer-level daily dispatch limits, not by blocking bots at the workflow level. See `docs/PATTERNS.md` for the Bot Guard and AI Dispatch patterns.
 
 ### Consumer Repo Caller Pattern
 

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -195,41 +195,29 @@ Note: `actions: write` is required for `gh workflow run` to trigger the same wor
 
 ## Bot Guard Pattern
 
-Used by any workflow triggered by `issues:` events to prevent bot-created issues from causing Claude failures.
+`claude-code-action@v1` internally rejects Bot-type `github.actor` values. All dispatch patterns (`gh workflow run` with `GITHUB_TOKEN`) set `github.actor` to `github-actions[bot]`, which would cause "Workflow initiated by non-human actor" failures.
 
-**Background**: `claude-code-action@v1` internally rejects Bot-type `github.actor` values. This affects ALL dispatch patterns (AI Dispatch, Post-Merge Dispatch, schedule triggers) because `gh workflow run` with `GITHUB_TOKEN` sets `github.actor` to `github-actions[bot]`.
+**Fix**: Every `claude-code-action@v1` step includes `allowed_bots: "github-actions"`. This is the only guard needed — cost control is handled by consumer-level daily dispatch limits, not by blocking bots at the workflow level.
 
-**Two-layer defense**:
-
-1. **`allowed_bots: "github-actions"`** — Required on every `claude-code-action@v1` step. Without this, any workflow called via dispatch or schedule will fail with "Workflow initiated by non-human actor." This is the primary fix.
-
-2. **Job-level `if:` guard** — Secondary filter on the reusable workflow job to block direct bot-triggered calls without an explicit issue number:
-
-```yaml
-jobs:
-  triage:
-    if: (inputs.issue_number || '0') != '0' || github.event.sender.type != 'Bot'
-```
-
-**Required on**: All `claude-code-action@v1` steps (for `allowed_bots`), plus issue-triage (for the job guard).
-
-**Why `github-actions` specifically**: The dispatch patterns use `GITHUB_TOKEN` to call `gh workflow run`, which sets the actor to `github-actions[bot]`. This is a trusted internal actor — not external bot spam. The consumer's dispatch job already filters untrusted bots before dispatching.
+**Why `github-actions` specifically**: The dispatch patterns use `GITHUB_TOKEN` to call `gh workflow run`, which sets the actor to `github-actions[bot]`. This is a trusted internal actor. Consumer dispatch jobs enforce daily limits before dispatching.
 
 ---
 
 ## AI Dispatch Pattern
 
-Used by consumer `issue-auto-resolve.yml` callers to allow AI-created issues (tagged `ai:created`) to flow through the triage + resolve pipeline while blocking random bot spam.
+Used by consumer `issue-auto-resolve.yml` callers to dispatch issues through the triage + resolve pipeline. All actors (human and bot) are welcome — cost control is via daily dispatch limits, not bot filtering.
 
-**Why**: `claude-code-action@v1` rejects Bot-type `github.actor` values internally. Re-dispatching as `workflow_dispatch` changes the event type but sets `github.actor` to `github-actions[bot]`. The reusable workflows must include `allowed_bots: "github-actions"` on every `claude-code-action@v1` step to allow this actor through.
+**Triggers**:
+- `issues: opened` — new issues auto-dispatch
+- `issues: labeled` with `ai:ready` — re-trigger mechanism for existing issues
 
 **Flow**:
 ```
-issues:opened → dispatch job → workflow_dispatch → [triage if human] → resolve
-                 ↑ filters:
-                 - human issues: dispatch with skip_triage=false
-                 - ai:created bot issues: dispatch with skip_triage=true
-                 - other bot issues: exit (no dispatch)
+issues:opened  → dispatch job → workflow_dispatch → triage → resolve
+issues:labeled → (ai:ready?)  → workflow_dispatch → triage → resolve
+                   ↑ safety:
+                   - daily dispatch limit (default: 5/day)
+                   - ai:ready label removed after dispatch (re-apply to re-trigger)
 ```
 
 **Consumer caller** (three-job unified pattern):
@@ -237,15 +225,12 @@ issues:opened → dispatch job → workflow_dispatch → [triage if human] → r
 name: Issue Auto-Resolve
 on:
   issues:
-    types: [opened]
+    types: [opened, labeled]
   workflow_dispatch:
     inputs:
       issue_number:
         required: true
         type: string
-      skip_triage:
-        type: string
-        default: "false"
 permissions:
   actions: write
   contents: write
@@ -258,30 +243,47 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: write
+      issues: write
     steps:
       - name: Dispatch as workflow_dispatch
         env:
           GH_TOKEN: ${{ github.token }}
           WORKFLOW_NAME: ${{ github.workflow }}
+          REPO: ${{ github.repository }}
           ISSUE_NUM: ${{ github.event.issue.number }}
-          IS_BOT: ${{ github.event.sender.type == 'Bot' }}
-          HAS_AI_LABEL: ${{ contains(github.event.issue.labels.*.name, 'ai:created') }}
+          EVENT_ACTION: ${{ github.event.action }}
+          LABEL_NAME: ${{ github.event.label.name }}
         run: |
-          if [[ "$IS_BOT" == "true" && "$HAS_AI_LABEL" != "true" ]]; then
-            echo "Bot issue without ai:created label — skipping"
+          # Filter labeled events to only ai:ready
+          if [[ "$EVENT_ACTION" == "labeled" && "$LABEL_NAME" != "ai:ready" ]]; then
+            echo "Label '$LABEL_NAME' is not ai:ready — skipping"
             exit 0
           fi
-          SKIP="false"
-          if [[ "$IS_BOT" == "true" ]]; then SKIP="true"; fi
+
+          # Daily dispatch limit (cost control safety valve)
+          TODAY=$(date -u +%Y-%m-%d)
+          COUNT=$(gh run list \
+            --workflow "$WORKFLOW_NAME" \
+            --repo "$REPO" \
+            --event workflow_dispatch \
+            --created ">=$TODAY" \
+            --json databaseId --jq 'length')
+          if [[ "$COUNT" -ge 5 ]]; then
+            echo "Daily dispatch limit reached ($COUNT/5) — skipping"
+            exit 0
+          fi
+
+          # Remove ai:ready label so it can be re-applied to re-trigger
+          if [[ "$EVENT_ACTION" == "labeled" && "$LABEL_NAME" == "ai:ready" ]]; then
+            gh issue edit "$ISSUE_NUM" --repo "$REPO" --remove-label "ai:ready" || true
+          fi
+
           gh workflow run "$WORKFLOW_NAME" \
-            --repo "$GITHUB_REPOSITORY" \
-            -f issue_number="$ISSUE_NUM" \
-            -f skip_triage="$SKIP"
+            --repo "$REPO" \
+            -f issue_number="$ISSUE_NUM"
   run-triage:
-    if: >-
-      github.event_name == 'workflow_dispatch' &&
-      inputs.skip_triage != 'true'
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-triage.yml@v0.4.0
+    if: github.event_name == 'workflow_dispatch'
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-triage.yml@<version>
     secrets: inherit
     with:
       issue_number: ${{ inputs.issue_number }}
@@ -291,7 +293,7 @@ jobs:
       always() &&
       github.event_name == 'workflow_dispatch' &&
       (needs.run-triage.result == 'success' || needs.run-triage.result == 'skipped')
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.4.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@<version>
     secrets: inherit
     with:
       repo_context: "<repo-specific>"
@@ -299,8 +301,9 @@ jobs:
 ```
 
 **Key points**:
-- `WORKFLOW_NAME` passed via `env:` (not inline `${{ github.workflow }}`) to prevent template injection
+- `WORKFLOW_NAME` and `REPO` passed via `env:` (not inline `${{ }}`) to prevent template injection
 - `always()` on `resolve-issue` ensures it runs even when `run-triage` was skipped
-- `ai:created` label is the trust signal for bot issues (applied by `next-steps.yml`)
-- `actions: write` scoped to the dispatch job only
-- Daily resolver limit enforced by Gate 10 in `check-eligibility.js` (default: 5/24h)
+- `ai:ready` label is the re-trigger mechanism — removed after dispatch so it can be re-applied
+- Daily dispatch limit (5/day) is the cost-control safety valve
+- `actions: write` + `issues: write` scoped to the dispatch job
+- Triage always runs (idempotent) — no `skip_triage` input needed


### PR DESCRIPTION
## Summary

- Remove `github.event.sender.type != 'Bot'` job guards from all 14 workflows
- Simplify Bot Guard Pattern docs to just `allowed_bots` (no two-layer defense)
- Rewrite AI Dispatch Pattern docs with `ai:ready` re-trigger and daily dispatch limits
- Update CLAUDE.md bot guard description

Follow-up to #65 — that PR added `allowed_bots: "github-actions"` to all `claude-code-action@v1` steps. This PR removes the now-unnecessary job-level `sender.type` guards that were blocking dispatch-triggered runs.

**Philosophy**: All bots should auto-trigger. Cost control is via consumer-level daily dispatch limits, not bot-blocking.

## Test plan

- [x] `bun test` passes (64 tests, 0 failures)
- [ ] After merge + tag, verify nix-darwin issue #757 dispatches correctly via `ai:ready` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove bot guards from workflows and update dispatch patterns for better automation and cost control.
> 
>   - **Behavior**:
>     - Remove `github.event.sender.type != 'Bot'` guards from 14 workflows, including `best-practices.yml`, `ci-fix.yml`, and `claude-review.yml`.
>     - Update AI Dispatch Pattern in `docs/PATTERNS.md` to include `ai:ready` re-trigger and daily dispatch limits.
>   - **Documentation**:
>     - Simplify Bot Guard Pattern in `docs/PATTERNS.md` to use only `allowed_bots`.
>     - Update `CLAUDE.md` to reflect new bot guard description.
>   - **Philosophy**:
>     - All bots should auto-trigger workflows; cost control via daily dispatch limits, not bot-blocking.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fai-workflows&utm_source=github&utm_medium=referral)<sup> for dcf8ddbca0ae0a42a08796c0cbbc1fc3254d632c. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->