### PR TITLE
feat(actions): centralize claude-code-action invocation via composite

### DIFF
--- a/.github/actions/run-claude-code/action.yml
+++ b/.github/actions/run-claude-code/action.yml
@@ -1,0 +1,66 @@
+name: Run Claude Code with bot attribution
+description: >-
+  Mints a JacobPEvans-claude App installation token and invokes
+  anthropics/claude-code-action@v1 with that token, so every commit and PR
+  comment is attributed to JacobPEvans-claude[bot] via the Contents API
+  web-flow signing path. Centralizes the token-mint and action invocation
+  that previously had to be copy-pasted into every reusable workflow.
+
+inputs:
+  prompt:
+    description: Rendered prompt content sent to Claude (typically `${{ steps.prompt.outputs.content }}`).
+    required: true
+  model:
+    description: >-
+      Model name forwarded as `--model`. The caller resolves the appropriate
+      `vars.AI_MODEL_*` chain; this action does not pick a default.
+    required: true
+  allowed_tools:
+    description: >-
+      Full --allowedTools value forwarded inside `claude_args`. Each caller
+      owns its own tool scope so the policy stays visible in the workflow.
+    required: true
+  anthropic_api_key:
+    description: API key for the LLM provider (e.g. OpenRouter). Pass-through; treat as secret at the caller.
+    required: true
+  app_id:
+    description: JacobPEvans-claude App ID, e.g. `${{ vars.GH_APP_CLAUDE_BOT_ID }}`.
+    required: true
+  app_private_key:
+    description: JacobPEvans-claude App private key PEM, e.g. `${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}`.
+    required: true
+  allowed_bots:
+    description: Comma-separated bot logins claude-code-action may process.
+    required: false
+    default: github-actions
+  use_commit_signing:
+    description: >-
+      "true" to route commits through the Contents API (web-flow signed and
+      attributed to the App). "false" for review-only callers that make no
+      commits.
+    required: false
+    default: "true"
+
+runs:
+  using: composite
+  steps:
+    - name: Mint JacobPEvans-claude installation token
+      id: app-token
+      uses: actions/create-github-app-token@v2
+      with:
+        app-id: ${{ inputs.app_id }}
+        private-key: ${{ inputs.app_private_key }}
+        owner: ${{ github.repository_owner }}
+        repositories: ${{ github.event.repository.name }}
+
+    - name: Run Claude Code
+      uses: anthropics/claude-code-action@v1
+      with:
+        github_token: ${{ steps.app-token.outputs.token }}
+        anthropic_api_key: ${{ inputs.anthropic_api_key }}
+        allowed_bots: ${{ inputs.allowed_bots }}
+        use_commit_signing: ${{ inputs.use_commit_signing }}
+        prompt: ${{ inputs.prompt }}
+        claude_args: >-
+          --allowedTools "${{ inputs.allowed_tools }}"
+          --model ${{ inputs.model }}

--- a/.github/workflows/ci-fix.yml
+++ b/.github/workflows/ci-fix.yml
@@ -215,26 +215,16 @@ jobs:
           TRIGGER_ACTOR: ${{ github.triggering_actor }}
         run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/ci-fix.md FAILURE_LOGS REPO_CONTEXT CI_STRUCTURE ATTEMPT_NUM WORKFLOW_NAME RUN_ID RUN_URL EVENT_NAME TRIGGER_ACTOR
 
-      - name: Mint JacobPEvans-claude installation token
-        id: app-token
-        uses: actions/create-github-app-token@v2
+      - name: Run Claude Code with bot attribution
+        uses: JacobPEvans/ai-workflows/.github/actions/run-claude-code@main
         with:
-          app-id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
-          private-key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
-
-      - name: Run Claude Code
-        uses: anthropics/claude-code-action@v1
-        with:
-          github_token: ${{ steps.app-token.outputs.token }}
-          anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
-          allowed_bots: "github-actions,claude"
-          use_commit_signing: "true"
           prompt: ${{ steps.prompt.outputs.content }}
-          claude_args: >-
-            --model ${{ vars.AI_MODEL_CODE || vars.AI_MODEL || 'openrouter/free' }}
-            --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),Bash(git branch:*)${{ inputs.extra_tools != '' && format(',{0}', inputs.extra_tools) || '' }}"
+          model: ${{ vars.AI_MODEL_CODE || vars.AI_MODEL || 'openrouter/free' }}
+          allowed_tools: "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),Bash(git branch:*)${{ inputs.extra_tools != '' && format(',{0}', inputs.extra_tools) || '' }}"
+          anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          app_id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
+          app_private_key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}
+          allowed_bots: "github-actions,claude"
 
       - name: Comment on failure
         if: failure()

