### PR TITLE
fix(workflows): remove invalid openrouter/free fallback

### DIFF
--- a/.github/workflows/post-merge-docs-review.yml
+++ b/.github/workflows/post-merge-docs-review.yml
@@ -120,6 +120,15 @@ jobs:
     env:
       ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL || secrets.OPENROUTER_BASE_URL }}
     steps:
+      - name: Validate model configuration
+        env:
+          AI_MODEL_VAR: ${{ vars.AI_MODEL_DOCS || vars.AI_MODEL }}
+        run: |
+          if [ -z "$AI_MODEL_VAR" ]; then
+            echo "::error::AI_MODEL_DOCS or AI_MODEL must be set as an org/repo variable. See docs/AUTHENTICATION.md for configuration."
+            exit 1
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@v6
 

--- a/.github/workflows/post-merge-docs-review.yml
+++ b/.github/workflows/post-merge-docs-review.yml
@@ -153,4 +153,4 @@ jobs:
           prompt: ${{ steps.prompt.outputs.content }}
           claude_args: >-
             --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),Bash(git branch:*),Bash(gh pr:*),Bash(gh api:*),Bash(gh search:*)"
-            --model ${{ vars.AI_MODEL_DOCS || vars.AI_MODEL || 'openrouter/free' }}
+            --model ${{ vars.AI_MODEL_DOCS || vars.AI_MODEL }}

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -120,6 +120,15 @@ jobs:
     env:
       ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL || secrets.OPENROUTER_BASE_URL }}
     steps:
+      - name: Validate model configuration
+        env:
+          AI_MODEL_VAR: ${{ vars.AI_MODEL_CODE || vars.AI_MODEL }}
+        run: |
+          if [ -z "$AI_MODEL_VAR" ]; then
+            echo "::error::AI_MODEL_CODE or AI_MODEL must be set as an org/repo variable. See docs/AUTHENTICATION.md for configuration."
+            exit 1
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@v6
 

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -153,4 +153,4 @@ jobs:
           prompt: ${{ steps.prompt.outputs.content }}
           claude_args: >-
             --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),Bash(git branch:*),Bash(gh pr:*),Bash(gh api:*),Bash(gh search:*)"
-            --model ${{ vars.AI_MODEL_CODE || vars.AI_MODEL || 'openrouter/free' }}
+            --model ${{ vars.AI_MODEL_CODE || vars.AI_MODEL }}

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ All workflows route through [OpenRouter](https://openrouter.ai) by default. Add 
 1. **Secret**: `OPENROUTER_API_KEY` — your OpenRouter API key (set a $/day spend limit)
 2. **Secret**: `OPENROUTER_BASE_URL` — set to `https://openrouter.ai/api/v1`
 
-If no model variables are configured, workflows automatically fall back to `openrouter/free` (zero cost). See [docs/AUTHENTICATION.md](docs/AUTHENTICATION.md) for alternative providers (Chutes.ai, direct Anthropic API) and model configuration.
+Most workflows fall back to `openrouter/free` when no model variables are configured. Exceptions: `post-merge-docs-review` and `post-merge-tests` require `AI_MODEL_DOCS`/`AI_MODEL_CODE` or `AI_MODEL` to be set — they fail with a clear error when unconfigured. See [docs/AUTHENTICATION.md](docs/AUTHENTICATION.md) for model configuration and alternative providers.
 
 ---
 

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -131,7 +131,7 @@ The `anthropic_api_key` input also accepts a direct [Anthropic API key](https://
 
 ### Fallback Chain
 
-Every workflow uses a 3-tier fallback chain to determine which model to use:
+Most workflows use a 3-tier fallback chain to determine which model to use:
 
 ```
 inputs.model → vars.AI_MODEL_{CATEGORY} → vars.AI_MODEL → 'openrouter/free'
@@ -140,8 +140,12 @@ inputs.model → vars.AI_MODEL_{CATEGORY} → vars.AI_MODEL → 'openrouter/free
   (workflow input)   (per-task tier)       (repo-wide)      (safety net)
 ```
 
+**Exceptions** — `post-merge-docs-review` and `post-merge-tests` have no hardcoded fallback.
+They fail with a clear `::error::` message when neither `AI_MODEL_DOCS`/`AI_MODEL_CODE` nor
+`AI_MODEL` is set. Configure at least `AI_MODEL` to enable these workflows.
+
 This means:
-- **If you set nothing**: All workflows use `openrouter/free` — zero cost, rate-limited, lower capability
+- **If you set nothing**: Most workflows use `openrouter/free`; `post-merge-docs-review` and `post-merge-tests` fail at startup with a configuration error
 - **If you set `AI_MODEL` only**: All workflows use that model as a baseline
 - **If you set category vars**: Each workflow type gets an appropriate model tier
 - **If a caller passes `model`**: That overrides everything
@@ -164,7 +168,9 @@ Workflows are grouped by the intelligence level they need:
 
 **Minimal** (zero cost, limited capability):
 ```
-# Set nothing — all workflows use openrouter/free automatically
+# Most workflows fall back to openrouter/free automatically.
+# post-merge-docs-review and post-merge-tests require at least AI_MODEL:
+AI_MODEL = openrouter/free
 ```
 
 **Budget-conscious** (one variable, moderate capability):


### PR DESCRIPTION
## Summary

Removes hardcoded `openrouter/free` fallback from post-merge workflows. This is not a valid OpenRouter model alias and causes "There's an issue with the selected model" failures when org/repo variables (`AI_MODEL_DOCS`, `AI_MODEL_CODE`, `AI_MODEL`) are unset. Implements the fix half of #235 — removing the fallback and requiring explicit configuration.

## Changes

- `post-merge-docs-review.yml`: `--model ${{ vars.AI_MODEL_DOCS || vars.AI_MODEL || 'openrouter/free' }}` → `--model ${{ vars.AI_MODEL_DOCS || vars.AI_MODEL }}`
- `post-merge-tests.yml`: `--model ${{ vars.AI_MODEL_CODE || vars.AI_MODEL || 'openrouter/free' }}` → `--model ${{ vars.AI_MODEL_CODE || vars.AI_MODEL }}`

Callers must configure `AI_MODEL`, `AI_MODEL_DOCS`, or `AI_MODEL_CODE` at the org or repo level. This is correct behavior for a reusable workflow: fail explicitly when unconfigured rather than silently using an invalid alias.

## Test Plan

- [ ] Verify `post-merge-docs-review` runs in a repo with `AI_MODEL` or `AI_MODEL_DOCS` configured at org or repo level
- [ ] Verify `post-merge-tests` runs in a repo with `AI_MODEL` or `AI_MODEL_CODE` configured at org or repo level
- [ ] Confirm all org-level callers (`nix-darwin`, `nix-ai`, `nix-home`, `ai-workflows`) have `AI_MODEL` set

Relates to JacobPEvans/.github#235

🤖 Generated with [Claude Code](https://claude.com/claude-code)