### PR TITLE
fix(workflows): move ANTHROPIC_BASE_URL to job-level env

### DIFF
--- a/.github/workflows/best-practices.yml
+++ b/.github/workflows/best-practices.yml
@@ -88,6 +88,8 @@ jobs:
       issues: write
       pull-requests: read
     timeout-minutes: 5
+    env:
+      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -107,8 +109,6 @@ jobs:
 
       - name: Run Claude
         uses: anthropics/claude-code-action@v1
-        env:
-          ANTHROPIC_BASE_URL: ${{ secrets.OPENROUTER_BASE_URL }}
         with:
           anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
           allowed_bots: "github-actions"

--- a/.github/workflows/best-practices.yml
+++ b/.github/workflows/best-practices.yml
@@ -89,7 +89,7 @@ jobs:
       pull-requests: read
     timeout-minutes: 5
     env:
-      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL }}
+      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL || secrets.OPENROUTER_BASE_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/ci-fix.yml
+++ b/.github/workflows/ci-fix.yml
@@ -184,7 +184,7 @@ jobs:
       pull-requests: write
     timeout-minutes: 15
     env:
-      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL }}
+      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL || secrets.OPENROUTER_BASE_URL }}
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@v6

--- a/.github/workflows/ci-fix.yml
+++ b/.github/workflows/ci-fix.yml
@@ -183,6 +183,8 @@ jobs:
       id-token: write
       pull-requests: write
     timeout-minutes: 15
+    env:
+      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL }}
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@v6
@@ -215,8 +217,6 @@ jobs:
 
       - name: Run Claude Code
         uses: anthropics/claude-code-action@v1
-        env:
-          ANTHROPIC_BASE_URL: ${{ secrets.OPENROUTER_BASE_URL }}
         with:
           anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
           allowed_bots: "github-actions,claude"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -82,6 +82,8 @@ jobs:
       issues: read
       id-token: write
     timeout-minutes: 10
+    env:
+      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -132,8 +134,6 @@ jobs:
             contains(inputs.allowed_bots, '*')
           )
         uses: anthropics/claude-code-action@v1
-        env:
-          ANTHROPIC_BASE_URL: ${{ secrets.OPENROUTER_BASE_URL }}
         with:
           anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
           allowed_bots: "github-actions"
@@ -155,14 +155,14 @@ jobs:
       issues: write
       id-token: write
     timeout-minutes: 10
+    env:
+      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
 
       - name: Run Claude Interactive
         uses: anthropics/claude-code-action@v1
-        env:
-          ANTHROPIC_BASE_URL: ${{ secrets.OPENROUTER_BASE_URL }}
         with:
           anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
           allowed_bots: "github-actions"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -83,7 +83,7 @@ jobs:
       id-token: write
     timeout-minutes: 10
     env:
-      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL }}
+      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL || secrets.OPENROUTER_BASE_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -156,7 +156,7 @@ jobs:
       id-token: write
     timeout-minutes: 10
     env:
-      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL }}
+      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL || secrets.OPENROUTER_BASE_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/code-simplifier.yml
+++ b/.github/workflows/code-simplifier.yml
@@ -87,6 +87,8 @@ jobs:
       id-token: write
       pull-requests: write
     timeout-minutes: 15
+    env:
+      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -112,8 +114,6 @@ jobs:
 
       - name: Execute Claude Code
         uses: anthropics/claude-code-action@v1
-        env:
-          ANTHROPIC_BASE_URL: ${{ secrets.OPENROUTER_BASE_URL }}
         with:
           anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
           allowed_bots: "github-actions"

--- a/.github/workflows/code-simplifier.yml
+++ b/.github/workflows/code-simplifier.yml
@@ -88,7 +88,7 @@ jobs:
       pull-requests: write
     timeout-minutes: 15
     env:
-      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL }}
+      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL || secrets.OPENROUTER_BASE_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/final-pr-review.yml
+++ b/.github/workflows/final-pr-review.yml
@@ -103,7 +103,7 @@ jobs:
       pull-requests: write
     timeout-minutes: 10
     env:
