### PR TITLE
fix(gh-aw): use --action-mode script in compile

### DIFF
--- a/.github/workflows/gh-aw-ai-moderator.lock.yml
+++ b/.github/workflows/gh-aw-ai-moderator.lock.yml
@@ -84,11 +84,14 @@ jobs:
           repository: github/gh-aw
           sparse-checkout: |
             actions
+          path: /tmp/gh-aw/actions-source
+          fetch-depth: 1
           persist-credentials: false
       - name: Setup Scripts
-        uses: ./actions/setup
-        with:
-          destination: ${{ runner.temp }}/gh-aw/actions
+        run: |
+          bash /tmp/gh-aw/actions-source/actions/setup/setup.sh
+        env:
+          INPUT_DESTINATION: ${{ runner.temp }}/gh-aw/actions
       - name: Generate agentic run info
         id: generate_aw_info
         env:
@@ -126,7 +129,6 @@ jobs:
           sparse-checkout: |
             .github
             .agents
-            actions/setup
           sparse-checkout-cone-mode: true
           fetch-depth: 1
       - name: Check workflow file timestamps
@@ -284,7 +286,7 @@ jobs:
         run: bash ${RUNNER_TEMP}/gh-aw/actions/print_prompt_summary.sh
       - name: Upload activation artifact
         if: success()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: activation
           path: |
@@ -320,11 +322,14 @@ jobs:
           repository: github/gh-aw
           sparse-checkout: |
             actions
+          path: /tmp/gh-aw/actions-source
+          fetch-depth: 1
           persist-credentials: false
       - name: Setup Scripts
-        uses: ./actions/setup
-        with:
-          destination: ${{ runner.temp }}/gh-aw/actions
+        run: |
+          bash /tmp/gh-aw/actions-source/actions/setup/setup.sh
+        env:
+          INPUT_DESTINATION: ${{ runner.temp }}/gh-aw/actions
       - name: Set runtime paths
         id: set-runtime-paths
         run: |
@@ -780,7 +785,7 @@ jobs:
       - name: Upload agent artifacts
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: agent
           path: |
@@ -796,7 +801,7 @@ jobs:
       - name: Upload firewall audit logs
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: firewall-audit-logs
           path: |
@@ -831,11 +836,14 @@ jobs:
           repository: github/gh-aw
           sparse-checkout: |
             actions
+          path: /tmp/gh-aw/actions-source
+          fetch-depth: 1
           persist-credentials: false
       - name: Setup Scripts
-        uses: ./actions/setup
-        with:
-          destination: ${{ runner.temp }}/gh-aw/actions
+        run: |
+          bash /tmp/gh-aw/actions-source/actions/setup/setup.sh
+        env:
+          INPUT_DESTINATION: ${{ runner.temp }}/gh-aw/actions
       - name: Download agent output artifact
         id: download-agent-output
         continue-on-error: true
@@ -935,11 +943,14 @@ jobs:
           repository: github/gh-aw
           sparse-checkout: |
             actions
+          path: /tmp/gh-aw/actions-source
+          fetch-depth: 1
           persist-credentials: false
       - name: Setup Scripts
-        uses: ./actions/setup
-        with:
-          destination: ${{ runner.temp }}/gh-aw/actions
+        run: |
+          bash /tmp/gh-aw/actions-source/actions/setup/setup.sh
+        env:
+          INPUT_DESTINATION: ${{ runner.temp }}/gh-aw/actions
       - name: Check skip-roles
         id: check_skip_roles
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -999,11 +1010,14 @@ jobs:
           repository: github/gh-aw
           sparse-checkout: |
             actions
+          path: /tmp/gh-aw/actions-source
+          fetch-depth: 1
           persist-credentials: false
       - name: Setup Scripts
-        uses: ./actions/setup
-        with:
-          destination: ${{ runner.temp }}/gh-aw/actions
+        run: |
+          bash /tmp/gh-aw/actions-source/actions/setup/setup.sh
+        env:
+          INPUT_DESTINATION: ${{ runner.temp }}/gh-aw/actions
       - name: Download agent output artifact
         id: download-agent-output
         continue-on-error: true
@@ -1045,7 +1059,7 @@ jobs:
             await main();
       - name: Upload Safe Output Items
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: safe-output-items
           path: /tmp/gh-aw/safe-output-items.jsonl
@@ -1068,11 +1082,14 @@ jobs:
           repository: github/gh-aw
           sparse-checkout: |
             actions
