### PR TITLE
feat(actions): add ai-action-with-signing composite for SSH-signed AI commits

### DIFF
--- a/.github/actions/ai-action-with-signing/action.yml
+++ b/.github/actions/ai-action-with-signing/action.yml
@@ -1,0 +1,57 @@
+name: AI Action with SSH Signing
+description: |
+  Run anthropics/claude-code-action@v1 with SSH commit signing pre-configured so every
+  commit Claude makes is GitHub-verified. Replaces the runner-side `use_commit_signing: "true"`
+  path (which uses the GitHub Contents API and cannot perform local git operations like
+  rebase/cherry-pick) with the action's native SSH signing path.
+
+  Signing identity: JacobPEvans (user id 20714140). The matching SSH public key is registered
+  on the JacobPEvans user account at key id 826672 ("Doppler stored GitHub Actions Claude
+  GPG Key for direct pull request generation with signed commits"). Bot attribution belongs
+  in a Co-authored-by: trailer appended by the prompt (see ai-workflows shared prompts).
+
+inputs:
+  prompt:
+    description: Fully-rendered prompt content passed to Claude (typically the `content` output of render-prompt.sh).
+    required: true
+  allowed_tools:
+    description: Comma-separated list of tools to allow Claude to use (passed to --allowedTools).
+    required: true
+  model:
+    description: Optional Claude model identifier (passed to --model). Defaults to empty, letting the action resolve via env.
+    required: false
+    default: ""
+  anthropic_api_key:
+    description: API key for the model provider (use secrets.OPENROUTER_API_KEY for the canonical OpenRouter routing).
+    required: true
+  ssh_signing_key:
+    description: SSH private key for commit signing (use secrets.GH_APP_CLAUDE_SSH_SIGNING_KEY). The public counterpart MUST be registered on the GitHub user identified by bot_id.
+    required: true
+  allowed_bots:
+    description: Comma-separated bot actors permitted to trigger Claude. Default permits the github-actions[bot] that fires from dispatch / workflow_run flows.
+    required: false
+    default: "github-actions"
+  bot_id:
+    description: GitHub numeric user id used for the commit author (combined with bot_name to form the noreply email). Default is JacobPEvans's user id, which owns the SSH signing key.
+    required: false
+    default: "20714140"
+  bot_name:
+    description: GitHub username used for the commit author. Must match a verified-email owner of the SSH signing key for signatures to verify.
+    required: false
+    default: "JacobPEvans"
+
+runs:
+  using: composite
+  steps:
+    - name: Run Claude Code (SSH-signed via ssh_signing_key)
+      uses: anthropics/claude-code-action@v1
+      with:
+        anthropic_api_key: ${{ inputs.anthropic_api_key }}
+        ssh_signing_key: ${{ inputs.ssh_signing_key }}
+        allowed_bots: ${{ inputs.allowed_bots }}
+        bot_id: ${{ inputs.bot_id }}
+        bot_name: ${{ inputs.bot_name }}
+        prompt: ${{ inputs.prompt }}
+        claude_args: >-
+          --allowedTools "${{ inputs.allowed_tools }}"
+          ${{ inputs.model != '' && format('--model {0}', inputs.model) || '' }}

--- a/.github/actions/ai-action-with-signing/action.yml
+++ b/.github/actions/ai-action-with-signing/action.yml
@@ -5,10 +5,10 @@ description: |
   path (which uses the GitHub Contents API and cannot perform local git operations like
   rebase/cherry-pick) with the action's native SSH signing path.
 
-  Signing identity: JacobPEvans (user id 20714140). The matching SSH public key is registered
-  on the JacobPEvans user account at key id 826672 ("Doppler stored GitHub Actions Claude
-  GPG Key for direct pull request generation with signed commits"). Bot attribution belongs
-  in a Co-authored-by: trailer appended by the prompt (see ai-workflows shared prompts).
+  Signing identity: the GitHub user whose SSH signing key the caller supplies via
+  ssh_signing_key. Bot/automation attribution (e.g. "Co-authored-by: <bot>") belongs in the
+  commit body via the prompt, not in the author field — the author MUST match the
+  ssh_signing_key owner for GitHub to verify the signature.
 
 inputs:
   prompt:
@@ -32,11 +32,11 @@ inputs:
     required: false
     default: "github-actions"
   bot_id:
-    description: GitHub numeric user id used for the commit author (combined with bot_name to form the noreply email). Default is JacobPEvans's user id, which owns the SSH signing key.
+    description: GitHub numeric user id used for the commit author (combined with bot_name to form the noreply email). MUST match the user account that owns the public counterpart of ssh_signing_key for signatures to verify. Default fits the current canonical key registration; override if rotating to a different signing identity.
     required: false
     default: "20714140"
   bot_name:
-    description: GitHub username used for the commit author. Must match a verified-email owner of the SSH signing key for signatures to verify.
+    description: GitHub username used for the commit author. MUST match the user account that owns the public counterpart of ssh_signing_key. Default fits the current canonical key registration.
     required: false
     default: "JacobPEvans"
 
@@ -54,4 +54,4 @@ runs:
         prompt: ${{ inputs.prompt }}
         claude_args: >-
           --allowedTools "${{ inputs.allowed_tools }}"
-          ${{ inputs.model != '' && format('--model {0}', inputs.model) || '' }}
+          ${{ inputs.model != '' && format('--model "{0}"', inputs.model) || '' }}


### PR DESCRIPTION
## Summary

- New composite action `ai-action-with-signing` wraps `anthropics/claude-code-action@v1` with SSH commit signing pre-configured
- Drop-in replacement for the `use_commit_signing: "true"` Contents-API path — gives Claude back local `git commit`/`rebase`/`cherry-pick` while still producing GitHub-verified commits
- Signing identity: JacobPEvans (user id 20714140); public counterpart of `GH_APP_CLAUDE_SSH_SIGNING_KEY` is already on the user's profile as ssh-signing-key id 826672

## Why a composite action, not a reusable workflow

The plan originally sketched a reusable workflow at `.github/workflows/_ai-action-with-signing.yml`. A composite action is cleaner because:

- Consumer migration is a one-line `uses:` swap, not a job restructure
- Consumer keeps its existing checkout / prompt-render / failure-handling steps unchanged
- The wrapper does exactly one thing (substitute the Claude step), with no scope creep

## Consumer migration (PR #3)

Each of these flips one step:

- `issue-resolver.yml`
- `ci-fix.yml`
- `code-simplifier.yml`
- `post-merge-tests.yml`
- `post-merge-docs-review.yml`
- `final-pr-review.yml`
- `claude-review.yml`

Before:

\`\`\`yaml
uses: anthropics/claude-code-action@v1
with:
  anthropic_api_key: \${{ secrets.OPENROUTER_API_KEY }}
  allowed_bots: github-actions
  use_commit_signing: "true"
  prompt: \${{ steps.prompt.outputs.content }}
  claude_args: --allowedTools "...,Bash(git log:*),..." --model \${{ vars.AI_MODEL_PLAN }}
\`\`\`

After:

\`\`\`yaml
uses: JacobPEvans/ai-workflows/.github/actions/ai-action-with-signing@v0
with:
  anthropic_api_key: \${{ secrets.OPENROUTER_API_KEY }}
  ssh_signing_key: \${{ secrets.GH_APP_CLAUDE_SSH_SIGNING_KEY }}
  prompt: \${{ steps.prompt.outputs.content }}
  allowed_tools: "...,Bash(git:*),..."
  model: \${{ vars.AI_MODEL_PLAN }}
\`\`\`

The migration expands the allowed-tools list to include write-mode git commands (which `use_commit_signing` forbade).

## Test plan

After merge:

- [ ] Trigger `issue-resolver.yml` against a sacrificial test issue (via PR #3)
- [ ] Confirm the resulting PR's commits return `verified:true, reason:"valid"` via `gh api repos/.../commits/<sha>`
- [ ] Confirm `commit.author.email == "20714140+JacobPEvans@users.noreply.github.com"` and `commit.author.name == "JacobPEvans"`
- [ ] Confirm Claude was able to execute `git commit` locally (visible in workflow logs)
- [ ] Verify the Co-authored-by trailer is present in the commit body (PR #3 will add this to the shared prompts)

## Part of larger initiative

PR 2 of 8 in the "eliminate unsigned automated commits" rollout. See plan in \`~/.claude/plans/you-are-opus-on-breezy-valiant.md\` for the full sequence.

Assisted-by: Claude <noreply@anthropic.com>