### PR TITLE
feat: add suite grouping reusable workflows

### DIFF
--- a/.github/workflows/suite-all.yml
+++ b/.github/workflows/suite-all.yml
@@ -1,0 +1,79 @@
+# Suite: All
+#
+# Reusable workflow: top-level coordinator for standard repos.
+# Routes PR events → suite-pr, workflow_dispatch → suite-post-merge.
+# CI (workflow_run) and issues stay in caller-side files — they require
+# repo-specific trigger configuration.
+#
+# Nesting: caller → suite-all → suite-pr/suite-post-merge → individual workflow
+# = 3 levels (well within the 10-level GitHub Actions limit).
+#
+# Internal uses: paths are relative — they resolve to the same ref as this
+# suite when called by a child repo (e.g., @v0.8.0 pins the whole chain).
+#
+# Usage:
+#   uses: JacobPEvans/ai-workflows/.github/workflows/suite-all.yml@v0.8.0
+#   with:
+#     caller_event: ${{ github.event_name }}
+#     review_prompt: "Repo-specific review focus"
+#     commit_sha: ${{ inputs.commit_sha || github.sha }}
+
+name: "Suite: All"
+
+on:
+  workflow_call:
+    inputs:
+      caller_event:
+        description: "Event that triggered the caller (pass github.event_name)"
+        type: string
+        required: true
+      review_prompt:
+        description: "Repo-specific review focus for Claude Code Review"
+        type: string
+        default: ""
+      max_reviews:
+        description: "Max Claude reviews per PR (0 = unlimited)"
+        type: string
+        default: "1"
+      model:
+        description: "Claude model to use"
+        type: string
+        default: "claude-sonnet-4-6"
+      commit_sha:
+        description: "Commit SHA for post-merge reviews (from workflow_dispatch)"
+        type: string
+        default: ""
+
+# Workflow-level permissions set the maximum for all jobs.
+# permissions: {} silently skips all jobs in cross-repo calls.
+permissions:
+  actions: read
+  checks: read
+  contents: write
+  id-token: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  # PR events → PR Suite (claude-review + final-pr-review)
+  pr-suite:
+    if: >-
+      inputs.caller_event == 'pull_request' ||
+      inputs.caller_event == 'issue_comment' ||
+      inputs.caller_event == 'pull_request_review' ||
+      inputs.caller_event == 'check_suite'
+    uses: ./.github/workflows/suite-pr.yml
+    with:
+      caller_event: ${{ inputs.caller_event }}
+      review_prompt: ${{ inputs.review_prompt }}
+      max_reviews: ${{ inputs.max_reviews }}
+      model: ${{ inputs.model }}
+    secrets: inherit
+
+  # workflow_dispatch → Post-Merge Suite (docs-review + tests-review)
+  post-merge-suite:
+    if: inputs.caller_event == 'workflow_dispatch'
+    uses: ./.github/workflows/suite-post-merge.yml
+    with:
+      commit_sha: ${{ inputs.commit_sha }}
+    secrets: inherit

--- a/.github/workflows/suite-ci.yml
+++ b/.github/workflows/suite-ci.yml
@@ -1,0 +1,69 @@
+# Suite: CI Failures
+#
+# Reusable workflow: bundles ci-fix + ci-fail-issue.
+# Routing is based on github.event.workflow_run context (branch == main → issue, else → fix).
+# Fork guard is baked into ci-fix job condition.
+# Caller keeps repo-specific workflow_run trigger (workflows: ["<CI-GATE-NAME>"]).
+#
+# Internal uses: paths are relative — they resolve to the same ref as this
+# suite when called by a child repo (e.g., @v0.8.0 pins the whole chain).
+#
+# Usage:
+#   uses: JacobPEvans/ai-workflows/.github/workflows/suite-ci.yml@v0.8.0
+#   with:
+#     repo_context: "Brief description of the repository"
+#     ci_structure: "Description of CI workflows and what they check"
+#     workflow_name: "<CI-GATE-NAME>"
+
+name: "Suite: CI Failures"
+
+on:
+  workflow_call:
+    inputs:
+      repo_context:
+        description: "Brief description of the repository"
+        type: string
+        required: true
+      ci_structure:
+        description: "Description of CI workflows and what they check"
+        type: string
+        required: true
+      workflow_name:
+        description: "Name of the CI workflow that failed (for issue creation)"
+        type: string
+        required: true
+      extra_tools:
+        description: "Additional allowed tools beyond defaults (e.g., Bash(tofu:*))"
+        type: string
+        default: ""
+
+# Workflow-level permissions set the maximum for all jobs.
+# permissions: {} silently skips all jobs in cross-repo calls.
+permissions:
+  actions: read
+  contents: write
+  id-token: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  ci-fix:
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.head_branch != 'main' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
+    uses: ./.github/workflows/ci-fix.yml
+    with:
+      repo_context: ${{ inputs.repo_context }}
+      ci_structure: ${{ inputs.ci_structure }}
+      extra_tools: ${{ inputs.extra_tools }}
+    secrets: inherit
+
+  ci-fail-issue:
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.head_branch == 'main'
+    uses: ./.github/workflows/ci-fail-issue.yml
+    with:
+      workflow_name: ${{ inputs.workflow_name }}
+    secrets: inherit

