### PR TITLE
fix: rename SLACK_WEBHOOK_URL to GH_SLACK_WEBHOOK_URL_GITHUB_AUTOMATION

### DIFF
--- a/.github/workflows/notify-ai-pr.yml
+++ b/.github/workflows/notify-ai-pr.yml
@@ -8,7 +8,7 @@ name: AI PR Notification
 on:
   workflow_call:
     secrets:
-      SLACK_WEBHOOK_URL:
+      GH_SLACK_WEBHOOK_URL_GITHUB_AUTOMATION:
         required: true
 
 permissions:
@@ -31,7 +31,7 @@ jobs:
       - name: Send Slack notification
         uses: actions/github-script@v8
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.GH_SLACK_WEBHOOK_URL_GITHUB_AUTOMATION }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_URL: ${{ github.event.pull_request.html_url }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ This repo is the single source of truth for CI/CD automation workflows. Each wor
 
 **AI Provenance**: All PR-creating workflows (`code-simplifier`, `next-steps`, `post-merge-docs-review`, `post-merge-tests`, `issue-resolver`) include a standardized provenance footer in every PR body. `ci-fix` appends provenance to the commit message. See `docs/PATTERNS.md` for the AI Provenance Pattern.
 
-**Slack notifications**: `notify-ai-pr.yml` is a reusable workflow that consumer repos call on `pull_request: opened`. It filters for `claude[bot]`-authored PRs and posts to `#github-automation` via Slack Incoming Webhook. Requires `SLACK_WEBHOOK_URL` secret.
+**Slack notifications**: `notify-ai-pr.yml` is a reusable workflow that consumer repos call on `pull_request: opened`. It filters for `claude[bot]`-authored PRs and posts to `#github-automation` via Slack Incoming Webhook. Requires `GH_SLACK_WEBHOOK_URL_GITHUB_AUTOMATION` secret (synced via secrets-sync).
 
 ### Consumer Repo Caller Pattern
 

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -460,7 +460,7 @@ jobs:
     secrets: inherit
 ```
 
-**Required secret**: `SLACK_WEBHOOK_URL` (Slack Incoming Webhook URL for `#github-automation`)
+**Required secret**: `GH_SLACK_WEBHOOK_URL_GITHUB_AUTOMATION` (Slack Incoming Webhook URL for `#github-automation`, synced from Doppler via secrets-sync)
 
 **Message content** (Slack Block Kit):
 - Header: "AI-Created PR Opened"


### PR DESCRIPTION
## Summary

- Renames the `SLACK_WEBHOOK_URL` secret declaration in `notify-ai-pr.yml` to `GH_SLACK_WEBHOOK_URL_GITHUB_AUTOMATION` to match the Doppler naming convention
- `secrets-sync` pushes Doppler secret names directly as-is to GitHub repos, so the workflow must reference the Doppler name
- Updates `docs/PATTERNS.md` and `CLAUDE.md` to reflect the correct secret name

## Companion PR

JacobPEvans/secrets-sync — adds `GH_SLACK_WEBHOOK_URL_GITHUB_AUTOMATION` to the sync config (must merge first to distribute the secret before this workflow will work end-to-end)

## Test Plan

- [x] Local smoke test passed: `send-slack-pr-notify.js` ran against real webhook via `doppler run` and message appeared in `#github-automation`
- [ ] Merge secrets-sync PR to distribute secret to all repos
- [ ] Verify end-to-end when next `claude[bot]` PR is opened in a consumer repo
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Renames `SLACK_WEBHOOK_URL` to `GH_SLACK_WEBHOOK_URL_GITHUB_AUTOMATION` in `notify-ai-pr.yml` and updates documentation for Doppler compatibility.
> 
>   - **Secret Rename**:
>     - Renames `SLACK_WEBHOOK_URL` to `GH_SLACK_WEBHOOK_URL_GITHUB_AUTOMATION` in `notify-ai-pr.yml`.
>     - Updates references in `CLAUDE.md` and `docs/PATTERNS.md` to the new secret name.
>   - **Workflow Behavior**:
>     - `notify-ai-pr.yml` now requires `GH_SLACK_WEBHOOK_URL_GITHUB_AUTOMATION` secret for Slack notifications.
>     - Ensures compatibility with `secrets-sync` by using Doppler secret names directly.
>   - **Documentation**:
>     - Updates `CLAUDE.md` and `docs/PATTERNS.md` to reflect the correct secret name and usage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fai-workflows&utm_source=github&utm_medium=referral)<sup> for 42c8781173048943605824c765612215e90a6720. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->