--- a/.github/workflows/ci-fix.yml
+++ b/.github/workflows/ci-fix.yml
@@ -215,9 +215,19 @@ jobs:
           TRIGGER_ACTOR: ${{ github.triggering_actor }}
         run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/ci-fix.md FAILURE_LOGS REPO_CONTEXT CI_STRUCTURE ATTEMPT_NUM WORKFLOW_NAME RUN_ID RUN_URL EVENT_NAME TRIGGER_ACTOR
 
+      - name: Mint JacobPEvans-claude installation token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
+          private-key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+
       - name: Run Claude Code
         uses: anthropics/claude-code-action@v1
         with:
+          github_token: ${{ steps.app-token.outputs.token }}
           anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
           allowed_bots: "github-actions,claude"
           use_commit_signing: "true"

--- a/.github/workflows/code-simplifier.yml
+++ b/.github/workflows/code-simplifier.yml
@@ -112,23 +112,12 @@ jobs:
           TRIGGER_ACTOR: ${{ github.triggering_actor }}
         run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/code-simplifier.md WORKFLOW_NAME RUN_ID RUN_URL EVENT_NAME TRIGGER_ACTOR
 
-      - name: Mint JacobPEvans-claude installation token
-        id: app-token
-        uses: actions/create-github-app-token@v2
+      - name: Run Claude Code with bot attribution
+        uses: JacobPEvans/ai-workflows/.github/actions/run-claude-code@main
         with:
-          app-id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
-          private-key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
-
-      - name: Execute Claude Code
-        uses: anthropics/claude-code-action@v1
-        with:
-          github_token: ${{ steps.app-token.outputs.token }}
-          anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
-          allowed_bots: "github-actions"
-          use_commit_signing: "true"
           prompt: ${{ steps.prompt.outputs.content }}
-          claude_args: >-
-            --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),Bash(git branch:*),Bash(gh pr:*),Bash(gh api:*)"
-            --model ${{ vars.AI_MODEL_CODE || vars.AI_MODEL || 'openrouter/free' }}
+          model: ${{ vars.AI_MODEL_CODE || vars.AI_MODEL || 'openrouter/free' }}
+          allowed_tools: "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),Bash(git branch:*),Bash(gh pr:*),Bash(gh api:*)"
+          anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          app_id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
+          app_private_key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}

--- a/.github/workflows/code-simplifier.yml
+++ b/.github/workflows/code-simplifier.yml
@@ -112,9 +112,19 @@ jobs:
           TRIGGER_ACTOR: ${{ github.triggering_actor }}
         run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/code-simplifier.md WORKFLOW_NAME RUN_ID RUN_URL EVENT_NAME TRIGGER_ACTOR
 
+      - name: Mint JacobPEvans-claude installation token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
+          private-key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+
       - name: Execute Claude Code
         uses: anthropics/claude-code-action@v1
         with:
+          github_token: ${{ steps.app-token.outputs.token }}
           anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
           allowed_bots: "github-actions"
           use_commit_signing: "true"

--- a/.github/workflows/final-pr-review.yml
+++ b/.github/workflows/final-pr-review.yml
@@ -131,27 +131,17 @@ jobs:
           PR_NUMBER: ${{ needs.gate-check.outputs.pr_number }}
         run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/final-pr-review.md
 
-      - name: Mint JacobPEvans-claude installation token
+      - name: Run Claude Code with bot attribution
         if: steps.bot-check.outputs.run == 'true'
-        id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: JacobPEvans/ai-workflows/.github/actions/run-claude-code@main
         with:
-          app-id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
-          private-key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
-
-      - name: Run Claude Code
-        if: steps.bot-check.outputs.run == 'true'
-        uses: anthropics/claude-code-action@v1
-        with:
-          github_token: ${{ steps.app-token.outputs.token }}
-          anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
-          allowed_bots: "github-actions"
           prompt: ${{ steps.prompt.outputs.content }}
-          claude_args: >-
-            --model ${{ vars.AI_MODEL_REVIEW || vars.AI_MODEL || 'openrouter/free' }}
-            --allowedTools "Read,Glob,Grep,LS,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*)"
+          model: ${{ vars.AI_MODEL_REVIEW || vars.AI_MODEL || 'openrouter/free' }}
+          allowed_tools: "Read,Glob,Grep,LS,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*)"
+          anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          app_id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
+          app_private_key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}
+          use_commit_signing: "false"
 
   add-label:
     name: Mark as reviewed

