### PR TITLE
fix(workflows): remove unknown input and handle schedule events

### DIFF
--- a/.github/workflows/dogfood-all.yml
+++ b/.github/workflows/dogfood-all.yml
@@ -63,6 +63,8 @@ jobs:
       pull-requests: write
     uses: JacobPEvans/ai-workflows/.github/workflows/suite-all.yml@v0.12.6
     with:
-      caller_event: ${{ github.event_name }}
+      # Map schedule → workflow_dispatch so cron triggers exercise post-merge-suite
+      # (suite-all only routes 'workflow_dispatch' or PR events; 'schedule' would no-op).
+      caller_event: ${{ github.event_name == 'schedule' && 'workflow_dispatch' || github.event_name }}
       commit_sha: ${{ inputs.commit_sha || github.sha }}
     secrets: inherit

--- a/.github/workflows/dogfood-all.yml
+++ b/.github/workflows/dogfood-all.yml
@@ -64,6 +64,5 @@ jobs:
     uses: JacobPEvans/ai-workflows/.github/workflows/suite-all.yml@v0.12.6
     with:
       caller_event: ${{ github.event_name }}
-      review_prompt: "Focus on GitHub Actions workflow patterns, reusable workflow design, prompt engineering, and JavaScript script quality"
       commit_sha: ${{ inputs.commit_sha || github.sha }}
     secrets: inherit


### PR DESCRIPTION
## Summary

- `dogfood-all.yml` passed unknown input `review_prompt:` to `suite-all.yml`, causing `startup_failure` on every dispatch
- Removed the invalid input (it has no consumer in the suite chain)
- Added schedule → workflow_dispatch mapping so cron-triggered runs exercise post-merge-suite

## Changes

- Removed `review_prompt:` input (not accepted by `suite-all.yml@v0.12.6`)
- Added condition to map `schedule` events to `workflow_dispatch` so Monday cron runs don't no-op
- Both issues now fixed in a single commit

## Test Plan

- [x] Confirmed `suite-all.yml` v0.12.6 accepts only `caller_event`, `commit_sha`, `allowed_bots`
- [x] Confirmed `review_prompt` has no consumer in suite chain
- [ ] CI green on this PR (YAML-only change)
- [ ] After merge, manually dispatch AI Workflows once and verify no startup_failure

Related: #175