### PR TITLE
feat: soft bot guard — skip instead of fail when bot creates PR

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -23,6 +23,10 @@ on:
         description: "Claude model to use"
         type: string
         default: "claude-sonnet-4-6"
+      allowed_bots:
+        description: "Comma-separated bot logins allowed to trigger review (supports *)"
+        type: string
+        default: ""
   workflow_dispatch:
 
 # Workflow-level permissions set the maximum for all jobs.
@@ -81,7 +85,13 @@ jobs:
             await run({ github, context, core });
 
       - name: Render prompt
-        if: steps.eligibility.outputs.eligible == 'true'
+        if: >-
+          steps.eligibility.outputs.eligible == 'true' &&
+          (
+            github.event.pull_request.user.type != 'Bot' ||
+            contains(inputs.allowed_bots, github.event.pull_request.user.login) ||
+            contains(inputs.allowed_bots, '*')
+          )
         id: prompt
         env:
           REPO: ${{ github.repository }}
@@ -90,7 +100,13 @@ jobs:
         run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/claude-review.md
 
       - name: Run Claude Code Review
-        if: steps.eligibility.outputs.eligible == 'true'
+        if: >-
+          steps.eligibility.outputs.eligible == 'true' &&
+          (
+            github.event.pull_request.user.type != 'Bot' ||
+            contains(inputs.allowed_bots, github.event.pull_request.user.login) ||
+            contains(inputs.allowed_bots, '*')
+          )
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/final-pr-review.yml
+++ b/.github/workflows/final-pr-review.yml
@@ -8,6 +8,11 @@ name: Final PR Review
 
 on:
   workflow_call:
+    inputs:
+      allowed_bots:
+        description: "Comma-separated bot logins allowed to trigger review (supports *)"
+        type: string
+        default: ""
   workflow_dispatch:
 
 # Workflow-level permissions set the maximum for all jobs.
@@ -85,6 +90,10 @@ jobs:
         run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/final-pr-review.md
 
       - name: Run Claude Code
+        if: >-
+          github.event.pull_request.user.type != 'Bot' ||
+          contains(inputs.allowed_bots, github.event.pull_request.user.login) ||
+          contains(inputs.allowed_bots, '*')
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/issue-linker.yml
+++ b/.github/workflows/issue-linker.yml
@@ -14,6 +14,10 @@ on:
         description: "Claude model to use"
         type: string
         default: "claude-sonnet-4-6"
+      allowed_bots:
+        description: "Comma-separated bot logins allowed to trigger review (supports *)"
+        type: string
+        default: ""
   workflow_dispatch:
 
 # Workflow-level permissions set the maximum for all jobs.
@@ -91,6 +95,10 @@ jobs:
         run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/issue-linker.md MODE PR_NUMBER
 
       - name: Run Claude Code
+        if: >-
+          github.event.pull_request.user.type != 'Bot' ||
+          contains(inputs.allowed_bots, github.event.pull_request.user.login) ||
+          contains(inputs.allowed_bots, '*')
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/suite-all.yml
+++ b/.github/workflows/suite-all.yml
@@ -43,6 +43,10 @@ on:
         description: "Commit SHA for post-merge reviews (from workflow_dispatch)"
         type: string
         default: ""
+      allowed_bots:
+        description: "Comma-separated bot logins allowed to trigger review (supports *)"
+        type: string
+        default: ""
 
 # Workflow-level permissions set the maximum for all jobs.
 # permissions: {} silently skips all jobs in cross-repo calls.
@@ -68,6 +72,7 @@ jobs:
       review_prompt: ${{ inputs.review_prompt }}
       max_reviews: ${{ inputs.max_reviews }}
       model: ${{ inputs.model }}
+      allowed_bots: ${{ inputs.allowed_bots }}
     secrets: inherit
 
   # workflow_dispatch → Post-Merge Suite (docs-review + tests-review)

--- a/.github/workflows/suite-pr.yml
+++ b/.github/workflows/suite-pr.yml
@@ -33,6 +33,10 @@ on:
         description: "Claude model to use"
         type: string
         default: "claude-sonnet-4-6"
+      allowed_bots:
+        description: "Comma-separated bot logins allowed to trigger review (supports *)"
+        type: string
+        default: ""
 
 # Workflow-level permissions set the maximum for all jobs.
 # permissions: {} silently skips all jobs in cross-repo calls.
@@ -54,6 +58,7 @@ jobs:
       review_prompt: ${{ inputs.review_prompt }}
       max_reviews: ${{ inputs.max_reviews }}
       model: ${{ inputs.model }}
+      allowed_bots: ${{ inputs.allowed_bots }}
     secrets: inherit
 
   final-pr-review:
@@ -61,4 +66,6 @@ jobs:
       inputs.caller_event == 'pull_request_review' ||
       inputs.caller_event == 'check_suite'
     uses: ./.github/workflows/final-pr-review.yml
+    with:
+      allowed_bots: ${{ inputs.allowed_bots }}
     secrets: inherit

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -195,7 +195,7 @@ Note: `actions: write` is required for `gh workflow run` to trigger the same wor
 
 ## Bot Guard Pattern
 
-Three layers of bot filtering apply, depending on workflow type.
+Four layers of bot filtering apply, depending on workflow type.
 
 ### Layer 1: Internal actor allowlist (`allowed_bots`)
 
