### PR TITLE
feat: add issue-linker reusable workflow

### DIFF
--- a/.github/prompts/issue-linker.md
+++ b/.github/prompts/issue-linker.md
@@ -1,0 +1,52 @@
+# Issue Linker
+
+You are a PR-issue linking specialist. Your job is to identify GitHub issues that are resolved or related to the current PR, then take appropriate action.
+
+## Context
+- Mode: ${MODE} (opened = link mode, merged = close mode)
+- PR: #${PR_NUMBER}
+
+## Step 1: Analyze the PR
+Run these commands to understand what the PR does:
+- `gh pr view ${PR_NUMBER}` — title, description, labels
+- `gh pr diff ${PR_NUMBER}` — what changed
+Extract: the problem being solved, files changed, keywords from title/description.
+
+## Step 2: Search for Related Issues
+- `gh issue list --state open --limit 50` — all open issues
+- `gh search issues "repo:$GITHUB_REPOSITORY state:open <keywords>"` — targeted search
+For EACH open issue, compare its title, body, and acceptance criteria against the PR changes.
+Classify each as: RESOLVED (PR fully addresses all criteria), RELATED (partial overlap), or UNRELATED.
+
+## Step 3: Actions (Link Mode — PR is open, mode=opened)
+
+For RESOLVED issues:
+- Edit the PR body to add a "Related Issues" section with `Closes #N` if not already present
+  - Use: `gh pr edit ${PR_NUMBER} --body "...existing body...\n\n## Related Issues\nCloses #N"`
+  - Preserve ALL existing PR body content — only append the new section
+- Comment on the issue: `gh issue comment N --body "This issue is being addressed in #${PR_NUMBER}."`
+  - Only if no comment with `<!-- issue-linker-opened -->` marker already exists on the issue
+
+For RELATED issues:
+- Post a request-changes review: `gh pr review ${PR_NUMBER} --request-changes --body "..."`
+  - Body should explain which issue (#N) is related and what would need to change to fully close it
+  - Include marker `<!-- issue-linker-review #N -->` in the review body
+
+## Step 4: Actions (Close Mode — PR is merged, mode=merged)
+
+For RESOLVED issues:
+- Close with comment: `gh issue close N --comment "Resolved by #${PR_NUMBER}."`
+  - Only if not already closed
+
+For RELATED issues:
+- Add informational comment: `gh issue comment N --body "PR #${PR_NUMBER} addressed part of this. Remaining work: <description>"`
+  - Only if no comment with `<!-- issue-linker-merged -->` marker already exists
+
+## Rules
+- Check for existing comments before posting to avoid duplicates
+- RESOLVED = ALL acceptance criteria met by PR changes (high confidence only)
+- RELATED = genuine overlap but not full resolution
+- UNRELATED = coincidental keyword matches — ignore these
+- Maximum 10 issues to evaluate per run
+- Never modify issue labels or milestones
+- Never close RELATED issues — only RESOLVED ones

--- a/.github/scripts/issue-linker/check-eligibility.js
+++ b/.github/scripts/issue-linker/check-eligibility.js
@@ -1,0 +1,63 @@
+module.exports = async ({ github, context, core }) => {
+  const action = context.payload.action;
+  const pr = context.payload.pull_request;
+
+  // Gate 1: Determine mode from action + merged status
+  let mode;
+  if (action === 'opened') {
+    mode = 'opened';
+  } else if (action === 'closed' && pr && pr.merged === true) {
+    mode = 'merged';
+  } else if (action === 'closed' && pr && pr.merged !== true) {
+    core.setOutput('should_run', 'false');
+    core.info('PR was closed without merging — skipping');
+    return;
+  } else {
+    core.setOutput('should_run', 'false');
+    core.info(`Unrecognized action "${action}" — skipping`);
+    return;
+  }
+
+  // Gate 2: Get PR number
+  const prNumber = pr && pr.number;
+  if (!prNumber) {
+    core.setOutput('should_run', 'false');
+    core.info('No PR number in event payload — skipping');
+    return;
+  }
+
+  const { owner, repo } = context.repo;
+
+  // Gate 3: Check for open issues — no point running if there are none
+  const { data: openIssues } = await github.rest.issues.listForRepo({
+    owner,
+    repo,
+    state: 'open',
+    per_page: 1,
+  });
+  if (openIssues.length === 0) {
+    core.setOutput('should_run', 'false');
+    core.info('No open issues found — skipping');
+    return;
+  }
+
+  // Gate 4: Dedup check — skip if a marker comment already exists on this PR
+  const marker = `<!-- issue-linker-${mode} -->`;
+  const { data: prComments } = await github.rest.issues.listComments({
+    owner,
+    repo,
+    issue_number: prNumber,
+  });
+  const alreadyRan = prComments.some(c => c.body && c.body.includes(marker));
+  if (alreadyRan) {
+    core.setOutput('should_run', 'false');
+    core.info(`Dedup marker "${marker}" already present on PR #${prNumber} — skipping`);
+    return;
+  }
+
+  // All gates passed
+  core.setOutput('should_run', 'true');
+  core.setOutput('mode', mode);
+  core.setOutput('pr_number', prNumber.toString());
+  core.info(`PR #${prNumber} passed all gates — mode=${mode}`);
+};

--- a/.github/workflows/issue-linker.yml
+++ b/.github/workflows/issue-linker.yml
@@ -1,0 +1,98 @@
+# Issue Linker
+#
+# Reusable workflow: links open issues to PRs when opened, and closes resolved
+# issues when PRs merge.
+#
+# This is a reusable workflow that can be called from other repositories.
+
+name: Issue Linker
+
+on:
+  workflow_call:
+    inputs:
+      model:
+        description: "Claude model to use"
+        type: string
+        default: "claude-sonnet-4-6"
+  workflow_dispatch:
+
+# Workflow-level permissions set the maximum for all jobs.
+# permissions: {} silently skips all jobs in cross-repo calls.
+permissions:
+  contents: read
+  id-token: write
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: issue-linker-${{ github.repository }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  check-eligibility:
+    name: Check eligibility
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
+    outputs:
+      should_run: ${{ steps.check.outputs.should_run }}
+      mode: ${{ steps.check.outputs.mode }}
+      pr_number: ${{ steps.check.outputs.pr_number }}
+    steps:
+      - name: Checkout ai-workflows scripts
+        uses: actions/checkout@v6
+        with:
+          repository: JacobPEvans/ai-workflows
+          sparse-checkout: .github/scripts
+          path: .ai-workflows
+
+      - name: Check eligibility
+        id: check
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const run = require('./.ai-workflows/.github/scripts/issue-linker/check-eligibility.js');
+            await run({ github, context, core });
+
+  link-issues:
+    name: Link or close issues
+    needs: check-eligibility
+    if: needs.check-eligibility.outputs.should_run == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      issues: write
+      pull-requests: write
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Checkout ai-workflows
+        uses: actions/checkout@v6
+        with:
+          repository: JacobPEvans/ai-workflows
+          sparse-checkout: |
+            .github/prompts
+            .github/scripts
+          path: .ai-workflows
+
+      - name: Render prompt
+        id: render-prompt
+        env:
+          MODE: ${{ needs.check-eligibility.outputs.mode }}
+          PR_NUMBER: ${{ needs.check-eligibility.outputs.pr_number }}
+        run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/issue-linker.md MODE PR_NUMBER
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: "github-actions"
+          model: ${{ inputs.model }}
+          prompt: ${{ steps.render-prompt.outputs.content }}
+          claude_args: >-
+            --allowedTools "Read,Glob,Grep,LS,Bash(gh pr:*),Bash(gh issue:*),Bash(gh search:*),Bash(gh api:*)"

--- a/.github/workflows/pr-issue-linker.yml
+++ b/.github/workflows/pr-issue-linker.yml
@@ -1,0 +1,20 @@
+name: PR Issue Linker
+on:
+  pull_request:
+    types: [opened, closed]
+    branches: [main]
+permissions:
+  contents: read
+  id-token: write
+  issues: write
+  pull-requests: write
+jobs:
+  link-issues:
+    if: >-
+      !contains(github.event.pull_request.labels.*.name, 'ai:skip-review') &&
+      (
+        (github.event.action == 'opened' && !github.event.pull_request.draft) ||
+        (github.event.action == 'closed' && github.event.pull_request.merged == true)
+      )
+    uses: ./.github/workflows/issue-linker.yml
+    secrets: inherit

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -307,3 +307,38 @@ jobs:
 - Daily dispatch limit (5/day) is the cost-control safety valve
 - `actions: write` + `issues: write` scoped to the dispatch job
 - Triage always runs (idempotent) — no `skip_triage` input needed
+
+---
+
+## Issue Linker Consumer Caller
+
+The `issue-linker` workflow runs when PRs are opened or merged. Consumer repos should call it with both trigger types and inline `if:` conditions:
+
+```yaml
+name: PR Issue Linker
+on:
+  pull_request:
+    types: [opened, closed]
+    branches: [main]
+permissions:
+  contents: read
+  id-token: write
+  issues: write
+  pull-requests: write
+jobs:
+  link-issues:
+    if: >-
+      !contains(github.event.pull_request.labels.*.name, 'ai:skip-review') &&
+      (
+        (github.event.action == 'opened' && !github.event.pull_request.draft) ||
+        (github.event.action == 'closed' && github.event.pull_request.merged == true)
+      )
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-linker.yml@v0.4.0
+    secrets: inherit
+```
+
+The `if:` condition handles two trigger modes:
+- **Link mode** (`opened`): Runs when a non-draft PR is opened, linking issues and posting reviews for related issues
+- **Close mode** (`closed` + `merged`): Runs when a PR merges, closing resolved issues with a reference comment
+
+The gate script (`check-eligibility.js`) additionally skips runs when no open issues exist or when a dedup marker is already present.

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -35,6 +35,7 @@ function createMockGithub() {
         get: mock(),
         listComments: mock(),
         listCommentsForRepo: mock(),
+        listForRepo: mock(),
         createComment: mock(),
         addLabels: mock(),
       },

--- a/tests/issue-linker-check-eligibility.test.js
+++ b/tests/issue-linker-check-eligibility.test.js
@@ -1,0 +1,111 @@
+const { createMockCore, createMockContext, createMockGithub } = require('./helpers.js');
+const run = require('../.github/scripts/issue-linker/check-eligibility.js');
+
+function makePRPayload(action, merged = false, prNumber = 42) {
+  return {
+    action,
+    pull_request: {
+      number: prNumber,
+      merged,
+    },
+  };
+}
+
+describe('issue-linker/check-eligibility', () => {
+  let core, context, github;
+
+  beforeEach(() => {
+    core = createMockCore();
+    context = createMockContext({ payload: makePRPayload('opened') });
+    github = createMockGithub();
+
+    // Default: one open issue exists
+    github.rest.issues.listForRepo.mockResolvedValue({ data: [{ number: 1, title: 'Some issue' }] });
+
+    // Default: no existing PR comments with dedup marker
+    github.rest.issues.listComments.mockResolvedValue({ data: [] });
+  });
+
+  it('happy path: opened action with open issues and no dedup marker sets should_run=true, mode=opened', async () => {
+    await run({ github, context, core });
+
+    expect(core.getOutput('should_run')).toBe('true');
+    expect(core.getOutput('mode')).toBe('opened');
+    expect(core.getOutput('pr_number')).toBe('42');
+  });
+
+  it('happy path: closed+merged action with open issues and no dedup marker sets should_run=true, mode=merged', async () => {
+    context.payload = makePRPayload('closed', true);
+
+    await run({ github, context, core });
+
+    expect(core.getOutput('should_run')).toBe('true');
+    expect(core.getOutput('mode')).toBe('merged');
+    expect(core.getOutput('pr_number')).toBe('42');
+  });
+
+  it('skip: closed without merging sets should_run=false', async () => {
+    context.payload = makePRPayload('closed', false);
+
+    await run({ github, context, core });
+
+    expect(core.getOutput('should_run')).toBe('false');
+  });
+
+  it('skip: unrecognized action (synchronize) sets should_run=false', async () => {
+    context.payload = makePRPayload('synchronize');
+
+    await run({ github, context, core });
+
+    expect(core.getOutput('should_run')).toBe('false');
+  });
+
+  it('skip: no open issues sets should_run=false', async () => {
+    github.rest.issues.listForRepo.mockResolvedValue({ data: [] });
+
+    await run({ github, context, core });
+
+    expect(core.getOutput('should_run')).toBe('false');
+  });
+
+  it('skip: dedup marker <!-- issue-linker-opened --> in PR comments for opened mode sets should_run=false', async () => {
+    github.rest.issues.listComments.mockResolvedValue({
+      data: [
+        { body: 'Some prior comment with <!-- issue-linker-opened --> marker' },
+      ],
+    });
+
+    await run({ github, context, core });
+
+    expect(core.getOutput('should_run')).toBe('false');
+  });
+
+  it('skip: dedup marker <!-- issue-linker-merged --> in PR comments for merged mode sets should_run=false', async () => {
+    context.payload = makePRPayload('closed', true);
+    github.rest.issues.listComments.mockResolvedValue({
+      data: [
+        { body: 'Some prior comment with <!-- issue-linker-merged --> marker' },
+      ],
+    });
+
+    await run({ github, context, core });
+
+    expect(core.getOutput('should_run')).toBe('false');
+  });
+
+  it('mode detection: opened action produces mode=opened', async () => {
+    context.payload = makePRPayload('opened');
+
+    await run({ github, context, core });
+
+    expect(core.getOutput('mode')).toBe('opened');
+  });
+
+  it('mode detection: closed+merged action produces mode=merged', async () => {
+    context.payload = makePRPayload('closed', true);
+
+    await run({ github, context, core });
+
+    expect(core.getOutput('mode')).toBe('merged');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `issue-linker.yml` reusable workflow to close the gap between PR creation and issue cleanup — runs at PR open (link/review mode) and PR merge (close mode)
- Adds `check-eligibility.js` gate script with 4 checks: mode detection, PR number, open issues exist, dedup marker
- Adds `issue-linker.md` dynamic prompt with `${MODE}` / `${PR_NUMBER}` placeholders
- Adds `pr-issue-linker.yml` local self-consumer caller for this repo
- Updates `docs/PATTERNS.md` with consumer caller example

## Test plan
- [ ] `bun test` passes (73/73 including 9 new issue-linker tests)
- [ ] Verify workflow YAML is valid after push
- [ ] Gate script correctly skips closed-not-merged PRs
- [ ] Gate script deduplicates on `<!-- issue-linker-opened -->` / `<!-- issue-linker-merged -->` markers
- [ ] Consumer caller triggers correctly on `pull_request` opened/closed events

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduces a reusable workflow for linking and closing issues based on PR events, with eligibility checks and dynamic prompts.
> 
>   - **Workflow**:
>     - Adds `issue-linker.yml` reusable workflow to link issues when PRs open and close resolved issues when PRs merge.
>     - Adds `pr-issue-linker.yml` to trigger the workflow on `pull_request` events.
>   - **Scripts**:
>     - Adds `check-eligibility.js` to determine if the workflow should run based on PR state and existing issues.
>     - Skips execution if PR is closed without merging, no open issues exist, or deduplication markers are present.
>   - **Prompts**:
>     - Adds `issue-linker.md` with placeholders for dynamic prompt generation.
>   - **Documentation**:
>     - Updates `docs/PATTERNS.md` with an example of the consumer caller for the issue linker.
>   - **Tests**:
>     - Adds `issue-linker-check-eligibility.test.js` to test eligibility script behavior under various conditions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fai-workflows&utm_source=github&utm_medium=referral)<sup> for f90b2e0cb4d7aedd476a63127f0784bf37cfb5b4. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->