### PR TITLE
fix: allow claude[bot] to trigger ci-fix on its own PRs

### DIFF
--- a/.github/workflows/ci-fix.yml
+++ b/.github/workflows/ci-fix.yml
@@ -47,8 +47,7 @@ jobs:
     name: Check if fix needed
     if: >-
       github.actor != 'renovate[bot]' &&
-      github.actor != 'dependabot[bot]' &&
-      github.actor != 'claude[bot]'
+      github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
@@ -217,7 +216,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed_bots: "github-actions"
+          allowed_bots: "github-actions,claude"
           use_commit_signing: "true"
           prompt: ${{ steps.prompt.outputs.content }}
           claude_args: >-

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -203,6 +203,8 @@ Four layers of bot filtering apply, depending on workflow type.
 
 **Fix**: Every `claude-code-action@v1` step includes `allowed_bots: "github-actions"`. This allows the trusted internal dispatch actor while blocking external bots.
 
+**Exception**: ci-fix uses `allowed_bots: "github-actions,claude"` because `workflow_run` events propagate the original actor. When `claude[bot]` pushes a commit, `github.actor` is `claude[bot]` — the action strips `[bot]` and checks against `allowed_bots`. Loop prevention is handled by the attempt counter (max 2), not by blocking the actor.
+
 ### Layer 2: PR author pre-check (`if:` on action steps)
 
 When a bot creates a PR (e.g., the `claude` GitHub App), `claude-code-action@v1`'s built-in bot guard hard-fails the step — producing a red CI failure. The fix: add an `if:` condition directly on the `claude-code-action` step (and any steps that depend on its output) to check the PR author type *before* the action runs.
@@ -241,7 +243,7 @@ Supports comma-separated logins or `*` to allow all bots.
 
 ### Layer 3: Dependency bot filtering (`if:` guards)
 
-PR-triggered workflows (claude-review, final-pr-review, ci-fix, issue-linker, pr-issue-linker) add `if:` guards on their first job to skip runs triggered by dependency bots (Renovate, Dependabot) and the Claude GitHub App. This produces a clean **skipped** (grey) status instead of a **failed** (red) status.
+PR-triggered workflows (claude-review, final-pr-review, issue-linker, pr-issue-linker) add `if:` guards on their first job to skip runs triggered by dependency bots (Renovate, Dependabot) and the Claude GitHub App. This produces a clean **skipped** (grey) status instead of a **failed** (red) status.
 
 ```yaml
   gate-check:
@@ -250,6 +252,8 @@ PR-triggered workflows (claude-review, final-pr-review, ci-fix, issue-linker, pr
       github.actor != 'dependabot[bot]' &&
       github.actor != 'claude[bot]'
 ```
+
+**Exception**: ci-fix does NOT block `claude[bot]` — it only blocks dependency bots (`renovate[bot]`, `dependabot[bot]`). When Claude creates a PR and CI fails, ci-fix needs to run. Loop prevention is handled by the attempt counter (`check-attempts.js`, max 2 attempts per PR), not by blocking the actor.
 
 **Why at the job level**: Skipping the first job causes GitHub to show all downstream jobs as skipped too — a clean grey tree.
 


### PR DESCRIPTION
## Summary

When `claude[bot]` creates a PR and CI fails, the ci-fix workflow was blocked by two overlapping guards that both rejected `claude[bot]` as the actor. The existing attempt counter (`check-attempts.js`, max 2 per PR) already prevents infinite loops, making these `claude[bot]` exclusions redundant and harmful.

This PR removes the `claude[bot]` exclusion from ci-fix's bot guards so it can auto-fix CI failures on Claude-authored PRs.

## Changes

- **`.github/workflows/ci-fix.yml`**
  - Remove `claude[bot]` from the Layer 3 job-level `if:` guard (dependency bot filter) so ci-fix is not skipped when Claude is the actor
  - Add `claude` to `allowed_bots` in the `claude-code-action@v1` step so the action accepts `claude[bot]` as the `workflow_run` actor (the action strips `[bot]` and checks against this list)
- **`docs/PATTERNS.md`**
  - Add exception note to Layer 1 explaining why ci-fix uses `allowed_bots: "github-actions,claude"` instead of just `"github-actions"`
  - Update Layer 3 description to remove ci-fix from the list of workflows that block `claude[bot]`, with an exception note explaining the rationale

## Test Plan

- [x] `bun test` -- 132 tests pass, no regressions
- [ ] After merge + release: trigger a CI failure on a `claude[bot]`-authored PR and verify ci-fix runs successfully
- [ ] Verify attempt counter still caps at 2 fix attempts per PR (existing coverage in `check-attempts.test.js`)