### PR TITLE
feat(notify): Slack notifications for CI failures

### DIFF
--- a/.github/scripts/notification/send-slack-ci-fail-notify.js
+++ b/.github/scripts/notification/send-slack-ci-fail-notify.js
@@ -8,6 +8,7 @@ module.exports = async ({ github, context, core }) => {
   const headSha = process.env.HEAD_SHA;
   const headBranch = process.env.HEAD_BRANCH;
   const repoName = process.env.REPO_NAME;
+  const conclusion = process.env.CONCLUSION;
   const eventName = process.env.EVENT_NAME;
 
   const sha7 = headSha ? headSha.slice(0, 7) : 'unknown';
@@ -33,17 +34,24 @@ module.exports = async ({ github, context, core }) => {
       fields: [
         { type: 'mrkdwn', text: `*Branch:*\n${headBranch}` },
         { type: 'mrkdwn', text: `*Commit:*\n\`${sha7}\`` },
-        { type: 'mrkdwn', text: `*Triggered by:*\n${eventName}` },
+        { type: 'mrkdwn', text: `*Event:*\n${eventName}` },
+        { type: 'mrkdwn', text: `*Conclusion:*\n${conclusion}` },
         { type: 'mrkdwn', text: `*Run:*\n<${runUrl}|${runId}>` },
       ],
     },
   ];
 
-  const response = await fetch(webhookUrl, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ blocks }),
-  });
+  let response;
+  try {
+    response = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ blocks }),
+    });
+  } catch (error) {
+    core.setFailed(`Slack webhook request failed: ${error.message}`);
+    return;
+  }
 
   if (!response.ok) {
     core.setFailed(`Slack webhook failed: ${response.status} ${response.statusText}`);

--- a/.github/scripts/notification/send-slack-ci-fail-notify.js
+++ b/.github/scripts/notification/send-slack-ci-fail-notify.js
@@ -1,0 +1,54 @@
+// .github/scripts/notification/send-slack-ci-fail-notify.js
+// Posts a Slack Block Kit notification to #github-ci-failures when a workflow run fails.
+module.exports = async ({ github, context, core }) => {
+  const webhookUrl = process.env.SLACK_WEBHOOK_URL;
+  const workflowName = process.env.WORKFLOW_NAME;
+  const runUrl = process.env.RUN_URL;
+  const runId = process.env.RUN_ID;
+  const headSha = process.env.HEAD_SHA;
+  const headBranch = process.env.HEAD_BRANCH;
+  const repoName = process.env.REPO_NAME;
+  const eventName = process.env.EVENT_NAME;
+
+  const sha7 = headSha ? headSha.slice(0, 7) : 'unknown';
+
+  const blocks = [
+    {
+      type: 'header',
+      text: {
+        type: 'plain_text',
+        text: ':rotating_light: CI Failure',
+        emoji: true,
+      },
+    },
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: `*<${runUrl}|${repoName} — ${workflowName}>*`,
+      },
+    },
+    {
+      type: 'section',
+      fields: [
+        { type: 'mrkdwn', text: `*Branch:*\n${headBranch}` },
+        { type: 'mrkdwn', text: `*Commit:*\n\`${sha7}\`` },
+        { type: 'mrkdwn', text: `*Triggered by:*\n${eventName}` },
+        { type: 'mrkdwn', text: `*Run:*\n<${runUrl}|${runId}>` },
+      ],
+    },
+  ];
+
+  const response = await fetch(webhookUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ blocks }),
+  });
+
+  if (!response.ok) {
+    core.setFailed(`Slack webhook failed: ${response.status} ${response.statusText}`);
+    return;
+  }
+
+  core.info(`Slack CI failure notification sent: ${repoName} — ${workflowName} run ${runId}`);
+};

--- a/.github/scripts/notification/send-slack-ci-fail-notify.js
+++ b/.github/scripts/notification/send-slack-ci-fail-notify.js
@@ -41,20 +41,18 @@ module.exports = async ({ github, context, core }) => {
     },
   ];
 
-  let response;
   try {
-    response = await fetch(webhookUrl, {
+    const response = await fetch(webhookUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ blocks }),
     });
+    if (!response.ok) {
+      core.setFailed(`Slack webhook failed: ${response.status} ${response.statusText}`);
+      return;
+    }
   } catch (error) {
     core.setFailed(`Slack webhook request failed: ${error.message}`);
-    return;
-  }
-
-  if (!response.ok) {
-    core.setFailed(`Slack webhook failed: ${response.status} ${response.statusText}`);
     return;
   }
 