+          path: /tmp/gh-aw/actions-source
+          fetch-depth: 1
           persist-credentials: false
       - name: Setup Scripts
-        uses: ./actions/setup
-        with:
-          destination: ${{ runner.temp }}/gh-aw/actions
+        run: |
+          bash /tmp/gh-aw/actions-source/actions/setup/setup.sh
+        env:
+          INPUT_DESTINATION: ${{ runner.temp }}/gh-aw/actions
       - name: Unlock issue after agent workflow
         id: unlock-issue
         if: (github.event_name == 'issues' || github.event_name == 'issue_comment') && needs.activation.outputs.issue_locked == 'true'

--- a/.github/workflows/gh-aw-ci-doctor.lock.yml
+++ b/.github/workflows/gh-aw-ci-doctor.lock.yml
@@ -69,11 +69,14 @@ jobs:
           repository: github/gh-aw
           sparse-checkout: |
             actions
+          path: /tmp/gh-aw/actions-source
+          fetch-depth: 1
           persist-credentials: false
       - name: Setup Scripts
-        uses: ./actions/setup
-        with:
-          destination: ${{ runner.temp }}/gh-aw/actions
+        run: |
+          bash /tmp/gh-aw/actions-source/actions/setup/setup.sh
+        env:
+          INPUT_DESTINATION: ${{ runner.temp }}/gh-aw/actions
       - name: Generate agentic run info
         id: generate_aw_info
         env:
@@ -111,7 +114,6 @@ jobs:
           sparse-checkout: |
             .github
             .agents
-            actions/setup
           sparse-checkout-cone-mode: true
           fetch-depth: 1
       - name: Check workflow file timestamps
@@ -251,7 +253,7 @@ jobs:
         run: bash ${RUNNER_TEMP}/gh-aw/actions/print_prompt_summary.sh
       - name: Upload activation artifact
         if: success()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: activation
           path: |
@@ -287,11 +289,14 @@ jobs:
           repository: github/gh-aw
           sparse-checkout: |
             actions
+          path: /tmp/gh-aw/actions-source
+          fetch-depth: 1
           persist-credentials: false
       - name: Setup Scripts
-        uses: ./actions/setup
-        with:
-          destination: ${{ runner.temp }}/gh-aw/actions
+        run: |
+          bash /tmp/gh-aw/actions-source/actions/setup/setup.sh
+        env:
+          INPUT_DESTINATION: ${{ runner.temp }}/gh-aw/actions
       - name: Set runtime paths
         id: set-runtime-paths
         run: |
@@ -778,7 +783,7 @@ jobs:
       - name: Upload agent artifacts
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: agent
           path: |
@@ -794,7 +799,7 @@ jobs:
       - name: Upload firewall audit logs
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: firewall-audit-logs
           path: |
@@ -828,11 +833,14 @@ jobs:
           repository: github/gh-aw
           sparse-checkout: |
             actions
+          path: /tmp/gh-aw/actions-source
+          fetch-depth: 1
           persist-credentials: false
       - name: Setup Scripts
-        uses: ./actions/setup
-        with:
-          destination: ${{ runner.temp }}/gh-aw/actions
+        run: |
+          bash /tmp/gh-aw/actions-source/actions/setup/setup.sh
+        env:
+          INPUT_DESTINATION: ${{ runner.temp }}/gh-aw/actions
       - name: Download agent output artifact
         id: download-agent-output
         continue-on-error: true
@@ -933,11 +941,14 @@ jobs:
           repository: github/gh-aw
           sparse-checkout: |
             actions
+          path: /tmp/gh-aw/actions-source
+          fetch-depth: 1
           persist-credentials: false
       - name: Setup Scripts
-        uses: ./actions/setup
-        with:
-          destination: ${{ runner.temp }}/gh-aw/actions
+        run: |
+          bash /tmp/gh-aw/actions-source/actions/setup/setup.sh
+        env:
+          INPUT_DESTINATION: ${{ runner.temp }}/gh-aw/actions
       - name: Check team membership for workflow
         id: check_membership
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -985,11 +996,14 @@ jobs:
           repository: github/gh-aw
           sparse-checkout: |
             actions
+          path: /tmp/gh-aw/actions-source
+          fetch-depth: 1
           persist-credentials: false
       - name: Setup Scripts