-      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL }}
+      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL || secrets.OPENROUTER_BASE_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/final-pr-review.yml
+++ b/.github/workflows/final-pr-review.yml
@@ -102,6 +102,8 @@ jobs:
       issues: read
       pull-requests: write
     timeout-minutes: 10
+    env:
+      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -127,8 +129,6 @@ jobs:
           contains(inputs.allowed_bots, github.event.pull_request.user.login) ||
           contains(inputs.allowed_bots, '*')
         uses: anthropics/claude-code-action@v1
-        env:
-          ANTHROPIC_BASE_URL: ${{ secrets.OPENROUTER_BASE_URL }}
         with:
           anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
           allowed_bots: "github-actions"

--- a/.github/workflows/issue-hygiene.yml
+++ b/.github/workflows/issue-hygiene.yml
@@ -32,6 +32,8 @@ jobs:
       issues: write
       pull-requests: read
     timeout-minutes: 5
+    env:
+      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -51,8 +53,6 @@ jobs:
 
       - name: Execute Claude Code
         uses: anthropics/claude-code-action@v1
-        env:
-          ANTHROPIC_BASE_URL: ${{ secrets.OPENROUTER_BASE_URL }}
         with:
           anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
           allowed_bots: "github-actions"

--- a/.github/workflows/issue-hygiene.yml
+++ b/.github/workflows/issue-hygiene.yml
@@ -33,7 +33,7 @@ jobs:
       pull-requests: read
     timeout-minutes: 5
     env:
-      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL }}
+      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL || secrets.OPENROUTER_BASE_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/issue-linker.yml
+++ b/.github/workflows/issue-linker.yml
@@ -75,6 +75,8 @@ jobs:
       issues: write
       pull-requests: write
     timeout-minutes: 10
+    env:
+      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -101,8 +103,6 @@ jobs:
           contains(inputs.allowed_bots, github.event.pull_request.user.login) ||
           contains(inputs.allowed_bots, '*')
         uses: anthropics/claude-code-action@v1
-        env:
-          ANTHROPIC_BASE_URL: ${{ secrets.OPENROUTER_BASE_URL }}
         with:
           anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
           allowed_bots: "github-actions"

--- a/.github/workflows/issue-linker.yml
+++ b/.github/workflows/issue-linker.yml
@@ -76,7 +76,7 @@ jobs:
       pull-requests: write
     timeout-minutes: 10
     env:
-      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL }}
+      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL || secrets.OPENROUTER_BASE_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/issue-resolver.yml
+++ b/.github/workflows/issue-resolver.yml
@@ -103,7 +103,7 @@ jobs:
       pull-requests: write
     timeout-minutes: 15
     env:
-      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL }}
+      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL || secrets.OPENROUTER_BASE_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/issue-resolver.yml
+++ b/.github/workflows/issue-resolver.yml
@@ -102,6 +102,8 @@ jobs:
       issues: write
       pull-requests: write
     timeout-minutes: 15
+    env:
+      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -136,8 +138,6 @@ jobs:
 
       - name: Run Claude Code
         uses: anthropics/claude-code-action@v1
-        env:
-          ANTHROPIC_BASE_URL: ${{ secrets.OPENROUTER_BASE_URL }}
         with:
           anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
           allowed_bots: "github-actions"

--- a/.github/workflows/issue-sweeper.yml
+++ b/.github/workflows/issue-sweeper.yml
@@ -31,6 +31,8 @@ jobs:
       issues: write
       pull-requests: read
     timeout-minutes: 5
+    env:
+      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -50,8 +52,6 @@ jobs:
 
       - name: Execute Claude Code
         uses: anthropics/claude-code-action@v1
-        env:
-          ANTHROPIC_BASE_URL: ${{ secrets.OPENROUTER_BASE_URL }}
         with:
           anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
           allowed_bots: "github-actions"

--- a/.github/workflows/issue-sweeper.yml
+++ b/.github/workflows/issue-sweeper.yml
@@ -32,7 +32,7 @@ jobs:
       pull-requests: read
     timeout-minutes: 5
     env:
