### PR TITLE
fix: disable claude-review workflow — replaced by Gemini + Copilot

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,7 +1,7 @@
 # Claude Code Review
 #
 # DEPRECATED 2026-04-04: Removed in favor of Gemini + Copilot PR reviews.
-# This workflow is disabled. Callers will receive a "not found" error.
+# This workflow is disabled. Callers will silently skip (all jobs gated with if: false).
 # To fully remove: delete this file and all caller references.
 #
 # Reusable workflow: automatic PR review with inline comments + interactive mode.
@@ -14,7 +14,7 @@ name: Claude Code Review
 
 on:
   # DEPRECATED 2026-04-04: Removed in favor of Gemini + Copilot PR reviews.
-  # This workflow is disabled. Callers will receive a "not found" error.
+  # This workflow is disabled. Callers will silently skip (all jobs gated with if: false).
   # To fully remove: delete this file and all caller references.
   workflow_call:
     inputs:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,5 +1,9 @@
 # Claude Code Review
 #
+# DEPRECATED 2026-04-04: Removed in favor of Gemini + Copilot PR reviews.
+# This workflow is disabled. Callers will receive a "not found" error.
+# To fully remove: delete this file and all caller references.
+#
 # Reusable workflow: automatic PR review with inline comments + interactive mode.
 # Posts inline resolvable comments via mcp__github_inline_comment.
 #
@@ -9,29 +13,14 @@
 name: Claude Code Review
 
 on:
+  # DEPRECATED 2026-04-04: Removed in favor of Gemini + Copilot PR reviews.
+  # This workflow is disabled. Callers will receive a "not found" error.
+  # To fully remove: delete this file and all caller references.
   workflow_call:
     inputs:
-      daily_run_limit:
-        description: "Max workflow runs per day (0 to disable)"
+      dummy:
         type: string
-        default: "5"
-      review_prompt:
-        description: "Optional repo-specific review focus"
-        type: string
-        default: ""
-      max_reviews:
-        description: "Max Claude reviews per PR (0 = unlimited)"
-        type: string
-        default: "1"
-      model:
-        description: "Claude model to use (overrides AI_MODEL_REVIEW and AI_MODEL vars)"
-        type: string
-        default: ""
-      allowed_bots:
-        description: "Comma-separated bot logins allowed to trigger review (supports *)"
-        type: string
-        default: ""
-  workflow_dispatch:
+        description: "This workflow is deprecated and will not run"
 
 # Workflow-level permissions set the maximum for all jobs.
 # permissions: {} silently skips all jobs in cross-repo calls.
@@ -48,6 +37,7 @@ concurrency:
 
 jobs:
   check-daily-limit:
+    if: false
     name: Check daily run limit
     runs-on: ubuntu-latest
     permissions:
@@ -74,15 +64,9 @@ jobs:
             await run({ github, context, core });
 
   review:
+    if: false
     name: Claude Code Review
     needs: check-daily-limit
-    if: >-
-      needs.check-daily-limit.outputs.should_run == 'true' &&
-      github.actor != 'renovate[bot]' &&
-      github.actor != 'dependabot[bot]' &&
-      github.actor != 'claude[bot]' &&
-      github.event.pull_request != null &&
-      !contains(github.event.pull_request.labels.*.name, 'ai:skip-review')
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -152,10 +136,8 @@ jobs:
             --model ${{ inputs.model || vars.AI_MODEL_REVIEW || vars.AI_MODEL || 'openrouter/free' }} --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
 
   interactive:
+    if: false
     name: Claude Interactive
-    if: >-
-      github.event.comment != null &&
-      contains(github.event.comment.body, '@claude')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -65,6 +65,13 @@ jobs:
 
   review:
     if: false
+    # Original conditions (preserved for reuse in future AI review workflows):
+    #   needs.check-daily-limit.outputs.should_run == 'true' &&
+    #   github.actor != 'renovate[bot]' &&
+    #   github.actor != 'dependabot[bot]' &&
+    #   github.actor != 'claude[bot]' &&
+    #   github.event.pull_request != null &&
+    #   !contains(github.event.pull_request.labels.*.name, 'ai:skip-review')
     name: Claude Code Review
     needs: check-daily-limit
     runs-on: ubuntu-latest
