### PR TITLE
fix: add always-bump-minor versioning to prevent automated major bumps

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,8 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "packages": {
     ".": {
+      "$comment": "versioning: always-bump-minor is REQUIRED org-wide policy — prevents release-please from ever computing a major version bump. Major bumps are human-initiated only via .release-please-manifest.json. Do NOT remove.",
+      "versioning": "always-bump-minor",
       "release-type": "simple",
       "version-file": "VERSION",
       "bump-minor-pre-major": true,


### PR DESCRIPTION
## Summary

- Adds `"versioning": "always-bump-minor"` to `release-please-config.json` — a native release-please setting that prevents automated major version bumps
- Adds `$comment` documenting the org-wide policy so the key doesn't get silently removed again
- Triggered by [claude-code-plugins#176](https://github.com/JacobPEvans/claude-code-plugins/pull/176) where an accidental v2.0.0 was created after this config was dropped

## Test plan

- [ ] Verify release-please workflow still runs on next push to main
- [ ] Confirm no major version bump PR is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)