-      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL }}
+      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL || secrets.OPENROUTER_BASE_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -29,7 +29,7 @@ jobs:
       issues: write
     timeout-minutes: 5
     env:
-      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL }}
+      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL || secrets.OPENROUTER_BASE_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -28,6 +28,8 @@ jobs:
       id-token: write
       issues: write
     timeout-minutes: 5
+    env:
+      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -49,8 +51,6 @@ jobs:
 
       - name: Run Claude
         uses: anthropics/claude-code-action@v1
-        env:
-          ANTHROPIC_BASE_URL: ${{ secrets.OPENROUTER_BASE_URL }}
         with:
           anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
           allowed_bots: "github-actions"

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -24,7 +24,7 @@ jobs:
       issues: write
     timeout-minutes: 5
     env:
-      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL }}
+      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL || secrets.OPENROUTER_BASE_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -23,6 +23,8 @@ jobs:
       id-token: write
       issues: write
     timeout-minutes: 5
+    env:
+      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -42,8 +44,6 @@ jobs:
 
       - name: Run Claude
         uses: anthropics/claude-code-action@v1
-        env:
-          ANTHROPIC_BASE_URL: ${{ secrets.OPENROUTER_BASE_URL }}
         with:
           anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
           allowed_bots: "github-actions"

--- a/.github/workflows/next-steps.yml
+++ b/.github/workflows/next-steps.yml
@@ -90,7 +90,7 @@ jobs:
       pull-requests: write
     timeout-minutes: 15
     env:
-      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL }}
+      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL || secrets.OPENROUTER_BASE_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/next-steps.yml
+++ b/.github/workflows/next-steps.yml
@@ -89,6 +89,8 @@ jobs:
       issues: write
       pull-requests: write
     timeout-minutes: 15
+    env:
+      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -114,8 +116,6 @@ jobs:
 
       - name: Execute Claude Code
         uses: anthropics/claude-code-action@v1
-        env:
-          ANTHROPIC_BASE_URL: ${{ secrets.OPENROUTER_BASE_URL }}
         with:
           anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
           allowed_bots: "github-actions"

--- a/.github/workflows/post-merge-docs-review.yml
+++ b/.github/workflows/post-merge-docs-review.yml
@@ -118,7 +118,7 @@ jobs:
       pull-requests: write
     timeout-minutes: 15
     env:
-      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL }}
+      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL || secrets.OPENROUTER_BASE_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/post-merge-docs-review.yml
+++ b/.github/workflows/post-merge-docs-review.yml
@@ -117,6 +117,8 @@ jobs:
       id-token: write
       pull-requests: write
     timeout-minutes: 15
+    env:
+      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -144,8 +146,6 @@ jobs:
 
       - name: Run Claude
         uses: anthropics/claude-code-action@v1
-        env:
-          ANTHROPIC_BASE_URL: ${{ secrets.OPENROUTER_BASE_URL }}
         with:
           anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
           allowed_bots: "github-actions"

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -118,7 +118,7 @@ jobs:
       pull-requests: write
     timeout-minutes: 15
     env:
-      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL }}
+      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL || secrets.OPENROUTER_BASE_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -117,6 +117,8 @@ jobs:
       id-token: write
       pull-requests: write
     timeout-minutes: 15
+    env:
+      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -144,8 +146,6 @@ jobs:
 
       - name: Run Claude
         uses: anthropics/claude-code-action@v1
-        env:
-          ANTHROPIC_BASE_URL: ${{ secrets.OPENROUTER_BASE_URL }}
         with:
           anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
           allowed_bots: "github-actions"

--- a/.github/workflows/project-router.yml
+++ b/.github/workflows/project-router.yml
@@ -26,7 +26,7 @@ jobs:
       pull-requests: read
     timeout-minutes: 5
     env:
-      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL }}
+      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL || secrets.OPENROUTER_BASE_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/project-router.yml
+++ b/.github/workflows/project-router.yml
@@ -25,6 +25,8 @@ jobs:
       issues: write
       pull-requests: read
     timeout-minutes: 5
