### PR TITLE
fix(workflows): replace dogfood-all nested calls with gh API

### DIFF
--- a/.github/workflows/dogfood-all.yml
+++ b/.github/workflows/dogfood-all.yml
@@ -10,61 +10,23 @@ on:
   schedule:
     # Weekly regression coverage for published reusable workflows (Mondays 12:00 UTC)
     - cron: "0 12 * * 1"
-  # --- DISABLED AUTOMATIC TRIGGERS (restore by uncommenting) ---
-  # pull_request:
-  #   types: [opened, synchronize]
-  # issue_comment:
-  #   types: [created]
-  # pull_request_review:
-  #   types: [submitted]
-  # push:
-  #   branches: [main]
-  # --- END DISABLED ---
 
 permissions:
   actions: write
-  checks: read
-  contents: write
-  id-token: write
-  issues: write
-  pull-requests: write
+  contents: read
 
 jobs:
-  # --- DISABLED AUTOMATIC TRIGGERS (restore by uncommenting) ---
-  # # Push to main -> re-dispatch as workflow_dispatch so post-merge suites
-  # # can use the commit SHA via inputs.commit_sha (workflow_run context workaround).
-  # post-merge-dispatch:
-  #   if: github.event_name == 'push'
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     actions: write
-  #   steps:
-  #     - name: Re-trigger as workflow_dispatch
-  #       env:
-  #         WORKFLOW_NAME: ${{ github.workflow }}
-  #         GH_TOKEN: ${{ github.token }}
-  #       run: |
-  #         gh workflow run "$WORKFLOW_NAME" \
-  #           --repo "${{ github.repository }}" \
-  #           --ref main \
-  #           -f commit_sha="${{ github.sha }}"
-  # --- END DISABLED ---
-
-  all:
-    # --- DISABLED AUTOMATIC TRIGGERS (restore by uncommenting) ---
-    # if: github.event_name != 'push'
-    # --- END DISABLED ---
+  trigger-post-merge-reviews:
+    runs-on: ubuntu-latest
     permissions:
-      actions: read
-      checks: read
-      contents: write
-      id-token: write
-      issues: write
-      pull-requests: write
-    uses: JacobPEvans/ai-workflows/.github/workflows/suite-all.yml@v0.12.7
-    with:
-      # Map schedule → workflow_dispatch so cron triggers exercise post-merge-suite
-      # (suite-all only routes 'workflow_dispatch' or PR events; 'schedule' would no-op).
-      caller_event: ${{ github.event_name == 'schedule' && 'workflow_dispatch' || github.event_name }}
-      commit_sha: ${{ inputs.commit_sha || github.sha }}
-    secrets: inherit
+      actions: write
+      contents: read
+    steps:
+      - name: Trigger post-merge docs review
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run post-merge-docs-review.yml --repo "$GITHUB_REPOSITORY" --ref main
+      - name: Trigger post-merge tests review
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run post-merge-tests.yml --repo "$GITHUB_REPOSITORY" --ref main

--- a/.github/workflows/dogfood-all.yml
+++ b/.github/workflows/dogfood-all.yml
@@ -2,11 +2,6 @@ name: AI Workflows
 
 on:
   workflow_dispatch:
-    inputs:
-      commit_sha:
-        description: "Commit SHA to review (leave blank for latest main)"
-        required: false
-        type: string
   schedule:
     # Weekly regression coverage for published reusable workflows (Mondays 12:00 UTC)
     - cron: "0 12 * * 1"
@@ -27,6 +22,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: gh workflow run post-merge-docs-review.yml --repo "$GITHUB_REPOSITORY" --ref main
       - name: Trigger post-merge tests review
+        if: always()
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh workflow run post-merge-tests.yml --repo "$GITHUB_REPOSITORY" --ref main


### PR DESCRIPTION
## Summary

- Replaced broken same-repo `workflow_call` nesting with `gh workflow run` API calls
- Removed unused `commit_sha` dispatch input from dogfood-all
- Ensured test dispatch runs even if docs dispatch fails via `if: always()`

## Root Cause

GitHub blocks same-repo `workflow_call` nesting. The `dogfood-all.yml` workflow couldn't invoke `suite-all.yml@v0.12.6` directly, causing startup failures.

## Changes

- Replaced `uses: suite-all.yml@v0.12.6` with sequential `gh workflow run` calls for docs review and test workflows
- Removed unused `commit_sha` dispatch input (target workflows don't accept it)
- Added `if: always()` to test dispatch step to ensure runs even if docs dispatch fails
- Cleaned up dead code (commented-out disabled triggers, unused permissions)

## Verification

- Run [24920282784](https://github.com/JacobPEvans/ai-workflows/actions/runs/24920282784) on `fix/flatten-dogfood` completed successfully
- Workflows triggered in correct sequence (post-merge docs review, then post-merge tests)