### PR TITLE
feat: skip dependency bot workflows (renovate, dependabot)

### DIFF
--- a/.github/scripts/ci-fail-issue/check-eligibility.js
+++ b/.github/scripts/ci-fail-issue/check-eligibility.js
@@ -23,7 +23,7 @@ module.exports = async ({ github, context, core }) => {
     core.info(`Could not get commit author: ${e.message}`);
   }
 
-  const botAuthors = ['copilot[bot]', 'github-actions[bot]'];
+  const botAuthors = ['copilot[bot]', 'github-actions[bot]', 'renovate[bot]', 'dependabot[bot]'];
   if (botAuthors.includes(authorLogin)) {
     core.info(`Gate 2/3: commit authored by ${authorLogin} — skipping to prevent loop`);
     core.setOutput('eligible', 'false');

--- a/.github/scripts/post-merge-docs-review/check-docs-relevance.js
+++ b/.github/scripts/post-merge-docs-review/check-docs-relevance.js
@@ -10,6 +10,15 @@ module.exports = async ({ github, context, core }) => {
     ref: sha,
   });
 
+  // Skip commits authored by dependency bots
+  const authorLogin = commit.author?.login || '';
+  const depBots = ['renovate[bot]', 'dependabot[bot]'];
+  if (depBots.includes(authorLogin)) {
+    core.setOutput('is_relevant', 'false');
+    core.info(`Commit authored by ${authorLogin} — skipping doc review`);
+    return;
+  }
+
   const files = commit.files || [];
   if (files.length === 0) {
     core.setOutput('is_relevant', 'false');

--- a/.github/scripts/post-merge-tests/check-test-infra.js
+++ b/.github/scripts/post-merge-tests/check-test-infra.js
@@ -2,6 +2,21 @@ module.exports = async ({ github, context, core }) => {
   const owner = context.repo.owner;
   const repo = context.repo.repo;
 
+  // Skip commits authored by dependency bots
+  const sha = process.env.OVERRIDE_SHA || context.sha;
+  try {
+    const { data: commitData } = await github.rest.repos.getCommit({ owner, repo, ref: sha });
+    const authorLogin = commitData.author?.login || '';
+    const depBots = ['renovate[bot]', 'dependabot[bot]'];
+    if (depBots.includes(authorLogin)) {
+      core.setOutput('has_tests', 'false');
+      core.info(`Commit authored by ${authorLogin} — skipping test review`);
+      return;
+    }
+  } catch (e) {
+    core.info(`Could not check commit author: ${e.message}`);
+  }
+
   const testIndicators = [
     'tests/', 'test/', '__tests__/', 'spec/',
     'jest.config.js', 'jest.config.ts', 'jest.config.mjs',

--- a/.github/workflows/ci-fix.yml
+++ b/.github/workflows/ci-fix.yml
@@ -41,6 +41,9 @@ concurrency:
 jobs:
   should-fix:
     name: Check if fix needed
+    if: >-
+      github.actor != 'renovate[bot]' &&
+      github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -42,6 +42,8 @@ jobs:
   review:
     name: Claude Code Review
     if: >-
+      github.actor != 'renovate[bot]' &&
+      github.actor != 'dependabot[bot]' &&
       github.event.pull_request != null &&
       !contains(github.event.pull_request.labels.*.name, 'ai:skip-review')
     runs-on: ubuntu-latest

--- a/.github/workflows/final-pr-review.yml
+++ b/.github/workflows/final-pr-review.yml
@@ -26,6 +26,9 @@ concurrency:
 jobs:
   gate-check:
     name: Check review gate
+    if: >-
+      github.actor != 'renovate[bot]' &&
+      github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read

--- a/.github/workflows/issue-linker.yml
+++ b/.github/workflows/issue-linker.yml
@@ -31,6 +31,9 @@ concurrency:
 jobs:
   check-eligibility:
     name: Check eligibility
+    if: >-
+      github.actor != 'renovate[bot]' &&
+      github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -46,6 +46,8 @@ jobs:
       - name: Check for test infrastructure
         id: check
         uses: actions/github-script@v8
+        env:
+          OVERRIDE_SHA: ${{ inputs.commit_sha }}
         with:
           script: |
             const run = require('./.ai-workflows/.github/scripts/post-merge-tests/check-test-infra.js');

--- a/.github/workflows/pr-issue-linker.yml
+++ b/.github/workflows/pr-issue-linker.yml
@@ -11,6 +11,8 @@ permissions:
 jobs:
   link-issues:
     if: >-
+      github.actor != 'renovate[bot]' &&
+      github.actor != 'dependabot[bot]' &&
       !contains(github.event.pull_request.labels.*.name, 'ai:skip-review') &&
       (
         (github.event.action == 'opened' && !github.event.pull_request.draft) ||

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -195,11 +195,40 @@ Note: `actions: write` is required for `gh workflow run` to trigger the same wor
 
 ## Bot Guard Pattern
 
+Two layers of bot filtering apply, depending on workflow type.
+
+### Layer 1: Internal actor allowlist (`allowed_bots`)
+
 `claude-code-action@v1` internally rejects Bot-type `github.actor` values. All dispatch patterns (`gh workflow run` with `GITHUB_TOKEN`) set `github.actor` to `github-actions[bot]`, which would cause "Workflow initiated by non-human actor" failures.
 
-**Fix**: Every `claude-code-action@v1` step includes `allowed_bots: "github-actions"`. This is the only guard needed — cost control is handled by consumer-level daily dispatch limits, not by blocking bots at the workflow level.
+**Fix**: Every `claude-code-action@v1` step includes `allowed_bots: "github-actions"`. This allows the trusted internal dispatch actor while blocking external bots.
 
-**Why `github-actions` specifically**: The dispatch patterns use `GITHUB_TOKEN` to call `gh workflow run`, which sets the actor to `github-actions[bot]`. This is a trusted internal actor. Consumer dispatch jobs enforce daily limits before dispatching.
+### Layer 2: Dependency bot filtering (`if:` guards)
+
+PR-triggered workflows (claude-review, final-pr-review, ci-fix, issue-linker) add `if:` guards on their first job to skip runs triggered by dependency bots (Renovate, Dependabot). This produces a clean **skipped** (grey) status instead of a **failed** (red) status.
+
+```yaml
+  gate-check:
+    if: >-
+      github.actor != 'renovate[bot]' &&
+      github.actor != 'dependabot[bot]'
+```
+
+**Why at the job level**: Skipping the first job causes GitHub to show all downstream jobs as skipped too — a clean grey tree.
+
+### Layer 3: Post-merge commit-author check (JS scripts)
+
+For post-merge workflows (push→dispatch pattern), `github.actor` in the re-dispatched `workflow_dispatch` run is `github-actions[bot]` — not the original merger. The gate scripts (`check-docs-relevance.js`, `check-test-infra.js`) instead check the **commit author** via the GitHub API and early-return when it matches a dependency bot.
+
+```javascript
+const authorLogin = commit.author?.login || '';
+const depBots = ['renovate[bot]', 'dependabot[bot]'];
+if (depBots.includes(authorLogin)) {
+  core.setOutput('is_relevant', 'false');
+  core.info(`Commit authored by ${authorLogin} — skipping`);
+  return;
+}
+```
 
 ---
 


### PR DESCRIPTION
## Summary

- Add `if:` bot guards to 5 PR-triggered reusable workflows (`claude-review`, `final-pr-review`, `ci-fix`, `issue-linker`, `pr-issue-linker`) so renovate[bot] and dependabot[bot] PRs show as **skipped** (grey) instead of **failed** (red)
- Add commit-author bot checks to 2 post-merge JS gate scripts (`check-docs-relevance.js`, `check-test-infra.js`) for the push→dispatch pattern where `github.actor` is `github-actions[bot]`
- Extend `ci-fail-issue/check-eligibility.js` bot list to include `renovate[bot]` and `dependabot[bot]`
- Pass `OVERRIDE_SHA` env var to `check-test-infra` step in `post-merge-tests.yml`
- Update `docs/PATTERNS.md` to document all three layers of bot filtering

## Problem

PR #98 (Renovate deps bump) on nix-ai triggered Claude Code Review, which failed because `renovate[bot]` isn't in `allowed_bots`. Result: red check marks on every Renovate/Dependabot PR across all 5+ consumer repos.

## Test plan

- [ ] Verify the PR itself shows Claude workflows as skipped (grey) since this is a Renovate-like change
- [ ] After merge → tag v0.7.0 → bump consumer repos → verify nix-ai PR #98 re-run shows Claude review as skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)