-        uses: ./actions/setup
-        with:
-          destination: ${{ runner.temp }}/gh-aw/actions
+        run: |
+          bash /tmp/gh-aw/actions-source/actions/setup/setup.sh
+        env:
+          INPUT_DESTINATION: ${{ runner.temp }}/gh-aw/actions
       - name: Download agent output artifact
         id: download-agent-output
         continue-on-error: true
@@ -1031,7 +1045,7 @@ jobs:
             await main();
       - name: Upload Safe Output Items
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: safe-output-items
           path: /tmp/gh-aw/safe-output-items.jsonl

--- a/.github/workflows/gh-aw-daily-malicious-code-scan.lock.yml
+++ b/.github/workflows/gh-aw-daily-malicious-code-scan.lock.yml
@@ -65,11 +65,14 @@ jobs:
           repository: github/gh-aw
           sparse-checkout: |
             actions
+          path: /tmp/gh-aw/actions-source
+          fetch-depth: 1
           persist-credentials: false
       - name: Setup Scripts
-        uses: ./actions/setup
-        with:
-          destination: ${{ runner.temp }}/gh-aw/actions
+        run: |
+          bash /tmp/gh-aw/actions-source/actions/setup/setup.sh
+        env:
+          INPUT_DESTINATION: ${{ runner.temp }}/gh-aw/actions
       - name: Generate agentic run info
         id: generate_aw_info
         env:
@@ -107,7 +110,6 @@ jobs:
           sparse-checkout: |
             .github
             .agents
-            actions/setup
           sparse-checkout-cone-mode: true
           fetch-depth: 1
       - name: Check workflow file timestamps
@@ -238,7 +240,7 @@ jobs:
         run: bash ${RUNNER_TEMP}/gh-aw/actions/print_prompt_summary.sh
       - name: Upload activation artifact
         if: success()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: activation
           path: |
@@ -276,11 +278,14 @@ jobs:
           repository: github/gh-aw
           sparse-checkout: |
             actions
+          path: /tmp/gh-aw/actions-source
+          fetch-depth: 1
           persist-credentials: false
       - name: Setup Scripts
-        uses: ./actions/setup
-        with:
-          destination: ${{ runner.temp }}/gh-aw/actions
+        run: |
+          bash /tmp/gh-aw/actions-source/actions/setup/setup.sh
+        env:
+          INPUT_DESTINATION: ${{ runner.temp }}/gh-aw/actions
       - name: Set runtime paths
         id: set-runtime-paths
         run: |
@@ -734,7 +739,7 @@ jobs:
       - name: Upload agent artifacts
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: agent
           path: |
@@ -750,7 +755,7 @@ jobs:
       - name: Upload firewall audit logs
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: firewall-audit-logs
           path: |
@@ -782,11 +787,14 @@ jobs:
           repository: github/gh-aw
           sparse-checkout: |
             actions
+          path: /tmp/gh-aw/actions-source
+          fetch-depth: 1
           persist-credentials: false
       - name: Setup Scripts
-        uses: ./actions/setup
-        with:
-          destination: ${{ runner.temp }}/gh-aw/actions
+        run: |
+          bash /tmp/gh-aw/actions-source/actions/setup/setup.sh
+        env:
+          INPUT_DESTINATION: ${{ runner.temp }}/gh-aw/actions
       - name: Download agent output artifact
         id: download-agent-output
         continue-on-error: true
@@ -901,11 +909,14 @@ jobs:
           repository: github/gh-aw
           sparse-checkout: |
             actions
+          path: /tmp/gh-aw/actions-source
+          fetch-depth: 1
           persist-credentials: false
       - name: Setup Scripts
-        uses: ./actions/setup
-        with:
-          destination: ${{ runner.temp }}/gh-aw/actions
+        run: |
+          bash /tmp/gh-aw/actions-source/actions/setup/setup.sh
+        env:
+          INPUT_DESTINATION: ${{ runner.temp }}/gh-aw/actions
       - name: Download agent output artifact
         id: download-agent-output
         continue-on-error: true
@@ -948,14 +959,14 @@ jobs:
       - name: Upload SARIF to GitHub Code Scanning
         id: upload_code_scanning_sarif
         if: steps.process_safe_outputs.outputs.sarif_file != ''
-        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
+        uses: github/codeql-action/upload-sarif@0e9f55954318745b37b7933c693bc093f7336125 # v4.35.1
         with:
           token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           sarif_file: ${{ steps.process_safe_outputs.outputs.sarif_file }}
           wait-for-processing: true
       - name: Upload Safe Output Items
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: safe-output-items
           path: /tmp/gh-aw/safe-output-items.jsonl

