### PR TITLE
fix: correct dogfood permissions and docs-review threshold

### DIFF
--- a/.github/prompts/post-merge-docs-review.md
+++ b/.github/prompts/post-merge-docs-review.md
@@ -23,7 +23,7 @@ Check for these issue categories in priority order:
 - **Sensitive data exposure**: API keys, tokens, real IP addresses, internal hostnames, passwords, or PII in documentation files. Check against scrubbing rules: use 192.168.0.* for IPs, example.com/example.local for domains, your-token-here for secrets.
 - **Broken functionality**: Code examples that reference deleted functions, renamed files, or changed APIs.
 
-### Non-critical (1+ needed to trigger a PR)
+### Non-critical (2+ needed to trigger a PR)
 - **DRY violations**: The same information repeated in multiple docs files.
 - **Code/doc inconsistency**: README describes behavior that no longer matches the code.
 - **Outdated references**: Links to moved/deleted files, references to old branch names, deprecated tool versions.
@@ -33,7 +33,7 @@ Check for these issue categories in priority order:
 
 Create a PR ONLY if:
 - 1 or more critical issues found, OR
-- 1 or more non-critical issues found
+- 2 or more non-critical issues found
 
 If below threshold, exit without action. Never create PRs for style-only changes.
 

--- a/.github/workflows/dogfood-all.yml
+++ b/.github/workflows/dogfood-all.yml
@@ -16,7 +16,13 @@ on:
         required: false
         type: string
 
-permissions: {}
+permissions:
+  actions: write
+  checks: read
+  contents: write
+  id-token: write
+  issues: write
+  pull-requests: write
 
 jobs:
   # Push to main -> re-dispatch as workflow_dispatch so post-merge suites

--- a/.github/workflows/dogfood-best-practices.yml
+++ b/.github/workflows/dogfood-best-practices.yml
@@ -6,7 +6,8 @@ on:
 permissions:
   contents: read
   id-token: write
-  pull-requests: write
+  issues: write
+  pull-requests: read
 jobs:
   best-practices:
     uses: JacobPEvans/ai-workflows/.github/workflows/best-practices.yml@v0.8.0


### PR DESCRIPTION
## Summary
Follow-up to #83 — fixes three review findings that auto-merged before landing:

- `post-merge-docs-review.md`: restore non-critical threshold to 2+ (was changed to 1+ in #83, removing meaningful distinction from critical threshold)
- `dogfood-all.yml`: replace `permissions: {}` with explicit permissions (empty object silently blocks cross-repo workflow calls)
- `dogfood-best-practices.yml`: add `issues: write`, downscope `pull-requests` from `write` to `read` (matching actual callee requirements)

🤖 Generated with [Claude Code](https://claude.com/claude-code)