+    env:
+      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -44,8 +46,6 @@ jobs:
 
       - name: Run Claude
         uses: anthropics/claude-code-action@v1
-        env:
-          ANTHROPIC_BASE_URL: ${{ secrets.OPENROUTER_BASE_URL }}
         with:
           anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
           allowed_bots: "github-actions"

--- a/.github/workflows/repo-orchestrator.yml
+++ b/.github/workflows/repo-orchestrator.yml
@@ -24,7 +24,7 @@ jobs:
       id-token: write
     timeout-minutes: 5
     env:
-      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL }}
+      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL || secrets.OPENROUTER_BASE_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/repo-orchestrator.yml
+++ b/.github/workflows/repo-orchestrator.yml
@@ -23,6 +23,8 @@ jobs:
       contents: read
       id-token: write
     timeout-minutes: 5
+    env:
+      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -42,8 +44,6 @@ jobs:
 
       - name: Run Claude
         uses: anthropics/claude-code-action@v1
-        env:
-          ANTHROPIC_BASE_URL: ${{ secrets.OPENROUTER_BASE_URL }}
         with:
           anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
           allowed_bots: "github-actions"

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -45,7 +45,7 @@ jobs:
     if: inputs.provider == 'openrouter'
     runs-on: ubuntu-latest
     env:
-      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL }}
+      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL || secrets.OPENROUTER_BASE_URL }}
     timeout-minutes: 5
     steps:
       - name: Run Claude

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -40,24 +40,16 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  smoke-test:
-    name: "${{ inputs.provider }} / ${{ inputs.model || 'default' }}"
+  smoke-openrouter:
+    name: "openrouter / ${{ inputs.model || 'default' }}"
+    if: inputs.provider == 'openrouter'
     runs-on: ubuntu-latest
+    env:
+      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL }}
+    timeout-minutes: 5
     steps:
-      - name: Log test parameters
-        env:
-          PROVIDER: ${{ inputs.provider }}
-          MODEL: ${{ inputs.model || vars.AI_MODEL || 'openrouter/free' }}
-        run: |
-          echo "Provider: $PROVIDER"
-          echo "Model: $MODEL"
-
-      - name: Run Claude (OpenRouter)
-        if: inputs.provider == 'openrouter'
-        id: claude-openrouter
+      - name: Run Claude
         uses: anthropics/claude-code-action@v1
-        env:
-          ANTHROPIC_BASE_URL: ${{ secrets.OPENROUTER_BASE_URL }}
         with:
           anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
           allowed_bots: "github-actions"
@@ -66,9 +58,28 @@ jobs:
             --model ${{ inputs.model || vars.AI_MODEL || 'openrouter/free' }}
             --allowedTools "Bash(echo:*)"
 
-      - name: Run Claude (Anthropic)
-        if: inputs.provider == 'anthropic'
-        id: claude-anthropic
+      - name: Verify response
+        env:
+          DEFAULT_PROMPT: "Respond with exactly this text and nothing else: SMOKE_TEST_PASS"
+          ACTUAL_PROMPT: ${{ inputs.prompt }}
+        run: |
+          echo "=== Smoke Test Results ==="
+          echo "Provider: openrouter"
+          echo "Model: ${{ inputs.model || vars.AI_MODEL || 'openrouter/free' }}"
+          echo "Status: Claude action completed successfully"
+          if [[ "$ACTUAL_PROMPT" == "$DEFAULT_PROMPT" ]]; then
+            echo "=== SMOKE_TEST_PASS ==="
+          else
+            echo "=== Custom prompt used — manual output verification required ==="
+          fi
+
+  smoke-anthropic:
+    name: "anthropic / ${{ inputs.model || 'default' }}"
+    if: inputs.provider == 'anthropic'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Run Claude
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -78,12 +89,31 @@ jobs:
             --model ${{ inputs.model || 'claude-haiku-4' }}
             --allowedTools "Bash(echo:*)"
 
