### PR TITLE
fix: standardize release-please workflow and config

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,10 +4,14 @@ on:
   push:
     branches: [main]
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   release-please:
+    permissions:
+      contents: write
+      pull-requests: write
     uses: JacobPEvans/.github/.github/workflows/_release-please.yml@main
+    secrets:
+      GH_ACTION_JACOBPEVANS_APP_ID: ${{ secrets.GH_ACTION_JACOBPEVANS_APP_ID }}
+      GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,19 +3,19 @@
   "packages": {
     ".": {
       "release-type": "simple",
-      "version-file": "VERSION"
+      "version-file": "VERSION",
+      "bump-minor-pre-major": true,
+      "include-v-in-tag": true,
+      "changelog-sections": [
+        {"type": "feat", "section": "Features"},
+        {"type": "fix", "section": "Bug Fixes"},
+        {"type": "perf", "section": "Performance"},
+        {"type": "docs", "section": "Documentation", "hidden": true},
+        {"type": "chore", "section": "Miscellaneous", "hidden": true},
+        {"type": "refactor", "section": "Refactoring", "hidden": true},
+        {"type": "test", "section": "Tests", "hidden": true},
+        {"type": "ci", "section": "CI", "hidden": true}
+      ]
     }
-  },
-  "bump-minor-pre-major": true,
-  "include-v-in-tag": true,
-  "changelog-sections": [
-    {"type": "feat", "section": "Features"},
-    {"type": "fix", "section": "Bug Fixes"},
-    {"type": "perf", "section": "Performance"},
-    {"type": "docs", "section": "Documentation", "hidden": true},
-    {"type": "chore", "section": "Miscellaneous", "hidden": true},
-    {"type": "refactor", "section": "Refactoring", "hidden": true},
-    {"type": "test", "section": "Tests", "hidden": true},
-    {"type": "ci", "section": "CI", "hidden": true}
-  ]
+  }
 }


### PR DESCRIPTION
## Summary
- Adds missing `secrets` block — workflow was failing because secrets are `required: true`
- Fixes permissions: `permissions: {}` top-level with job-level grants (least-privilege)
- Migrates config from hybrid format (root-level options + packages) to canonical packages format

## Test plan
- [ ] CI passes
- [ ] After merge, release-please workflow on main succeeds

## Related PRs
Part of the release-please standardization effort across all repos.
- **Wave 1 (merge first):** JacobPEvans/.github#112
- Wave 2: JacobPEvans/terraform-aws-bedrock#22, JacobPEvans/kubernetes-monitoring#98, JacobPEvans/ai-workflows#113, JacobPEvans/secrets-sync#29, JacobPEvans/tf-splunk-aws#75, JacobPEvans/terraform-aws-static-website#14, JacobPEvans/ansible-proxmox-apps#137, JacobPEvans/ansible-splunk#99

🤖 Generated with [Claude Code](https://claude.com/claude-code)