--- a/.github/workflows/suite-post-merge.yml
+++ b/.github/workflows/suite-post-merge.yml
@@ -1,0 +1,43 @@
+# Suite: Post-Merge Reviews
+#
+# Reusable workflow: bundles post-merge-docs-review + post-merge-tests.
+# Both run in parallel after a merge to main (triggered via workflow_dispatch re-dispatch).
+#
+# Internal uses: paths are relative — they resolve to the same ref as this
+# suite when called by a child repo (e.g., @v0.8.0 pins the whole chain).
+#
+# Usage:
+#   uses: JacobPEvans/ai-workflows/.github/workflows/suite-post-merge.yml@v0.8.0
+#   with:
+#     commit_sha: ${{ inputs.commit_sha || github.sha }}
+
+name: "Suite: Post-Merge Reviews"
+
+on:
+  workflow_call:
+    inputs:
+      commit_sha:
+        description: "Commit SHA to review (pass inputs.commit_sha from workflow_dispatch)"
+        type: string
+        required: false
+        default: ""
+
+# Workflow-level permissions set the maximum for all jobs.
+# permissions: {} silently skips all jobs in cross-repo calls.
+permissions:
+  contents: write
+  id-token: write
+  pull-requests: write
+
+jobs:
+  docs-review:
+    uses: ./.github/workflows/post-merge-docs-review.yml
+    with:
+      commit_sha: ${{ inputs.commit_sha }}
+    secrets: inherit
+
+  tests-review:
+    uses: ./.github/workflows/post-merge-tests.yml
+    with:
+      commit_sha: ${{ inputs.commit_sha }}
+    secrets: inherit

--- a/.github/workflows/suite-pr.yml
+++ b/.github/workflows/suite-pr.yml
@@ -1,0 +1,64 @@
+# Suite: PR Reviews
+#
+# Reusable workflow: bundles claude-review + final-pr-review.
+# Callers pass caller_event to route to the correct individual workflow.
+#
+# Internal uses: paths are relative — they resolve to the same ref as this
+# suite when called by a child repo (e.g., @v0.8.0 pins the whole chain).
+#
+# Usage:
+#   uses: JacobPEvans/ai-workflows/.github/workflows/suite-pr.yml@v0.8.0
+#   with:
+#     caller_event: ${{ github.event_name }}
+#     review_prompt: "Repo-specific review focus"
+
+name: "Suite: PR Reviews"
+
+on:
+  workflow_call:
+    inputs:
+      caller_event:
+        description: "Event that triggered the caller (pass github.event_name)"
+        type: string
+        required: true
+      review_prompt:
+        description: "Repo-specific review focus for Claude Code Review"
+        type: string
+        default: ""
+      max_reviews:
+        description: "Max Claude reviews per PR (0 = unlimited)"
+        type: string
+        default: "1"
+      model:
+        description: "Claude model to use"
+        type: string
+        default: "claude-sonnet-4-6"
+
+# Workflow-level permissions set the maximum for all jobs.
+# permissions: {} silently skips all jobs in cross-repo calls.
+permissions:
+  actions: read
+  checks: read
+  contents: read
+  id-token: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  claude-review:
+    if: >-
+      inputs.caller_event == 'pull_request' ||
+      inputs.caller_event == 'issue_comment'
+    uses: ./.github/workflows/claude-review.yml
+    with:
+      review_prompt: ${{ inputs.review_prompt }}
+      max_reviews: ${{ inputs.max_reviews }}
+      model: ${{ inputs.model }}
+    secrets: inherit
+
+  final-pr-review:
+    if: >-
+      inputs.caller_event == 'pull_request_review' ||
+      inputs.caller_event == 'check_suite'
+    uses: ./.github/workflows/final-pr-review.yml
+    secrets: inherit


### PR DESCRIPTION
## Summary

- Adds 4 suite workflows that bundle individual reusable workflows, reducing child repo maintenance from 7 files to 2-3 files
- `suite-pr.yml`: bundles `claude-review` + `final-pr-review`, routes by `caller_event`
- `suite-ci.yml`: bundles `ci-fix` + `ci-fail-issue`, routes by branch (non-main → fix, main → issue)
- `suite-post-merge.yml`: runs `post-merge-docs-review` + `post-merge-tests` in parallel
- `suite-all.yml`: top-level coordinator (caller → suite-all → suite-pr/suite-post-merge → individual = 3 levels)

All internal `uses:` are relative paths (`./.github/workflows/...`) so child repos pinning to `@v0.8.0` get the entire chain at that version. Backward compatible — existing individual-workflow callers at `@v0.7.0` continue to work unchanged.

## Test plan

- [ ] Verify suite workflows appear in the GitHub Actions UI
- [ ] Test with nix-ai migration PR (proof-of-concept)
- [ ] Confirm 3-level nesting is within GitHub's 10-level limit
- [ ] Tag as `v0.8.0` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds four suite workflows to streamline GitHub Actions by grouping existing workflows into reusable suites, reducing maintenance overhead and ensuring backward compatibility.
> 
>   - **New Workflows**:
>     - `suite-all.yml`: Top-level coordinator routing PR events to `suite-pr` and `workflow_dispatch` to `suite-post-merge`.
>     - `suite-ci.yml`: Bundles `ci-fix` and `ci-fail-issue`, routing based on branch context.
>     - `suite-post-merge.yml`: Runs `post-merge-docs-review` and `post-merge-tests` in parallel.
>     - `suite-pr.yml`: Bundles `claude-review` and `final-pr-review`, routing based on `caller_event`.
>   - **Behavior**:
>     - Reduces child repo maintenance from 7 files to 2-3 files.
>     - Uses relative paths for internal `uses:` to ensure version consistency across child repos.
>     - Backward compatible with existing workflows at `@v0.7.0`.
>   - **Permissions**:
>     - Sets workflow-level permissions for actions, checks, contents, id-token, issues, and pull-requests across all new workflows.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fai-workflows&utm_source=github&utm_medium=referral)<sup> for cada4898a6de5679ce36d44ab5c6b81c2b607ab3. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->