--- a/.github/workflows/notify-ci-fail.yml
+++ b/.github/workflows/notify-ci-fail.yml
@@ -13,6 +13,7 @@ name: CI Fail Slack Notification
 
 on:
   workflow_call:
+  workflow_dispatch:
     inputs:
       workflow_name:
         type: string

--- a/.github/workflows/notify-ci-fail.yml
+++ b/.github/workflows/notify-ci-fail.yml
@@ -1,0 +1,74 @@
+# CI Fail Slack Notification
+#
+# Reusable workflow: posts to #github-ci-failures when a workflow run fails.
+# Called by consumer repos via a workflow_run trigger.
+#
+# All workflow_run context fields must be passed as inputs because the reusable
+# sees workflow_call event, not the caller's workflow_run event.
+#
+# Required secret (pass via secrets: inherit):
+#   GH_SLACK_WEBHOOK_URL_GITHUB_CI_FAILURES
+
+name: CI Fail Slack Notification
+
+on:
+  workflow_call:
+    inputs:
+      workflow_name:
+        type: string
+        required: true
+      run_url:
+        type: string
+        required: true
+      run_id:
+        type: string
+        required: true
+      head_sha:
+        type: string
+        required: true
+      head_branch:
+        type: string
+        required: true
+      repository:
+        type: string
+        required: true
+      conclusion:
+        type: string
+        required: true
+      event_name:
+        type: string
+        required: true
+    secrets:
+      GH_SLACK_WEBHOOK_URL_GITHUB_CI_FAILURES:
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout ai-workflows scripts
+        uses: actions/checkout@v6
+        with:
+          repository: JacobPEvans/ai-workflows
+          sparse-checkout: .github/scripts
+          path: .ai-workflows
+
+      - name: Send Slack notification
+        uses: actions/github-script@v9
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.GH_SLACK_WEBHOOK_URL_GITHUB_CI_FAILURES }}
+          WORKFLOW_NAME: ${{ inputs.workflow_name }}
+          RUN_URL:       ${{ inputs.run_url }}
+          RUN_ID:        ${{ inputs.run_id }}
+          HEAD_SHA:      ${{ inputs.head_sha }}
+          HEAD_BRANCH:   ${{ inputs.head_branch }}
+          REPO_NAME:     ${{ inputs.repository }}
+          CONCLUSION:    ${{ inputs.conclusion }}
+          EVENT_NAME:    ${{ inputs.event_name }}
+        with:
+          script: |
+            const run = require('./.ai-workflows/.github/scripts/notification/send-slack-ci-fail-notify.js');
+            await run({ github, context, core });

--- a/.github/workflows/notify-ci-fail.yml
+++ b/.github/workflows/notify-ci-fail.yml
@@ -13,7 +13,6 @@ name: CI Fail Slack Notification
 
 on:
   workflow_call:
-  workflow_dispatch:
     inputs:
       workflow_name:
         type: string
@@ -42,6 +41,7 @@ on:
     secrets:
       GH_SLACK_WEBHOOK_URL_GITHUB_CI_FAILURES:
         required: true
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,9 @@ This repo is the single source of truth for CI/CD automation workflows. Each wor
 
 **AI Provenance**: All PR-creating workflows (`code-simplifier`, `next-steps`, `post-merge-docs-review`, `post-merge-tests`, `issue-resolver`) include a standardized provenance footer in every PR body. `ci-fix` appends provenance to the commit message. See `docs/PATTERNS.md` for the AI Provenance Pattern.
 
-**Slack notifications**: `notify-ai-pr.yml` is a reusable workflow that consumer repos call on `pull_request: opened`. It filters for `claude[bot]`-authored PRs and posts to `#github-automation` via Slack Incoming Webhook. Requires `GH_SLACK_WEBHOOK_URL_GITHUB_AUTOMATION` secret (synced via secrets-sync).
+**Slack notifications**: Two reusable notification workflows:
+- `notify-ai-pr.yml` — posts to `#github-automation` when `claude[bot]` opens a PR. Requires `GH_SLACK_WEBHOOK_URL_GITHUB_AUTOMATION`.
+- `notify-ci-fail.yml` — posts to `#github-ci-failures` when a watched workflow run fails. Consumer repos call it via `workflow_run` trigger, passing all run context as typed inputs. Requires `GH_SLACK_WEBHOOK_URL_GITHUB_CI_FAILURES`.
 
 ### Consumer Repo Caller Pattern
 

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -496,3 +496,53 @@ jobs:
 - Provenance fields: Workflow, Event, Actor, Run link (extracted from PR body footer)
 
 **Implementation**: Extracted script at `.github/scripts/notification/send-slack-pr-notify.js`. Parses the AI Provenance footer from the PR body using regex to populate the Slack message fields.
