### PR TITLE
feat: increase prompt scope, raise timeouts, and add dogfooding

### DIFF
--- a/.github/prompts/code-simplifier.md
+++ b/.github/prompts/code-simplifier.md
@@ -42,7 +42,7 @@ Examine the files changed in recent commits. Look for these issues in priority o
 
 ## Output
 
-Pick the single highest-impact improvement. Create one focused PR that:
+Pick up to 3 high-impact improvements from different categories. Create one PR addressing the selected improvements that:
 
 - Changes the minimum number of files needed
 - Has a clear title describing the improvement

--- a/.github/prompts/next-steps.md
+++ b/.github/prompts/next-steps.md
@@ -47,7 +47,7 @@ Choose exactly ONE action based on impact:
 
 ### Option A: PR (for simple changes)
 
-If the fix is straightforward (< 50 lines changed, <= 3 files):
+If the fix is straightforward (< 150 lines changed, <= 6 files):
 - Create a PR with the fix
 - Title format: `chore: [description of next step]`
 - Body must explain: what was detected, why this is the logical next step, what changed

--- a/.github/prompts/post-merge-docs-review.md
+++ b/.github/prompts/post-merge-docs-review.md
@@ -23,7 +23,7 @@ Check for these issue categories in priority order:
 - **Sensitive data exposure**: API keys, tokens, real IP addresses, internal hostnames, passwords, or PII in documentation files. Check against scrubbing rules: use 192.168.0.* for IPs, example.com/example.local for domains, your-token-here for secrets.
 - **Broken functionality**: Code examples that reference deleted functions, renamed files, or changed APIs.
 
-### Non-critical (2+ needed to trigger a PR)
+### Non-critical (1+ needed to trigger a PR)
 - **DRY violations**: The same information repeated in multiple docs files.
 - **Code/doc inconsistency**: README describes behavior that no longer matches the code.
 - **Outdated references**: Links to moved/deleted files, references to old branch names, deprecated tool versions.
@@ -33,7 +33,7 @@ Check for these issue categories in priority order:
 
 Create a PR ONLY if:
 - 1 or more critical issues found, OR
-- 2 or more non-critical issues found
+- 1 or more non-critical issues found
 
 If below threshold, exit without action. Never create PRs for style-only changes.
 

--- a/.github/prompts/post-merge-tests.md
+++ b/.github/prompts/post-merge-tests.md
@@ -27,7 +27,7 @@ For each changed file that has testable logic:
 If you find uncovered testable code:
 
 1. Create a new branch from `main` with name `chore/add-tests-<short-description>`
-2. Write 1-2 targeted test files following the EXACT patterns found in existing tests:
+2. Write 1-4 targeted test files following the EXACT patterns found in existing tests:
    - Same test framework and assertion style
    - Same file naming convention
    - Same directory structure
@@ -44,7 +44,7 @@ If you find uncovered testable code:
 
 ## Rules
 
-- Maximum 2 test files per run
+- Maximum 4 test files per run
 - Follow existing test patterns exactly — never introduce new test libraries or frameworks
 - Only test public APIs and exported functions
 - Do not create tests for trivial getters/setters or configuration files

--- a/.github/workflows/code-simplifier.yml
+++ b/.github/workflows/code-simplifier.yml
@@ -29,7 +29,7 @@ jobs:
       contents: write
       id-token: write
       pull-requests: write
