### PR TITLE
fix: remove deliberate failing test after ci-doctor validation

### DIFF
--- a/tests/ci-doctor-trigger.test.js
+++ b/tests/ci-doctor-trigger.test.js
@@ -1,8 +1,0 @@
-// Deliberately failing test to trigger ci-doctor investigation.
-// This file will be removed after ci-doctor fires once.
-
-describe('ci-doctor-trigger', () => {
-  it('intentional failure to trigger CI Failure Doctor on main', () => {
-    expect(true).toBe(false);
-  });
-});


### PR DESCRIPTION
## Summary

- Remove `tests/ci-doctor-trigger.test.js` — served its purpose (ci-doctor created #151)
- Keep the `push` trigger on `test.yml` (permanent — enables ci-doctor)

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)