--- a/.github/workflows/final-pr-review.yml
+++ b/.github/workflows/final-pr-review.yml
@@ -123,6 +123,19 @@ jobs:
           PR_NUMBER: ${{ needs.gate-check.outputs.pr_number }}
         run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/final-pr-review.md
 
+      - name: Mint JacobPEvans-claude installation token
+        if: >-
+          github.event.pull_request.user.type != 'Bot' ||
+          contains(inputs.allowed_bots, github.event.pull_request.user.login) ||
+          contains(inputs.allowed_bots, '*')
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
+          private-key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+
       - name: Run Claude Code
         if: >-
           github.event.pull_request.user.type != 'Bot' ||
@@ -130,6 +143,7 @@ jobs:
           contains(inputs.allowed_bots, '*')
         uses: anthropics/claude-code-action@v1
         with:
+          github_token: ${{ steps.app-token.outputs.token }}
           anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
           allowed_bots: "github-actions"
           prompt: ${{ steps.prompt.outputs.content }}

--- a/.github/workflows/final-pr-review.yml
+++ b/.github/workflows/final-pr-review.yml
@@ -117,17 +117,22 @@ jobs:
             .github/prompts
           path: .ai-workflows
 
+      # Evaluate the bot-eligibility predicate once and reuse via step output,
+      # so mint + Run Claude can't drift apart. Expression is evaluated by
+      # GitHub Actions and produces a literal "true" or "false" string.
+      - name: Check bot eligibility
+        id: bot-check
+        run: echo "run=${{ github.event.pull_request.user.type != 'Bot' || contains(inputs.allowed_bots, github.event.pull_request.user.login) || contains(inputs.allowed_bots, '*') }}" >> "$GITHUB_OUTPUT"
+
       - name: Render prompt
         id: prompt
+        if: steps.bot-check.outputs.run == 'true'
         env:
           PR_NUMBER: ${{ needs.gate-check.outputs.pr_number }}
         run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/final-pr-review.md
 
       - name: Mint JacobPEvans-claude installation token
-        if: >-
-          github.event.pull_request.user.type != 'Bot' ||
-          contains(inputs.allowed_bots, github.event.pull_request.user.login) ||
-          contains(inputs.allowed_bots, '*')
+        if: steps.bot-check.outputs.run == 'true'
         id: app-token
         uses: actions/create-github-app-token@v2
         with:
@@ -137,10 +142,7 @@ jobs:
           repositories: ${{ github.event.repository.name }}
 
       - name: Run Claude Code
-        if: >-
-          github.event.pull_request.user.type != 'Bot' ||
-          contains(inputs.allowed_bots, github.event.pull_request.user.login) ||
-          contains(inputs.allowed_bots, '*')
+        if: steps.bot-check.outputs.run == 'true'
         uses: anthropics/claude-code-action@v1
         with:
           github_token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/issue-resolver.yml
+++ b/.github/workflows/issue-resolver.yml
@@ -136,26 +136,15 @@ jobs:
           TRIGGER_ACTOR: ${{ github.triggering_actor }}
         run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/issue-resolver.md REPO_CONTEXT ISSUE_NUMBER ISSUE_TITLE ISSUE_BODY ISSUE_LABELS ATTEMPT MAX_ATTEMPTS WORKFLOW_NAME RUN_ID RUN_URL EVENT_NAME TRIGGER_ACTOR
 
-      - name: Mint JacobPEvans-claude installation token
-        id: app-token
-        uses: actions/create-github-app-token@v2
+      - name: Run Claude Code with bot attribution
+        uses: JacobPEvans/ai-workflows/.github/actions/run-claude-code@main
         with:
-          app-id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
-          private-key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
-
-      - name: Run Claude Code
-        uses: anthropics/claude-code-action@v1
-        with:
-          github_token: ${{ steps.app-token.outputs.token }}
-          anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
-          allowed_bots: "github-actions"
-          use_commit_signing: "true"
           prompt: ${{ steps.prompt.outputs.content }}
-          claude_args: >-
-            --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),Bash(git branch:*),Bash(gh pr create:*),Bash(gh issue comment:*)${{ inputs.extra_tools != '' && format(',{0}', inputs.extra_tools) || '' }}"
-            --model ${{ inputs.model || vars.AI_MODEL_PLAN || vars.AI_MODEL || 'openrouter/free' }}
+          model: ${{ inputs.model || vars.AI_MODEL_PLAN || vars.AI_MODEL || 'openrouter/free' }}
+          allowed_tools: "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),Bash(git branch:*),Bash(gh pr create:*),Bash(gh issue comment:*)${{ inputs.extra_tools != '' && format(',{0}', inputs.extra_tools) || '' }}"
+          anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          app_id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
+          app_private_key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}
 
       - name: Comment on failure
         if: failure()