-    timeout-minutes: 5
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/dogfood-all.yml
+++ b/.github/workflows/dogfood-all.yml
@@ -1,0 +1,55 @@
+name: AI Workflows
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+  issue_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: "Commit SHA to review (leave blank for latest main)"
+        required: false
+        type: string
+
+permissions: {}
+
+jobs:
+  # Push to main -> re-dispatch as workflow_dispatch so post-merge suites
+  # can use the commit SHA via inputs.commit_sha (workflow_run context workaround).
+  post-merge-dispatch:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Re-trigger as workflow_dispatch
+        env:
+          WORKFLOW_NAME: ${{ github.workflow }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run "$WORKFLOW_NAME" \
+            --repo "${{ github.repository }}" \
+            --ref main \
+            -f commit_sha="${{ github.sha }}"
+
+  # All non-push events -> suite-all routes to correct sub-suite
+  all:
+    if: github.event_name != 'push'
+    permissions:
+      actions: read
+      checks: read
+      contents: write
+      id-token: write
+      issues: write
+      pull-requests: write
+    uses: JacobPEvans/ai-workflows/.github/workflows/suite-all.yml@v0.8.0
+    with:
+      caller_event: ${{ github.event_name }}
+      review_prompt: "Focus on GitHub Actions workflow patterns, reusable workflow design, prompt engineering, and JavaScript script quality"
+      commit_sha: ${{ inputs.commit_sha || github.sha }}
+    secrets: inherit

--- a/.github/workflows/dogfood-best-practices.yml
+++ b/.github/workflows/dogfood-best-practices.yml
@@ -1,0 +1,13 @@
+name: Dogfood Best Practices
+on:
+  schedule:
+    - cron: "0 3 * * 2,5"
+  workflow_dispatch:
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: write
+jobs:
+  best-practices:
+    uses: JacobPEvans/ai-workflows/.github/workflows/best-practices.yml@v0.8.0
+    secrets: inherit

--- a/.github/workflows/dogfood-ci.yml
+++ b/.github/workflows/dogfood-ci.yml
@@ -1,0 +1,26 @@
+name: AI CI
+
+on:
+  workflow_run:
+    workflows: ["Tests"]
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: write
+  id-token: write
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: ai-ci-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  ci-suite:
+    uses: JacobPEvans/ai-workflows/.github/workflows/suite-ci.yml@v0.8.0
+    with:
+      repo_context: "Reusable GitHub Actions workflows for AI-powered CI/CD automation (prompts, scripts, YAML workflows)"
+      ci_structure: "test.yml (bun test for JavaScript scripts)"
+      workflow_name: "Tests"
+    secrets: inherit

--- a/.github/workflows/dogfood-issue-hygiene.yml
+++ b/.github/workflows/dogfood-issue-hygiene.yml
@@ -1,0 +1,14 @@
+name: Dogfood Issue Hygiene
+on:
+  schedule:
+    - cron: "0 7 * * 0"
+  workflow_dispatch:
+permissions:
+  contents: read
+  id-token: write
+  issues: write
+  pull-requests: read
+jobs:
+  hygiene:
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-hygiene.yml@v0.8.0
+    secrets: inherit

--- a/.github/workflows/dogfood-issue-sweeper.yml
+++ b/.github/workflows/dogfood-issue-sweeper.yml
@@ -1,0 +1,14 @@
+name: Dogfood Issue Sweeper
+on:
+  schedule:
+    - cron: "0 6 * * 0"
+  workflow_dispatch:
+permissions:
+  contents: read
+  id-token: write
+  issues: write
+  pull-requests: read
+jobs:
+  sweep:
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-sweeper.yml@v0.8.0
+    secrets: inherit

--- a/.github/workflows/next-steps.yml
+++ b/.github/workflows/next-steps.yml
@@ -31,7 +31,7 @@ jobs:
       id-token: write
       issues: write
       pull-requests: write
-    timeout-minutes: 5
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/post-merge-docs-review.yml
+++ b/.github/workflows/post-merge-docs-review.yml
@@ -62,7 +62,7 @@ jobs:
       contents: write
       id-token: write
       pull-requests: write
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -62,7 +62,7 @@ jobs:
       contents: write
       id-token: write
       pull-requests: write
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Raise timeouts: code-simplifier and next-steps 5->15 min, post-merge workflows 10->15 min
- Broaden prompt scope: code-simplifier allows up to 3 improvements, next-steps allows 150 lines/6 files, post-merge-docs-review lowers threshold to 1 non-critical, post-merge-tests allows 4 test files
- Add ai-workflows dogfooding: dogfood-all, dogfood-ci, dogfood-best-practices, dogfood-issue-sweeper, dogfood-issue-hygiene

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Related Issues
Closes #19