@@ -203,7 +203,43 @@ Three layers of bot filtering apply, depending on workflow type.
 
 **Fix**: Every `claude-code-action@v1` step includes `allowed_bots: "github-actions"`. This allows the trusted internal dispatch actor while blocking external bots.
 
-### Layer 2: Dependency bot filtering (`if:` guards)
+### Layer 2: PR author pre-check (`if:` on action steps)
+
+When a bot creates a PR (e.g., the `claude` GitHub App), `claude-code-action@v1`'s built-in bot guard hard-fails the step — producing a red CI failure. The fix: add an `if:` condition directly on the `claude-code-action` step (and any steps that depend on its output) to check the PR author type *before* the action runs.
+
+```yaml
+      - name: Run Claude Code Review
+        if: >-
+          steps.eligibility.outputs.eligible == 'true' &&
+          (
+            github.event.pull_request.user.type != 'Bot' ||
+            contains(inputs.allowed_bots, github.event.pull_request.user.login) ||
+            contains(inputs.allowed_bots, '*')
+          )
+        uses: anthropics/claude-code-action@v1
+```
+
+When a bot creates the PR and isn't in `allowed_bots`, the step shows as **skipped** (grey) — not failed (red). CI stays green.
+
+**Behavior by event type**:
+- `pull_request` events: `github.event.pull_request.user.type` is set — bot guard applies
+- `issue_comment` events (interactive job): `github.event.pull_request` is null → `'' != 'Bot'` → true — always runs
+- `workflow_run` events (ci-fix): `github.event.pull_request` is null → always runs
+
+**Consumer configuration**: PR-triggered workflows (`claude-review`, `final-pr-review`, `issue-linker`) and suites (`suite-pr`, `suite-all`) accept an `allowed_bots` input:
+
+```yaml
+jobs:
+  sweep:
+    uses: JacobPEvans/ai-workflows/.github/workflows/suite-all.yml@v0.9.0
+    with:
+      caller_event: ${{ github.event_name }}
+      allowed_bots: "claude"  # Allow Claude App PRs to be reviewed
+```
+
+Supports comma-separated logins or `*` to allow all bots.
+
+### Layer 3: Dependency bot filtering (`if:` guards)
 
 PR-triggered workflows (claude-review, final-pr-review, ci-fix, issue-linker, pr-issue-linker) add `if:` guards on their first job to skip runs triggered by dependency bots (Renovate, Dependabot). This produces a clean **skipped** (grey) status instead of a **failed** (red) status.
 
@@ -216,7 +252,7 @@ PR-triggered workflows (claude-review, final-pr-review, ci-fix, issue-linker, pr
 
 **Why at the job level**: Skipping the first job causes GitHub to show all downstream jobs as skipped too — a clean grey tree.
 
-### Layer 3: Post-merge commit-author check (JS scripts)
+### Layer 4: Post-merge commit-author check (JS scripts)
 
 For post-merge workflows (push→dispatch pattern), `github.actor` in the re-dispatched `workflow_dispatch` run is `github-actions[bot]` — not the original merger. The gate scripts (`check-docs-relevance.js`, `check-test-infra.js`) instead check the **commit author** via the GitHub API and early-return when it matches a dependency bot.
 


### PR DESCRIPTION
## Summary

- Add `allowed_bots` input to `claude-review`, `final-pr-review`, `issue-linker`, `suite-pr`, `suite-all` with passthrough to child workflows
- Extend `if:` on "Render prompt" and "Run Claude Code Review" steps in `claude-review.yml` to skip when an unapproved bot creates the PR
- Add `if:` on "Run Claude Code" step in `final-pr-review.yml` and `issue-linker.yml`
- Update `docs/PATTERNS.md`: Bot Guard Pattern now documents 4 layers with a new Layer 2 explaining the PR author pre-check and `allowed_bots` consumer configuration

## Problem

When the `claude` GitHub App creates a PR, `claude-code-action@v1`'s built-in bot guard hard-fails the step:
> `Workflow initiated by non-human actor: claude (type: Bot)`

This produces a red CI failure. It should be a clean skip.

## Solution

Add a native `if:` condition on the `claude-code-action` step (and dependent steps) that checks `github.event.pull_request.user.type` before the action runs. When a bot creates the PR and isn't in `allowed_bots`, the step shows as **skipped** (grey) — not failed (red). CI stays green.

## Test plan

- [x] `bun test` — 78 pass, 0 fail (no JS changes)
- [ ] Verify in consumer repo: re-run failed CI on a bot-created PR — step should show as skipped (grey), not failed (red)
- [ ] Verify human-created PRs still trigger review normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `allowed_bots` input and modify workflows to skip CI steps for unapproved bot-created PRs, maintaining green CI status.
> 
>   - **Behavior**:
>     - Add `allowed_bots` input to `claude-review.yml`, `final-pr-review.yml`, `issue-linker.yml`, `suite-pr.yml`, `suite-all.yml` to allow specific bots to trigger workflows.
>     - Modify `if:` conditions in `claude-review.yml`, `final-pr-review.yml`, `issue-linker.yml` to skip steps if PR is created by an unapproved bot.
>   - **Documentation**:
>     - Update `docs/PATTERNS.md` to include a new Layer 2 in the Bot Guard Pattern, explaining the PR author pre-check and `allowed_bots` configuration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fai-workflows&utm_source=github&utm_medium=referral)<sup> for 77349259a596498359d6ab712c6be8a1008b4b29. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->