--- a/.github/workflows/gh-aw-link-checker.lock.yml
+++ b/.github/workflows/gh-aw-link-checker.lock.yml
@@ -65,11 +65,14 @@ jobs:
           repository: github/gh-aw
           sparse-checkout: |
             actions
+          path: /tmp/gh-aw/actions-source
+          fetch-depth: 1
           persist-credentials: false
       - name: Setup Scripts
-        uses: ./actions/setup
-        with:
-          destination: ${{ runner.temp }}/gh-aw/actions
+        run: |
+          bash /tmp/gh-aw/actions-source/actions/setup/setup.sh
+        env:
+          INPUT_DESTINATION: ${{ runner.temp }}/gh-aw/actions
       - name: Generate agentic run info
         id: generate_aw_info
         env:
@@ -107,7 +110,6 @@ jobs:
           sparse-checkout: |
             .github
             .agents
-            actions/setup
           sparse-checkout-cone-mode: true
           fetch-depth: 1
       - name: Check workflow file timestamps
@@ -248,7 +250,7 @@ jobs:
         run: bash ${RUNNER_TEMP}/gh-aw/actions/print_prompt_summary.sh
       - name: Upload activation artifact
         if: success()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: activation
           path: |
@@ -286,11 +288,14 @@ jobs:
           repository: github/gh-aw
           sparse-checkout: |
             actions
+          path: /tmp/gh-aw/actions-source
+          fetch-depth: 1
           persist-credentials: false
       - name: Setup Scripts
-        uses: ./actions/setup
-        with:
-          destination: ${{ runner.temp }}/gh-aw/actions
+        run: |
+          bash /tmp/gh-aw/actions-source/actions/setup/setup.sh
+        env:
+          INPUT_DESTINATION: ${{ runner.temp }}/gh-aw/actions
       - name: Set runtime paths
         id: set-runtime-paths
         run: |
@@ -767,7 +772,7 @@ jobs:
       - name: Upload agent artifacts
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: agent
           path: |
@@ -785,7 +790,7 @@ jobs:
       - name: Upload firewall audit logs
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: firewall-audit-logs
           path: |
@@ -818,11 +823,14 @@ jobs:
           repository: github/gh-aw
           sparse-checkout: |
             actions
+          path: /tmp/gh-aw/actions-source
+          fetch-depth: 1
           persist-credentials: false
       - name: Setup Scripts
-        uses: ./actions/setup
-        with:
-          destination: ${{ runner.temp }}/gh-aw/actions
+        run: |
+          bash /tmp/gh-aw/actions-source/actions/setup/setup.sh
+        env:
+          INPUT_DESTINATION: ${{ runner.temp }}/gh-aw/actions
       - name: Download agent output artifact
         id: download-agent-output
         continue-on-error: true
@@ -957,11 +965,14 @@ jobs:
           repository: github/gh-aw
           sparse-checkout: |
             actions
+          path: /tmp/gh-aw/actions-source
+          fetch-depth: 1
           persist-credentials: false
       - name: Setup Scripts
-        uses: ./actions/setup
-        with:
-          destination: ${{ runner.temp }}/gh-aw/actions
+        run: |
+          bash /tmp/gh-aw/actions-source/actions/setup/setup.sh
+        env:
+          INPUT_DESTINATION: ${{ runner.temp }}/gh-aw/actions
       - name: Download agent output artifact
         id: download-agent-output
         continue-on-error: true
@@ -1032,18 +1043,9 @@ jobs:
             await main();
       - name: Upload Safe Output Items
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: safe-output-items
           path: /tmp/gh-aw/safe-output-items.jsonl
           if-no-files-found: ignore
-      - name: Restore actions folder
-        if: always()
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: github/gh-aw
-          sparse-checkout: |
-            actions/setup
-          sparse-checkout-cone-mode: true
-          persist-credentials: false
 

--- a/.github/workflows/gh-aw-sub-issue-closer.lock.yml
+++ b/.github/workflows/gh-aw-sub-issue-closer.lock.yml
@@ -65,11 +65,14 @@ jobs:
           repository: github/gh-aw
           sparse-checkout: |
             actions
+          path: /tmp/gh-aw/actions-source
+          fetch-depth: 1
           persist-credentials: false
       - name: Setup Scripts