--- a/.github/workflows/issue-resolver.yml
+++ b/.github/workflows/issue-resolver.yml
@@ -136,9 +136,19 @@ jobs:
           TRIGGER_ACTOR: ${{ github.triggering_actor }}
         run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/issue-resolver.md REPO_CONTEXT ISSUE_NUMBER ISSUE_TITLE ISSUE_BODY ISSUE_LABELS ATTEMPT MAX_ATTEMPTS WORKFLOW_NAME RUN_ID RUN_URL EVENT_NAME TRIGGER_ACTOR
 
+      - name: Mint JacobPEvans-claude installation token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
+          private-key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+
       - name: Run Claude Code
         uses: anthropics/claude-code-action@v1
         with:
+          github_token: ${{ steps.app-token.outputs.token }}
           anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
           allowed_bots: "github-actions"
           use_commit_signing: "true"

--- a/.github/workflows/post-merge-docs-review.yml
+++ b/.github/workflows/post-merge-docs-review.yml
@@ -153,23 +153,12 @@ jobs:
           TRIGGER_ACTOR: ${{ github.triggering_actor }}
         run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/post-merge-docs-review.md COMMIT_SHA REPO_NAME WORKFLOW_NAME RUN_ID RUN_URL EVENT_NAME TRIGGER_ACTOR
 
-      - name: Mint JacobPEvans-claude installation token
-        id: app-token
-        uses: actions/create-github-app-token@v2
+      - name: Run Claude Code with bot attribution
+        uses: JacobPEvans/ai-workflows/.github/actions/run-claude-code@main
         with:
-          app-id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
-          private-key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
-
-      - name: Run Claude
-        uses: anthropics/claude-code-action@v1
-        with:
-          github_token: ${{ steps.app-token.outputs.token }}
-          anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
-          allowed_bots: "github-actions"
-          use_commit_signing: "true"
           prompt: ${{ steps.prompt.outputs.content }}
-          claude_args: >-
-            --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),Bash(git branch:*),Bash(gh pr:*),Bash(gh api:*),Bash(gh search:*)"
-            --model ${{ vars.AI_MODEL_DOCS || vars.AI_MODEL }}
+          model: ${{ vars.AI_MODEL_DOCS || vars.AI_MODEL }}
+          allowed_tools: "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),Bash(git branch:*),Bash(gh pr:*),Bash(gh api:*),Bash(gh search:*)"
+          anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          app_id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
+          app_private_key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}

--- a/.github/workflows/post-merge-docs-review.yml
+++ b/.github/workflows/post-merge-docs-review.yml
@@ -153,9 +153,19 @@ jobs:
           TRIGGER_ACTOR: ${{ github.triggering_actor }}
         run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/post-merge-docs-review.md COMMIT_SHA REPO_NAME WORKFLOW_NAME RUN_ID RUN_URL EVENT_NAME TRIGGER_ACTOR
 
+      - name: Mint JacobPEvans-claude installation token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
+          private-key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+
       - name: Run Claude
         uses: anthropics/claude-code-action@v1
         with:
+          github_token: ${{ steps.app-token.outputs.token }}
           anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
           allowed_bots: "github-actions"
           use_commit_signing: "true"

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -153,23 +153,12 @@ jobs:
           TRIGGER_ACTOR: ${{ github.triggering_actor }}
         run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/post-merge-tests.md MERGE_SHA REPO_FULL_NAME WORKFLOW_NAME RUN_ID RUN_URL EVENT_NAME TRIGGER_ACTOR
 
-      - name: Mint JacobPEvans-claude installation token
-        id: app-token
-        uses: actions/create-github-app-token@v2
+      - name: Run Claude Code with bot attribution
+        uses: JacobPEvans/ai-workflows/.github/actions/run-claude-code@main
         with:
-          app-id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
-          private-key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
-
-      - name: Run Claude
-        uses: anthropics/claude-code-action@v1
-        with:
-          github_token: ${{ steps.app-token.outputs.token }}
-          anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
-          allowed_bots: "github-actions"
-          use_commit_signing: "true"
           prompt: ${{ steps.prompt.outputs.content }}