+
+---
+
+## CI Failure Slack Notification Pattern
+
+Consumer repos receive real-time Slack alerts in `#github-ci-failures` when any watched workflow fails.
+
+**Workflow**: `notify-ci-fail.yml` (reusable)
+**Trigger**: `workflow_run` on failure of specified workflows
+
+**Consumer caller** (added to each repo as `notify-ci-fail.yml`):
+```yaml
+name: CI Fail Notify
+on:
+  workflow_run:
+    workflows:
+      - "CI Gate"
+      - "Update flake dependencies"   # add any other watched workflows here
+    types: [completed]
+    branches: [main]
+concurrency:
+  group: ci-fail-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+permissions:
+  actions: read
+  contents: read
+jobs:
+  slack:
+    if: github.event.workflow_run.conclusion == 'failure'
+    uses: JacobPEvans/ai-workflows/.github/workflows/notify-ci-fail.yml@main
+    with:
+      workflow_name: ${{ github.event.workflow_run.name }}
+      run_url:       ${{ github.event.workflow_run.html_url }}
+      run_id:        ${{ github.event.workflow_run.id }}
+      head_sha:      ${{ github.event.workflow_run.head_sha }}
+      head_branch:   ${{ github.event.workflow_run.head_branch }}
+      repository:    ${{ github.event.workflow_run.repository.full_name }}
+      conclusion:    ${{ github.event.workflow_run.conclusion }}
+      event_name:    ${{ github.event.workflow_run.event }}
+    secrets: inherit
+```
+
+**Required secret** (pass via `secrets: inherit`): `GH_SLACK_WEBHOOK_URL_GITHUB_CI_FAILURES`
+
+**Message content** (Slack Block Kit):
+- Header: ":rotating_light: CI Failure"
+- Repo + workflow name (linked to run)
+- Fields: Branch, Commit (sha7), Triggered by, Run link
+
+**Implementation**: `.github/scripts/notification/send-slack-ci-fail-notify.js`. All `workflow_run` context values are forwarded as typed `workflow_call` inputs; the reusable exposes them only as Node.js `process.env.*` — no shell interpolation of user-controlled data.

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -525,7 +525,7 @@ permissions:
 jobs:
   slack:
     if: github.event.workflow_run.conclusion == 'failure'
-    uses: JacobPEvans/ai-workflows/.github/workflows/notify-ci-fail.yml@main
+    uses: JacobPEvans/ai-workflows/.github/workflows/notify-ci-fail.yml@<version>
     with:
       workflow_name: ${{ github.event.workflow_run.name }}
       run_url:       ${{ github.event.workflow_run.html_url }}

