### PR TITLE
fix: add workflow_dispatch to suite workflows and correct nesting limit

### DIFF
--- a/.github/workflows/suite-all.yml
+++ b/.github/workflows/suite-all.yml
@@ -6,7 +6,7 @@
 # repo-specific trigger configuration.
 #
 # Nesting: caller → suite-all → suite-pr/suite-post-merge → individual workflow
-# = 3 levels (well within the 10-level GitHub Actions limit).
+# = 3 levels (well within the 4-level GitHub Actions limit).
 #
 # Internal uses: paths are relative — they resolve to the same ref as this
 # suite when called by a child repo (e.g., @v0.8.0 pins the whole chain).
@@ -47,6 +47,7 @@ on:
         description: "Comma-separated bot logins allowed to trigger review (supports *)"
         type: string
         default: ""
+  workflow_dispatch:
 
 # Workflow-level permissions set the maximum for all jobs.
 # permissions: {} silently skips all jobs in cross-repo calls.

--- a/.github/workflows/suite-ci.yml
+++ b/.github/workflows/suite-ci.yml
@@ -36,6 +36,7 @@ on:
         description: "Additional allowed tools beyond defaults (e.g., Bash(tofu:*))"
         type: string
         default: ""
+  workflow_dispatch:
 
 # Workflow-level permissions set the maximum for all jobs.
 # permissions: {} silently skips all jobs in cross-repo calls.

--- a/.github/workflows/suite-post-merge.yml
+++ b/.github/workflows/suite-post-merge.yml
@@ -21,6 +21,7 @@ on:
         type: string
         required: false
         default: ""
+  workflow_dispatch:
 
 # Workflow-level permissions set the maximum for all jobs.
 # permissions: {} silently skips all jobs in cross-repo calls.

--- a/.github/workflows/suite-pr.yml
+++ b/.github/workflows/suite-pr.yml
@@ -38,6 +38,8 @@ on:
         type: string
         default: ""
 
+  workflow_dispatch:
+
 # Workflow-level permissions set the maximum for all jobs.
 # permissions: {} silently skips all jobs in cross-repo calls.
 permissions:


### PR DESCRIPTION
## Summary

Follow-up to #72 addressing review feedback from Copilot.

- Add `workflow_dispatch:` fallback trigger to all 4 suite workflows (`suite-pr.yml`, `suite-ci.yml`, `suite-post-merge.yml`, `suite-all.yml`) per the documented codebase convention (`.github/copilot-instructions.md` line 83, `CONTRIBUTING.md`)
- Correct nesting level comment in `suite-all.yml`: "10-level" → "4-level" (the documented GitHub Actions reusable workflow nesting limit)

## Test plan

- [ ] Confirm each suite workflow appears in the GitHub Actions UI manual trigger list
- [ ] Verify `workflow_dispatch` can be triggered without inputs on each suite workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `workflow_dispatch` trigger to suite workflows and correct nesting level comment in `suite-all.yml`.
> 
>   - **Triggers**:
>     - Add `workflow_dispatch` trigger to `suite-pr.yml`, `suite-ci.yml`, `suite-post-merge.yml`, and `suite-all.yml` for manual workflow execution.
>   - **Comments**:
>     - Correct nesting level comment in `suite-all.yml` from "10-level" to "4-level" to reflect GitHub Actions limit.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fai-workflows&utm_source=github&utm_medium=referral)<sup> for 9bb0946452ce554adbb289e4e59f8f5700d71e10. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->