-        uses: ./actions/setup
-        with:
-          destination: ${{ runner.temp }}/gh-aw/actions
+        run: |
+          bash /tmp/gh-aw/actions-source/actions/setup/setup.sh
+        env:
+          INPUT_DESTINATION: ${{ runner.temp }}/gh-aw/actions
       - name: Generate agentic run info
         id: generate_aw_info
         env:
@@ -107,7 +110,6 @@ jobs:
           sparse-checkout: |
             .github
             .agents
-            actions/setup
           sparse-checkout-cone-mode: true
           fetch-depth: 1
       - name: Check workflow file timestamps
@@ -238,7 +240,7 @@ jobs:
         run: bash ${RUNNER_TEMP}/gh-aw/actions/print_prompt_summary.sh
       - name: Upload activation artifact
         if: success()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: activation
           path: |
@@ -275,11 +277,14 @@ jobs:
           repository: github/gh-aw
           sparse-checkout: |
             actions
+          path: /tmp/gh-aw/actions-source
+          fetch-depth: 1
           persist-credentials: false
       - name: Setup Scripts
-        uses: ./actions/setup
-        with:
-          destination: ${{ runner.temp }}/gh-aw/actions
+        run: |
+          bash /tmp/gh-aw/actions-source/actions/setup/setup.sh
+        env:
+          INPUT_DESTINATION: ${{ runner.temp }}/gh-aw/actions
       - name: Set runtime paths
         id: set-runtime-paths
         run: |
@@ -767,7 +772,7 @@ jobs:
       - name: Upload agent artifacts
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: agent
           path: |
@@ -783,7 +788,7 @@ jobs:
       - name: Upload firewall audit logs
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: firewall-audit-logs
           path: |
@@ -817,11 +822,14 @@ jobs:
           repository: github/gh-aw
           sparse-checkout: |
             actions
+          path: /tmp/gh-aw/actions-source
+          fetch-depth: 1
           persist-credentials: false
       - name: Setup Scripts
-        uses: ./actions/setup
-        with:
-          destination: ${{ runner.temp }}/gh-aw/actions
+        run: |
+          bash /tmp/gh-aw/actions-source/actions/setup/setup.sh
+        env:
+          INPUT_DESTINATION: ${{ runner.temp }}/gh-aw/actions
       - name: Download agent output artifact
         id: download-agent-output
         continue-on-error: true
@@ -939,11 +947,14 @@ jobs:
           repository: github/gh-aw
           sparse-checkout: |
             actions
+          path: /tmp/gh-aw/actions-source
+          fetch-depth: 1
           persist-credentials: false
       - name: Setup Scripts
-        uses: ./actions/setup
-        with:
-          destination: ${{ runner.temp }}/gh-aw/actions
+        run: |
+          bash /tmp/gh-aw/actions-source/actions/setup/setup.sh
+        env:
+          INPUT_DESTINATION: ${{ runner.temp }}/gh-aw/actions
       - name: Download agent output artifact
         id: download-agent-output
         continue-on-error: true
@@ -985,7 +996,7 @@ jobs:
             await main();
       - name: Upload Safe Output Items
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: safe-output-items
           path: /tmp/gh-aw/safe-output-items.jsonl

--- a/.github/workflows/gh-aw-sync-upstream.yml
+++ b/.github/workflows/gh-aw-sync-upstream.yml
@@ -52,7 +52,10 @@ jobs:
       - name: Recompile workflows
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh aw compile
+        # --action-mode script: fetches gh-aw's actions/ folder to /tmp and
+        # runs setup via bash. Avoids the default "dev" mode which emits
+        # `uses: ./actions/setup` references that fail in consumer repos.
+        run: gh aw compile --action-mode script
 
       - name: Open PR on drift
         uses: peter-evans/create-pull-request@v7


### PR DESCRIPTION
PR #136 dispatch of `gh-aw-sub-issue-closer` failed in the `activation` job at `Post Setup Scripts`:

> Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under `.../actions/setup`. Did you forget to run actions/checkout before running your local action?

Root cause: `gh aw compile`'s default `dev` action mode emits `uses: ./actions/setup` which expects a local action tree that does not exist in this repo.

Fix: recompile all 5 lock files with `--action-mode script` and pin the sync workflow to the same flag so automated runs don't regress.

Failed run for reference: https://github.com/JacobPEvans/ai-workflows/actions/runs/24291533206

Verified against `--action-mode` options (dev, release, script, action). `script` is the only mode that fetches gh-aw's actions into `/tmp/gh-aw/actions-source` and runs the setup via bash, without requiring local action files.