### PR TITLE
fix: add workflow_dispatch trigger to release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,6 +3,7 @@ name: Release Please
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 # Workflow-level permissions set the maximum for all jobs.
 # permissions: {} silently skips all jobs in cross-repo calls.


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch` trigger to `release-please.yml` so it can be manually triggered when automatic push-triggered runs miss commits or need re-execution

## Context

Release-please couldn't create PRs because the repo's "Allow GitHub Actions to create and approve pull requests" setting was disabled. Now that it's enabled (fixed today), we need to trigger a fresh release-please run. Adding `workflow_dispatch` enables this and prevents the issue in the future.

## Test plan

- [ ] Merge this PR (triggers release-please via push event)
- [ ] Verify release-please creates v0.8.0 release PR with 6 unreleased commits
- [ ] If not auto-triggered, run manually: `gh workflow run release-please.yml --repo JacobPEvans/ai-workflows`

🤖 Generated with [Claude Code](https://claude.com/claude-code)