-          claude_args: >-
-            --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),Bash(git branch:*),Bash(gh pr:*),Bash(gh api:*),Bash(gh search:*)"
-            --model ${{ vars.AI_MODEL_CODE || vars.AI_MODEL }}
+          model: ${{ vars.AI_MODEL_CODE || vars.AI_MODEL }}
+          allowed_tools: "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),Bash(git branch:*),Bash(gh pr:*),Bash(gh api:*),Bash(gh search:*)"
+          anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          app_id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
+          app_private_key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -153,9 +153,19 @@ jobs:
           TRIGGER_ACTOR: ${{ github.triggering_actor }}
         run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/post-merge-tests.md MERGE_SHA REPO_FULL_NAME WORKFLOW_NAME RUN_ID RUN_URL EVENT_NAME TRIGGER_ACTOR
 
+      - name: Mint JacobPEvans-claude installation token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
+          private-key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+
       - name: Run Claude
         uses: anthropics/claude-code-action@v1
         with:
+          github_token: ${{ steps.app-token.outputs.token }}
           anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
           allowed_bots: "github-actions"
           use_commit_signing: "true"


### PR DESCRIPTION
## Summary

- Adds `.github/actions/run-claude-code/` — a composite action that mints a `JacobPEvans-claude` App installation token via `actions/create-github-app-token@v2` and invokes `anthropics/claude-code-action@v1` with that token, so every commit and PR comment is attributed to `JacobPEvans-claude[bot]`.
- Refactors all six Claude-driven reusable workflows (`issue-resolver`, `ci-fix`, `code-simplifier`, `post-merge-tests`, `post-merge-docs-review`, `final-pr-review`) to call the composite instead of inlining the mint + invoke pattern.

## Why

The user owns a dedicated `JacobPEvans-claude` GitHub App with credentials provisioned in Doppler and synced to consumer repos (`GH_APP_CLAUDE_BOT_ID` variable, `GH_APP_CLAUDE_BOT_PRIVATE_KEY` secret). But every recent commit and review produced by these workflows has been attributed to a different bot identity, because no workflow currently mints the App's token. After this change, every artifact these workflows produce comes from the App the user actually controls.

## DRY: one source of truth

Earlier drafts of this PR duplicated the mint-token + claude-code-action invocation across each of the six workflows — 8 identical lines × 6 files. That was a real DRY violation flagged in review. This version extracts both into a single composite at `.github/actions/run-claude-code/action.yml`. Per-workflow callers only carry the bits that legitimately vary: `prompt`, `model`, `allowed_tools`, and the few overrides (`ci-fix` uses `allowed_bots: github-actions,claude`; `final-pr-review` sets `use_commit_signing: false` and keeps its `bot-check` `if:` predicate on the composite invocation step).

Net change: +118 / -50 across 7 files. The composite owns the byte-identical infrastructure; the workflows stay readable about their own scope.

## Files

- **NEW** `.github/actions/run-claude-code/action.yml` — composite action: token mint + claude-code-action wrapper.
- **EDIT** six reusable workflows under `.github/workflows/` — each gets one `uses: JacobPEvans/ai-workflows/.github/actions/run-claude-code@main` step in place of the old mint + claude-code-action pair.

## Test plan

- [ ] Confirm `vars.GH_APP_CLAUDE_BOT_ID` and `secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY` are present on every consumer repo that calls these reusable workflows. Verified during /ship for all `*github_app_repos` after `secrets-sync#82` distribution.
- [ ] Confirm the `JacobPEvans-claude` App is installed on every consumer repo with `contents:write`, `pull-requests:write`, `issues:write`.
- [ ] Trigger any consumer repo's `issue-triage.yml` against a sacrificial issue; watch `issue-resolver.yml` run.
- [ ] On the resulting PR's commits:
  ```
  gh api repos/<consumer>/<repo>/commits/<sha> \
    --jq '{verified: .commit.verification.verified, reason: .commit.verification.reason, login: .author.login}'
  ```
  Expect `verified: true, reason: "valid", login: "JacobPEvans-claude[bot]"`.

## Related

- Related: `secrets-sync#82` (merged) — widened `GH_APP_CLAUDE_BOT_ID` / `GH_APP_CLAUDE_BOT_PRIVATE_KEY` distribution to all `*github_app_repos`.
- Related: `claude-code-routines#11` (merged) — Issue Solver migrated to native GHA workflow using the same App-token pattern (inline rather than via this composite because it runs in a single repo, not via `workflow_call` from arbitrary consumers).
- Supersedes: `#214` (closed) — SSH-signing composite. Same architectural pattern, wrong identity direction (signed as the user, not the bot).

Assisted-by: Claude <noreply@anthropic.com>