### PR TITLE
test: validate ci-doctor by triggering Tests on main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,12 @@ on:
       - '.github/scripts/**'
       - 'tests/**'
       - 'package.json'
+  push:
+    branches: [main]
+    paths:
+      - '.github/scripts/**'
+      - 'tests/**'
+      - 'package.json'
   workflow_dispatch:
 permissions:
   contents: read

--- a/tests/ci-doctor-trigger.test.js
+++ b/tests/ci-doctor-trigger.test.js
@@ -1,0 +1,8 @@
+// Deliberately failing test to trigger ci-doctor investigation.
+// This file will be removed after ci-doctor fires once.
+
+describe('ci-doctor-trigger', () => {
+  it('intentional failure to trigger CI Failure Doctor on main', () => {
+    expect(true).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `push` trigger to `test.yml` so Tests runs on main branch merges (not just PRs)
- Add a deliberately failing test to trigger the `CI Failure Doctor` gh-aw workflow for the first time

## Why

`CI Failure Doctor` triggers on `workflow_run` of "Tests" on `main` — but Tests previously only ran on `pull_request`. This means ci-doctor could **never** fire organically. The `push` trigger fixes that.

The failing test (`ci-doctor-trigger.test.js`) ensures Tests fails on merge to main, giving ci-doctor its first real trigger.

## After merging

1. Watch `CI Failure Doctor` run at: https://github.com/JacobPEvans/ai-workflows/actions/workflows/ci-doctor.lock.yml
2. It should create a GitHub issue with a CI failure investigation
3. Open a follow-up PR to delete `tests/ci-doctor-trigger.test.js`

## Test plan

- [x] `test.yml` gains `push: branches: [main]` with same path filters as `pull_request` trigger
- [ ] Tests runs on merge to main (fails due to deliberate test)
- [ ] CI Failure Doctor triggers and creates investigation issue
- [ ] Follow-up PR removes the failing test

🤖 Generated with [Claude Code](https://claude.com/claude-code)