--- a/tests/notification-send-slack-ci-fail-notify.test.js
+++ b/tests/notification-send-slack-ci-fail-notify.test.js
@@ -1,0 +1,104 @@
+const { mock, beforeEach, describe, it, expect } = require('bun:test');
+const { createMockCore, createMockContext, createMockGithub } = require('./helpers.js');
+
+let mockFetch;
+
+describe('send-slack-ci-fail-notify', () => {
+  let core, context, github;
+
+  beforeEach(() => {
+    core = createMockCore();
+    context = createMockContext();
+    github = createMockGithub();
+
+    delete process.env.SLACK_WEBHOOK_URL;
+    delete process.env.WORKFLOW_NAME;
+    delete process.env.RUN_URL;
+    delete process.env.RUN_ID;
+    delete process.env.HEAD_SHA;
+    delete process.env.HEAD_BRANCH;
+    delete process.env.REPO_NAME;
+    delete process.env.CONCLUSION;
+    delete process.env.EVENT_NAME;
+
+    mockFetch = mock(() => Promise.resolve({ ok: true, status: 200, statusText: 'OK' }));
+    global.fetch = mockFetch;
+  });
+
+  it('sends CI failure notification with all fields', async () => {
+    process.env.SLACK_WEBHOOK_URL = 'https://hooks.slack.com/test';
+    process.env.WORKFLOW_NAME = 'CI / test';
+    process.env.RUN_URL = 'https://github.com/owner/repo/actions/runs/99';
+    process.env.RUN_ID = '99';
+    process.env.HEAD_SHA = 'abc1234def5678';
+    process.env.HEAD_BRANCH = 'main';
+    process.env.REPO_NAME = 'owner/repo';
+    process.env.CONCLUSION = 'failure';
+    process.env.EVENT_NAME = 'push';
+
+    const run = require('../.github/scripts/notification/send-slack-ci-fail-notify.js');
+    await run({ github, context, core });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toBe('https://hooks.slack.com/test');
+    expect(options.method).toBe('POST');
+
+    const body = JSON.parse(options.body);
+    expect(body.blocks).toBeDefined();
+    expect(body.blocks[0].type).toBe('header');
+    expect(body.blocks[0].text.text).toContain('CI Failure');
+
+    const fields = body.blocks[2].fields;
+    const fieldTexts = fields.map((f) => f.text);
+    expect(fieldTexts.some((t) => t.includes('main'))).toBe(true);
+    expect(fieldTexts.some((t) => t.includes('abc1234'))).toBe(true);
+    expect(fieldTexts.some((t) => t.includes('push'))).toBe(true);
+    expect(fieldTexts.some((t) => t.includes('failure'))).toBe(true);
+
+    expect(core.failures).toHaveLength(0);
+    expect(core.infos.some((m) => m.includes('owner/repo'))).toBe(true);
+  });
+
+  it('calls setFailed when Slack webhook returns non-ok status', async () => {
+    process.env.SLACK_WEBHOOK_URL = 'https://hooks.slack.com/test';
+    process.env.WORKFLOW_NAME = 'CI';
+    process.env.RUN_URL = 'https://github.com/owner/repo/actions/runs/1';
+    process.env.RUN_ID = '1';
+    process.env.HEAD_SHA = 'aaa';
+    process.env.HEAD_BRANCH = 'main';
+    process.env.REPO_NAME = 'owner/repo';
+    process.env.CONCLUSION = 'failure';
+    process.env.EVENT_NAME = 'push';
+
+    mockFetch = mock(() => Promise.resolve({ ok: false, status: 500, statusText: 'Internal Server Error' }));
+    global.fetch = mockFetch;
+
+    const run = require('../.github/scripts/notification/send-slack-ci-fail-notify.js');
+    await run({ github, context, core });
+
+    expect(core.failures).toHaveLength(1);
+    expect(core.failures[0]).toContain('500');
+  });
+
+  it('calls setFailed on network error', async () => {
+    process.env.SLACK_WEBHOOK_URL = 'https://hooks.slack.com/test';
+    process.env.WORKFLOW_NAME = 'CI';
+    process.env.RUN_URL = 'https://github.com/owner/repo/actions/runs/1';
+    process.env.RUN_ID = '1';
+    process.env.HEAD_SHA = 'aaa';
+    process.env.HEAD_BRANCH = 'main';
+    process.env.REPO_NAME = 'owner/repo';
+    process.env.CONCLUSION = 'failure';
+    process.env.EVENT_NAME = 'push';
+
+    mockFetch = mock(() => Promise.reject(new Error('ECONNREFUSED')));
+    global.fetch = mockFetch;
+
+    const run = require('../.github/scripts/notification/send-slack-ci-fail-notify.js');
+    await run({ github, context, core });
+
+    expect(core.failures).toHaveLength(1);
+    expect(core.failures[0]).toContain('ECONNREFUSED');
+  });
+});


### PR DESCRIPTION
## Summary

Adds reusable `notify-ci-fail.yml` workflow for posting Block Kit messages to `#github-ci-failures` when watched workflows fail. Enables consumer repos (nix-darwin, nix-ai, nix-home, nix-devenv) to replace custom issue-spam notifiers with a centralized Slack alerting pattern.

**Root motivation**: `nix-darwin/deps-update-flake.yml` silently failed for 6.5 weeks because existing `ci-fail-issue.yml` only watched `CI Gate`. This provides infrastructure for consumer repos to watch multiple workflows.

## Changes

- Added `.github/workflows/notify-ci-fail.yml`: reusable `workflow_call` that accepts watched workflow names and posts Block Kit messages to Slack
- Added `.github/scripts/notification/send-slack-ci-fail-notify.js`: constructs and sends formatted failure notifications
- Added `tests/send-slack-ci-fail-notify.test.js`: tests happy path, webhook failures, and network errors
- Added `workflow_dispatch` trigger for manual testing (mirrors `notify-ai-pr.yml` pattern)
- Documented consumer pattern in `docs/PATTERNS.md`
- All `workflow_run` context values forwarded as typed `workflow_call` inputs — never exposed to shell commands
- Fixed YAML indentation bug where `workflow_dispatch` was stealing inputs/secrets from `workflow_call`
- Wrapped fetch in try/catch for proper network-error handling

## Test Plan

- [x] Unit tests pass (`bun test`)
- [ ] Merge this PR first (consumer repos reference `@main`)
- [ ] Merge `JacobPEvans/nix-darwin` fix PR (calls this reusable) — verify Slack message appears in `#github-ci-failures` on next failure
- [ ] Re-trigger a failure to confirm `concurrency:` group prevents duplicate messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)