### PR TITLE
fix: correct bot guard docs and add missing test coverage

### DIFF
--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -195,7 +195,7 @@ Note: `actions: write` is required for `gh workflow run` to trigger the same wor
 
 ## Bot Guard Pattern
 
-Two layers of bot filtering apply, depending on workflow type.
+Three layers of bot filtering apply, depending on workflow type.
 
 ### Layer 1: Internal actor allowlist (`allowed_bots`)
 
@@ -205,7 +205,7 @@ Two layers of bot filtering apply, depending on workflow type.
 
 ### Layer 2: Dependency bot filtering (`if:` guards)
 
-PR-triggered workflows (claude-review, final-pr-review, ci-fix, issue-linker) add `if:` guards on their first job to skip runs triggered by dependency bots (Renovate, Dependabot). This produces a clean **skipped** (grey) status instead of a **failed** (red) status.
+PR-triggered workflows (claude-review, final-pr-review, ci-fix, issue-linker, pr-issue-linker) add `if:` guards on their first job to skip runs triggered by dependency bots (Renovate, Dependabot). This produces a clean **skipped** (grey) status instead of a **failed** (red) status.
 
 ```yaml
   gate-check:

--- a/tests/check-docs-relevance.test.js
+++ b/tests/check-docs-relevance.test.js
@@ -40,4 +40,20 @@ describe('check-docs-relevance', () => {
     await run({ github, context, core });
     expect(core.getOutput('is_relevant')).toBe('false');
   });
+
+  it('sets is_relevant=false for renovate[bot] authored commits', async () => {
+    github.rest.repos.getCommit.mockResolvedValue({
+      data: { author: { login: 'renovate[bot]' }, files: [{ filename: 'README.md' }] },
+    });
+    await run({ github, context, core });
+    expect(core.getOutput('is_relevant')).toBe('false');
+  });
+
+  it('sets is_relevant=false for dependabot[bot] authored commits', async () => {
+    github.rest.repos.getCommit.mockResolvedValue({
+      data: { author: { login: 'dependabot[bot]' }, files: [{ filename: 'src/main.js' }] },
+    });
+    await run({ github, context, core });
+    expect(core.getOutput('is_relevant')).toBe('false');
+  });
 });

--- a/tests/check-test-infra.test.js
+++ b/tests/check-test-infra.test.js
@@ -44,4 +44,33 @@ describe('check-test-infra', () => {
     await run({ github, context, core });
     expect(core.getOutput('has_tests')).toBe('false');
   });
+
+  it('sets has_tests=false for renovate[bot] authored commits', async () => {
+    github.rest.repos.getCommit.mockResolvedValue({
+      data: { author: { login: 'renovate[bot]' } },
+    });
+    await run({ github, context, core });
+    expect(core.getOutput('has_tests')).toBe('false');
+  });
+
+  it('sets has_tests=false for dependabot[bot] authored commits', async () => {
+    github.rest.repos.getCommit.mockResolvedValue({
+      data: { author: { login: 'dependabot[bot]' } },
+    });
+    await run({ github, context, core });
+    expect(core.getOutput('has_tests')).toBe('false');
+  });
+
+  it('uses OVERRIDE_SHA for commit author lookup', async () => {
+    process.env.OVERRIDE_SHA = 'override-sha-123';
+    github.rest.repos.getCommit.mockResolvedValue({
+      data: { author: { login: 'renovate[bot]' } },
+    });
+    await run({ github, context, core });
+    expect(github.rest.repos.getCommit).toHaveBeenCalledWith(
+      expect.objectContaining({ ref: 'override-sha-123' })
+    );
+    expect(core.getOutput('has_tests')).toBe('false');
+    delete process.env.OVERRIDE_SHA;
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up fixes from Copilot review on #69.

- Correct "Two layers" → "Three layers" in PATTERNS.md bot guard section
- Add `pr-issue-linker` to the Layer 2 workflow list in PATTERNS.md
- Add bot-author test cases to `check-docs-relevance.test.js` (renovate[bot], dependabot[bot])
- Add bot-author test cases to `check-test-infra.test.js` (renovate[bot], dependabot[bot], OVERRIDE_SHA usage)

Resolves unresolved review threads from #69.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes bot guard documentation and adds test coverage for bot-authored commits.
> 
>   - **Documentation**:
>     - Correct "Two layers" to "Three layers" in `PATTERNS.md` bot guard section.
>     - Add `pr-issue-linker` to Layer 2 workflow list in `PATTERNS.md`.
>   - **Tests**:
>     - Add bot-author test cases for `renovate[bot]` and `dependabot[bot]` in `check-docs-relevance.test.js`.
>     - Add bot-author test cases for `renovate[bot]`, `dependabot[bot]`, and `OVERRIDE_SHA` usage in `check-test-infra.test.js`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fai-workflows&utm_source=github&utm_medium=referral)<sup> for e303429578b3031f1c1b35c2e66db5864ea06254. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->