@@ -137,6 +144,9 @@ jobs:
 
   interactive:
     if: false
+    # Original conditions (preserved for reuse):
+    #   github.event.comment != null &&
+    #   contains(github.event.comment.body, '@claude')
     name: Claude Interactive
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/suite-all.yml
+++ b/.github/workflows/suite-all.yml
@@ -15,7 +15,6 @@
 #   uses: JacobPEvans/ai-workflows/.github/workflows/suite-all.yml@v0.8.0
 #   with:
 #     caller_event: ${{ github.event_name }}
-#     review_prompt: "Repo-specific review focus"
 #     commit_sha: ${{ inputs.commit_sha || github.sha }}
 
 name: "Suite: All"
@@ -27,18 +26,6 @@ on:
         description: "Event that triggered the caller (pass github.event_name)"
         type: string
         required: true
-      review_prompt:
-        description: "Repo-specific review focus for Claude Code Review"
-        type: string
-        default: ""
-      max_reviews:
-        description: "Max Claude reviews per PR (0 = unlimited)"
-        type: string
-        default: "1"
-      model:
-        description: "Claude model to use (overrides AI_MODEL vars on child workflows)"
-        type: string
-        default: ""
       commit_sha:
         description: "Commit SHA for post-merge reviews (from workflow_dispatch)"
         type: string
@@ -70,9 +57,6 @@ jobs:
     uses: ./.github/workflows/suite-pr.yml
     with:
       caller_event: ${{ inputs.caller_event }}
-      review_prompt: ${{ inputs.review_prompt }}
-      max_reviews: ${{ inputs.max_reviews }}
-      model: ${{ inputs.model }}
       allowed_bots: ${{ inputs.allowed_bots }}
     secrets: inherit
 

--- a/.github/workflows/suite-pr.yml
+++ b/.github/workflows/suite-pr.yml
@@ -1,6 +1,6 @@
 # Suite: PR Reviews
 #
-# Reusable workflow: bundles claude-review + final-pr-review.
+# Reusable workflow: bundles final-pr-review.
 # Callers pass caller_event to route to the correct individual workflow.
 #
 # Internal uses: paths are relative — they resolve to the same ref as this
@@ -10,7 +10,6 @@
 #   uses: JacobPEvans/ai-workflows/.github/workflows/suite-pr.yml@v0.8.0
 #   with:
 #     caller_event: ${{ github.event_name }}
-#     review_prompt: "Repo-specific review focus"
 
 name: "Suite: PR Reviews"
 
@@ -21,18 +20,6 @@ on:
         description: "Event that triggered the caller (pass github.event_name)"
         type: string
         required: true
-      review_prompt:
-        description: "Repo-specific review focus for Claude Code Review"
-        type: string
-        default: ""
-      max_reviews:
-        description: "Max Claude reviews per PR (0 = unlimited)"
-        type: string
-        default: "1"
-      model:
-        description: "Claude model to use (overrides AI_MODEL vars on child workflows)"
-        type: string
-        default: ""
       allowed_bots:
         description: "Comma-separated bot logins allowed to trigger review (supports *)"
         type: string
@@ -51,18 +38,6 @@ permissions:
   pull-requests: write
 
 jobs:
-  claude-review:
-    if: >-
-      inputs.caller_event == 'pull_request' ||
-      inputs.caller_event == 'issue_comment'
-    uses: ./.github/workflows/claude-review.yml
-    with:
-      review_prompt: ${{ inputs.review_prompt }}
-      max_reviews: ${{ inputs.max_reviews }}
-      model: ${{ inputs.model }}
-      allowed_bots: ${{ inputs.allowed_bots }}
-    secrets: inherit
-
   final-pr-review:
     if: >-
       inputs.caller_event == 'pull_request_review' ||


### PR DESCRIPTION
## Summary

- Disable claude-review.yml template (all jobs gated with `if: false`)
- Remove claude-review from suite-pr.yml orchestrator (if present)
- PR reviews now handled by Gemini Code Assist + GitHub Copilot

Parallel PRs removing caller workflows from all consumer repos.

## Test plan

- [ ] Verify workflow cannot be triggered
- [ ] Verify suite-pr still works without claude-review


🤖 Generated with [Claude Code](https://claude.com/claude-code)