### PR TITLE
fix(issue-resolver): restrict git tools to read-only to enforce signed commits

### DIFF
--- a/.github/workflows/issue-resolver.yml
+++ b/.github/workflows/issue-resolver.yml
@@ -144,7 +144,7 @@ jobs:
           use_commit_signing: "true"
           prompt: ${{ steps.prompt.outputs.content }}
           claude_args: >-
-            --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),Bash(git branch:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git checkout:*),Bash(git switch:*),Bash(gh pr create:*),Bash(gh issue comment:*)${{ inputs.extra_tools != '' && format(',{0}', inputs.extra_tools) || '' }}"
+            --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),Bash(git branch:*),Bash(gh pr create:*),Bash(gh issue comment:*)${{ inputs.extra_tools != '' && format(',{0}', inputs.extra_tools) || '' }}"
             --model ${{ inputs.model || vars.AI_MODEL_PLAN || vars.AI_MODEL || 'openrouter/free' }}
 
       - name: Comment on failure


### PR DESCRIPTION
## Summary

The `issue-resolver.yml` workflow had `use_commit_signing: "true"` set, but
also allowed git write tools (`add/commit/push/checkout/switch`) in
`--allowedTools`. Claude could bypass the API-based signing path by using
local git commands, producing **unsigned** commits despite the config.

This PR removes those 5 tools so Claude is forced to use the API path,
which signs commits with the GitHub App identity.

## Root cause

\`\`\`text
issue-resolver.yml      use_commit_signing: true   unsigned-write tools allowed: 5  ← BAD
code-simplifier.yml     use_commit_signing: true   unsigned-write tools allowed: 0
next-steps.yml          use_commit_signing: true   unsigned-write tools allowed: 0
post-merge-docs-review  use_commit_signing: true   unsigned-write tools allowed: 0
post-merge-tests.yml    use_commit_signing: true   unsigned-write tools allowed: 0
ci-fix.yml              use_commit_signing: true   unsigned-write tools allowed: 0
\`\`\`

`docs/PATTERNS.md` already documents the correct pattern:

> \`Bash(git:*)\` is restricted to **read-only subcommands** to prevent
> unsigned CLI commits.

The code drifted from the docs in #116 (2026-03-25). This PR brings
`issue-resolver` back into compliance.

## Affected PRs (8 unsigned commits since 2026-04-27)

| PR | Date |
|---|---|
| terraform-proxmox#276 | 2026-05-06 |
| tf-splunk-aws#162 | 2026-05-05 |
| claude-code-plugins#281 | 2026-05-04 |
| terraform-proxmox#272 | 2026-05-03 |
| terraform-proxmox#271 | 2026-05-02 |
| terraform-proxmox#270 | 2026-04-30 |
| tf-splunk-aws#149 | 2026-04-28 |
| python-template#41 | 2026-04-27 |

## Test plan

- [ ] After merge, release-please cuts a new patch tag (v0.13.3 expected)
- [ ] Trigger a new `issue-auto-resolve` workflow run on a real issue
- [ ] Verify resulting PR commit shows `verified: true, reason: valid`
- [ ] Re-sweep all open PRs — only `[daily-polish-*]` PRs (local Claude
      sessions, not workflow-driven) should remain unsigned

## Related

- Followup to canonical-app-credentials migration (Phase 4 complete, all 20 PRs merged)