-      - name: Run Claude (Chutes)
-        if: inputs.provider == 'chutes'
-        id: claude-chutes
-        uses: anthropics/claude-code-action@v1
+      - name: Verify response
         env:
-          ANTHROPIC_BASE_URL: ${{ vars.CHUTES_BASE_URL }}
+          DEFAULT_PROMPT: "Respond with exactly this text and nothing else: SMOKE_TEST_PASS"
+          ACTUAL_PROMPT: ${{ inputs.prompt }}
+        run: |
+          echo "=== Smoke Test Results ==="
+          echo "Provider: anthropic"
+          echo "Model: ${{ inputs.model || 'claude-haiku-4' }}"
+          echo "Status: Claude action completed successfully"
+          if [[ "$ACTUAL_PROMPT" == "$DEFAULT_PROMPT" ]]; then
+            echo "=== SMOKE_TEST_PASS ==="
+          else
+            echo "=== Custom prompt used — manual output verification required ==="
+          fi
+
+  smoke-chutes:
+    name: "chutes / ${{ inputs.model || 'default' }}"
+    if: inputs.provider == 'chutes'
+    runs-on: ubuntu-latest
+    env:
+      ANTHROPIC_BASE_URL: ${{ vars.CHUTES_BASE_URL }}
+    timeout-minutes: 5
+    steps:
+      - name: Run Claude
+        uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.CHUTES_API_KEY }}
           allowed_bots: "github-actions"
@@ -94,14 +124,12 @@ jobs:
 
       - name: Verify response
         env:
-          PROVIDER: ${{ inputs.provider }}
-          MODEL: ${{ inputs.model || 'default fallback' }}
           DEFAULT_PROMPT: "Respond with exactly this text and nothing else: SMOKE_TEST_PASS"
           ACTUAL_PROMPT: ${{ inputs.prompt }}
         run: |
           echo "=== Smoke Test Results ==="
-          echo "Provider: $PROVIDER"
-          echo "Model: $MODEL"
+          echo "Provider: chutes"
+          echo "Model: ${{ inputs.model || vars.AI_MODEL || 'openrouter/free' }}"
           echo "Status: Claude action completed successfully"
           if [[ "$ACTUAL_PROMPT" == "$DEFAULT_PROMPT" ]]; then
             echo "=== SMOKE_TEST_PASS ==="


### PR DESCRIPTION
# Fix

## Summary

`claude-code-action@v1` composite action explicitly evaluates
`ANTHROPIC_BASE_URL: ${{ env.ANTHROPIC_BASE_URL }}` in its own `env:` block.
Per GitHub's behavior, this only sees workflow/job-level env vars, not
step-level ones.

All 17 affected workflows were setting `ANTHROPIC_BASE_URL` at step-level,
causing the composite to overwrite it with an empty string. Claude Code then
defaulted to Anthropic's API, rejecting non-Anthropic model names like
`minimax/minimax-m2.7` (OpenRouter-only).

Exposed today when secrets-sync pushed `AI_MODEL_ISSUES=minimax/minimax-m2.7`.

## Changes

- Moved `ANTHROPIC_BASE_URL` from step-level to **job-level `env:`** in all
  17 affected workflows
- Switched `secrets.OPENROUTER_BASE_URL` → `vars.OPENROUTER_BASE_URL`
  (non-sensitive URL, readable without vault access) with secrets fallback
  for migration
- Refactored `smoke-test.yml` into three per-provider jobs
  (`smoke-openrouter`, `smoke-anthropic`, `smoke-chutes`) since each provider
  needs a distinct `ANTHROPIC_BASE_URL` at job level

## Test Plan

- [x] All 147 unit tests pass (`bun test`)
- [ ] `OPENROUTER_BASE_URL` variable must be synced to consumer repos via
  secrets-sync before merging
- [ ] After merge, re-trigger `Issue Auto-Resolve` on
  `ai-assistant-instructions` to verify `minimax/minimax-m2.7` routes
  through OpenRouter
- [ ] Optional: run `gh workflow run smoke-test.yml -f provider=openrouter`
  to validate routing end-to-end

Related: #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)
