### PR TITLE
feat(workflows): add runner_label input to all reusable workflows

### DIFF
--- a/.github/workflows/_ai-merge-gate.yml
+++ b/.github/workflows/_ai-merge-gate.yml
@@ -10,6 +10,15 @@ name: _ai-merge-gate
 
 on:
   workflow_call:
+    inputs:
+      runner_label:
+        description: >-
+          GitHub Actions runner label to run the job(s) on. Defaults to
+          ubuntu-latest. Pass a RunsOn label (see runs-on.com job labels
+          docs) to opt the calling repo into self-hosted runners.
+        type: string
+        required: false
+        default: ubuntu-latest
   workflow_dispatch:
 
 permissions:
@@ -19,7 +28,7 @@ permissions:
 jobs:
   check:
     name: AI Merge Gate
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     env:
       GH_TOKEN: ${{ github.token }}
       HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/_ai-merge-gate.yml
+++ b/.github/workflows/_ai-merge-gate.yml
@@ -28,7 +28,7 @@ permissions:
 jobs:
   check:
     name: AI Merge Gate
-    runs-on: ${{ inputs.runner_label }}
+    runs-on: ${{ inputs.runner_label || 'ubuntu-latest' }}
     env:
       GH_TOKEN: ${{ github.token }}
       HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/_copilot-setup-steps.yml
+++ b/.github/workflows/_copilot-setup-steps.yml
@@ -14,6 +14,15 @@ name: _copilot-setup-steps
 
 on:
   workflow_call:
+    inputs:
+      runner_label:
+        description: >-
+          GitHub Actions runner label to run the job(s) on. Defaults to
+          ubuntu-latest. Pass a RunsOn label (see runs-on.com job labels
+          docs) to opt the calling repo into self-hosted runners.
+        type: string
+        required: false
+        default: ubuntu-latest
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -25,7 +34,7 @@ permissions:
 jobs:
   copilot-setup-steps:
     name: Copilot Setup Steps
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/best-practices.yml
+++ b/.github/workflows/best-practices.yml
@@ -8,6 +8,14 @@ name: Best Practices Recommender
 on:
   workflow_call:
     inputs:
+      runner_label:
+        description: >-
+          GitHub Actions runner label to run the job(s) on. Defaults to
+          ubuntu-latest. Pass a RunsOn label (see runs-on.com job labels
+          docs) to opt the calling repo into self-hosted runners.
+        type: string
+        required: false
+        default: ubuntu-latest
       daily_run_limit:
         description: "Max workflow runs per day (0 to disable)"
         type: string
@@ -29,7 +37,7 @@ concurrency:
 jobs:
   check-recent-activity:
     name: Check for recent human activity
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     permissions:
       contents: read
       issues: read
@@ -53,7 +61,7 @@ jobs:
 
   check-daily-limit:
     name: Check daily run limit
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     permissions:
       actions: read
     outputs:
@@ -81,7 +89,7 @@ jobs:
     name: Audit and recommend
     needs: [check-recent-activity, check-daily-limit]
     if: needs.check-recent-activity.outputs.should_run == 'true' && needs.check-daily-limit.outputs.should_run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/best-practices.yml
+++ b/.github/workflows/best-practices.yml
@@ -37,7 +37,7 @@ concurrency:
 jobs:
   check-recent-activity:
     name: Check for recent human activity
-    runs-on: ${{ inputs.runner_label }}
+    runs-on: ${{ inputs.runner_label || 'ubuntu-latest' }}
     permissions:
       contents: read
       issues: read
@@ -61,7 +61,7 @@ jobs:
 
   check-daily-limit:
     name: Check daily run limit
-    runs-on: ${{ inputs.runner_label }}
+    runs-on: ${{ inputs.runner_label || 'ubuntu-latest' }}
     permissions:
       actions: read
     outputs:
@@ -89,7 +89,7 @@ jobs:
     name: Audit and recommend
     needs: [check-recent-activity, check-daily-limit]
     if: needs.check-recent-activity.outputs.should_run == 'true' && needs.check-daily-limit.outputs.should_run == 'true'
-    runs-on: ${{ inputs.runner_label }}
+    runs-on: ${{ inputs.runner_label || 'ubuntu-latest' }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/ci-fail-issue.yml
+++ b/.github/workflows/ci-fail-issue.yml
@@ -42,7 +42,7 @@ concurrency:
 jobs:
   should-create:
     name: Check eligibility
-    runs-on: ${{ inputs.runner_label }}
+    runs-on: ${{ inputs.runner_label || 'ubuntu-latest' }}
     permissions:
       actions: read
       contents: read
@@ -72,7 +72,7 @@ jobs:
     name: Create failure issue
     needs: should-create
     if: needs.should-create.outputs.eligible == 'true'
-    runs-on: ${{ inputs.runner_label }}
+    runs-on: ${{ inputs.runner_label || 'ubuntu-latest' }}
     permissions:
       actions: read
       issues: write

--- a/.github/workflows/ci-fail-issue.yml
+++ b/.github/workflows/ci-fail-issue.yml
@@ -15,6 +15,14 @@ name: CI Fail Issue
 on:
   workflow_call:
     inputs:
+      runner_label:
+        description: >-
+          GitHub Actions runner label to run the job(s) on. Defaults to
+          ubuntu-latest. Pass a RunsOn label (see runs-on.com job labels
+          docs) to opt the calling repo into self-hosted runners.
+        type: string
+        required: false
+        default: ubuntu-latest
       workflow_name:
         description: "Name of the CI workflow that failed"
         type: string
@@ -34,7 +42,7 @@ concurrency:
 jobs:
   should-create:
     name: Check eligibility
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     permissions:
       actions: read
       contents: read
@@ -64,7 +72,7 @@ jobs:
     name: Create failure issue
     needs: should-create
     if: needs.should-create.outputs.eligible == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     permissions:
       actions: read
       issues: write

--- a/.github/workflows/ci-fix.yml
+++ b/.github/workflows/ci-fix.yml
@@ -57,7 +57,7 @@ jobs:
       github.actor != 'renovate[bot]' &&
       github.actor != 'dependabot[bot]' &&
       github.actor != 'copilot[bot]'
-    runs-on: ${{ inputs.runner_label }}
+    runs-on: ${{ inputs.runner_label || 'ubuntu-latest' }}
     permissions:
       pull-requests: read
       issues: read
@@ -94,7 +94,7 @@ jobs:
 
   check-daily-limit:
     name: Check daily run limit
-    runs-on: ${{ inputs.runner_label }}
+    runs-on: ${{ inputs.runner_label || 'ubuntu-latest' }}
     permissions:
       actions: read
     outputs:
@@ -125,7 +125,7 @@ jobs:
       github.event.workflow_run.head_repository.full_name == github.repository &&
       needs.should-fix.outputs.should_run == 'true' &&
       needs.check-daily-limit.outputs.should_run == 'true'
-    runs-on: ${{ inputs.runner_label }}
+    runs-on: ${{ inputs.runner_label || 'ubuntu-latest' }}
     permissions:
       pull-requests: write
       issues: write
@@ -154,7 +154,7 @@ jobs:
       github.event.workflow_run.head_repository.full_name == github.repository &&
       needs.should-fix.outputs.should_run == 'true' &&
       needs.check-daily-limit.outputs.should_run == 'true'
-    runs-on: ${{ inputs.runner_label }}
+    runs-on: ${{ inputs.runner_label || 'ubuntu-latest' }}
     permissions:
       actions: read
     outputs:
@@ -185,7 +185,7 @@ jobs:
       github.event.workflow_run.head_repository.full_name == github.repository &&
       needs.should-fix.outputs.should_run == 'true' &&
       needs.check-daily-limit.outputs.should_run == 'true'
-    runs-on: ${{ inputs.runner_label }}
+    runs-on: ${{ inputs.runner_label || 'ubuntu-latest' }}
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/ci-fix.yml
+++ b/.github/workflows/ci-fix.yml
@@ -11,6 +11,14 @@ name: CI Fix (Claude)
 on:
   workflow_call:
     inputs:
+      runner_label:
+        description: >-
+          GitHub Actions runner label to run the job(s) on. Defaults to
+          ubuntu-latest. Pass a RunsOn label (see runs-on.com job labels
+          docs) to opt the calling repo into self-hosted runners.
+        type: string
+        required: false
+        default: ubuntu-latest
       daily_run_limit:
         description: "Max workflow runs per day (0 to disable)"
         type: string
@@ -49,7 +57,7 @@ jobs:
       github.actor != 'renovate[bot]' &&
       github.actor != 'dependabot[bot]' &&
       github.actor != 'copilot[bot]'
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     permissions:
       pull-requests: read
       issues: read
@@ -86,7 +94,7 @@ jobs:
 
   check-daily-limit:
     name: Check daily run limit
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     permissions:
       actions: read
     outputs:
@@ -117,7 +125,7 @@ jobs:
       github.event.workflow_run.head_repository.full_name == github.repository &&
       needs.should-fix.outputs.should_run == 'true' &&
       needs.check-daily-limit.outputs.should_run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     permissions:
       pull-requests: write
       issues: write
@@ -146,7 +154,7 @@ jobs:
       github.event.workflow_run.head_repository.full_name == github.repository &&
       needs.should-fix.outputs.should_run == 'true' &&
       needs.check-daily-limit.outputs.should_run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     permissions:
       actions: read
     outputs:
@@ -177,7 +185,7 @@ jobs:
       github.event.workflow_run.head_repository.full_name == github.repository &&
       needs.should-fix.outputs.should_run == 'true' &&
       needs.check-daily-limit.outputs.should_run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -18,6 +18,14 @@ on:
   # To fully remove: delete this file and all caller references.
   workflow_call:
     inputs:
+      runner_label:
+        description: >-
+          GitHub Actions runner label to run the job(s) on. Defaults to
+          ubuntu-latest. Pass a RunsOn label (see runs-on.com job labels
+          docs) to opt the calling repo into self-hosted runners.
+        type: string
+        required: false
+        default: ubuntu-latest
       dummy:
         type: string
         description: "This workflow is deprecated and will not run"
@@ -39,7 +47,7 @@ jobs:
   check-daily-limit:
     if: false
     name: Check daily run limit
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     permissions:
       actions: read
     outputs:
@@ -74,7 +82,7 @@ jobs:
     #   !contains(github.event.pull_request.labels.*.name, 'ai:skip-review')
     name: Claude Code Review
     needs: check-daily-limit
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     permissions:
       actions: read
       contents: read
@@ -148,7 +156,7 @@ jobs:
     #   github.event.comment != null &&
     #   contains(github.event.comment.body, '@claude')
     name: Claude Interactive
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/code-simplifier.yml
+++ b/.github/workflows/code-simplifier.yml
@@ -10,6 +10,14 @@ name: Code Simplifier
 on:
   workflow_call:
     inputs:
+      runner_label:
+        description: >-
+          GitHub Actions runner label to run the job(s) on. Defaults to
+          ubuntu-latest. Pass a RunsOn label (see runs-on.com job labels
+          docs) to opt the calling repo into self-hosted runners.
+        type: string
+        required: false
+        default: ubuntu-latest
       daily_run_limit:
         description: "Max workflow runs per day (0 to disable)"
         type: string
@@ -31,7 +39,7 @@ concurrency:
 jobs:
   check-pr-ceiling:
     name: Check bot PR ceiling
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     permissions:
       pull-requests: read
     outputs:
@@ -54,7 +62,7 @@ jobs:
 
   check-daily-limit:
     name: Check daily run limit
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     permissions:
       actions: read
     outputs:
@@ -81,7 +89,7 @@ jobs:
   simplify:
     needs: [check-pr-ceiling, check-daily-limit]
     if: needs.check-pr-ceiling.outputs.allowed == 'true' && needs.check-daily-limit.outputs.should_run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/code-simplifier.yml
+++ b/.github/workflows/code-simplifier.yml
@@ -39,7 +39,7 @@ concurrency:
 jobs:
   check-pr-ceiling:
     name: Check bot PR ceiling
-    runs-on: ${{ inputs.runner_label }}
+    runs-on: ${{ inputs.runner_label || 'ubuntu-latest' }}
     permissions:
       pull-requests: read
     outputs:
@@ -62,7 +62,7 @@ jobs:
 
   check-daily-limit:
     name: Check daily run limit
-    runs-on: ${{ inputs.runner_label }}
+    runs-on: ${{ inputs.runner_label || 'ubuntu-latest' }}
     permissions:
       actions: read
     outputs:
@@ -89,7 +89,7 @@ jobs:
   simplify:
     needs: [check-pr-ceiling, check-daily-limit]
     if: needs.check-pr-ceiling.outputs.allowed == 'true' && needs.check-daily-limit.outputs.should_run == 'true'
-    runs-on: ${{ inputs.runner_label }}
+    runs-on: ${{ inputs.runner_label || 'ubuntu-latest' }}
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -2,11 +2,20 @@ name: Copilot Setup Steps
 
 on:
   workflow_call:
+    inputs:
+      runner_label:
+        description: >-
+          GitHub Actions runner label to run the job(s) on. Defaults to
+          ubuntu-latest. Pass a RunsOn label (see runs-on.com job labels
+          docs) to opt the calling repo into self-hosted runners.
+        type: string
+        required: false
+        default: ubuntu-latest
 
 jobs:
   copilot-setup-steps:
     name: Copilot Setup Steps
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     steps:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2

--- a/.github/workflows/final-pr-review.yml
+++ b/.github/workflows/final-pr-review.yml
@@ -48,7 +48,7 @@ jobs:
       github.actor != 'renovate[bot]' &&
       github.actor != 'dependabot[bot]' &&
       github.actor != 'claude[bot]'
-    runs-on: ${{ inputs.runner_label }}
+    runs-on: ${{ inputs.runner_label || 'ubuntu-latest' }}
     permissions:
       pull-requests: read
       issues: read
@@ -74,7 +74,7 @@ jobs:
 
   check-daily-limit:
     name: Check daily run limit
-    runs-on: ${{ inputs.runner_label }}
+    runs-on: ${{ inputs.runner_label || 'ubuntu-latest' }}
     permissions:
       actions: read
     outputs:
@@ -102,7 +102,7 @@ jobs:
     name: Claude Final Review
     needs: [gate-check, check-daily-limit]
     if: needs.gate-check.outputs.should_run == 'true' && needs.check-daily-limit.outputs.should_run == 'true'
-    runs-on: ${{ inputs.runner_label }}
+    runs-on: ${{ inputs.runner_label || 'ubuntu-latest' }}
     permissions:
       checks: read
       contents: read
@@ -155,7 +155,7 @@ jobs:
     name: Mark as reviewed
     needs: [gate-check, review]
     if: needs.gate-check.outputs.should_run == 'true'
-    runs-on: ${{ inputs.runner_label }}
+    runs-on: ${{ inputs.runner_label || 'ubuntu-latest' }}
     permissions:
       pull-requests: write
       issues: write

--- a/.github/workflows/final-pr-review.yml
+++ b/.github/workflows/final-pr-review.yml
@@ -9,6 +9,14 @@ name: Final PR Review
 on:
   workflow_call:
     inputs:
+      runner_label:
+        description: >-
+          GitHub Actions runner label to run the job(s) on. Defaults to
+          ubuntu-latest. Pass a RunsOn label (see runs-on.com job labels
+          docs) to opt the calling repo into self-hosted runners.
+        type: string
+        required: false
+        default: ubuntu-latest
       daily_run_limit:
         description: "Max workflow runs per day (0 to disable)"
         type: string
@@ -40,7 +48,7 @@ jobs:
       github.actor != 'renovate[bot]' &&
       github.actor != 'dependabot[bot]' &&
       github.actor != 'claude[bot]'
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     permissions:
       pull-requests: read
       issues: read
@@ -66,7 +74,7 @@ jobs:
 
   check-daily-limit:
     name: Check daily run limit
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     permissions:
       actions: read
     outputs:
@@ -94,7 +102,7 @@ jobs:
     name: Claude Final Review
     needs: [gate-check, check-daily-limit]
     if: needs.gate-check.outputs.should_run == 'true' && needs.check-daily-limit.outputs.should_run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     permissions:
       checks: read
       contents: read
@@ -147,7 +155,7 @@ jobs:
     name: Mark as reviewed
     needs: [gate-check, review]
     if: needs.gate-check.outputs.should_run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     permissions:
       pull-requests: write
       issues: write

--- a/.github/workflows/issue-hygiene.yml
+++ b/.github/workflows/issue-hygiene.yml
@@ -34,7 +34,7 @@ concurrency:
 
 jobs:
   hygiene:
-    runs-on: ${{ inputs.runner_label }}
+    runs-on: ${{ inputs.runner_label || 'ubuntu-latest' }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/issue-hygiene.yml
+++ b/.github/workflows/issue-hygiene.yml
@@ -9,6 +9,15 @@ name: Issue Hygiene
 
 on:
   workflow_call:
+    inputs:
+      runner_label:
+        description: >-
+          GitHub Actions runner label to run the job(s) on. Defaults to
+          ubuntu-latest. Pass a RunsOn label (see runs-on.com job labels
+          docs) to opt the calling repo into self-hosted runners.
+        type: string
+        required: false
+        default: ubuntu-latest
   workflow_dispatch:
 
 # Workflow-level permissions set the maximum for all jobs.
@@ -25,7 +34,7 @@ concurrency:
 
 jobs:
   hygiene:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/issue-linker.yml
+++ b/.github/workflows/issue-linker.yml
@@ -10,6 +10,14 @@ name: Issue Linker
 on:
   workflow_call:
     inputs:
+      runner_label:
+        description: >-
+          GitHub Actions runner label to run the job(s) on. Defaults to
+          ubuntu-latest. Pass a RunsOn label (see runs-on.com job labels
+          docs) to opt the calling repo into self-hosted runners.
+        type: string
+        required: false
+        default: ubuntu-latest
       model:
         description: "Claude model to use (overrides AI_MODEL_ISSUES and AI_MODEL vars)"
         type: string
@@ -39,7 +47,7 @@ jobs:
       github.actor != 'renovate[bot]' &&
       github.actor != 'dependabot[bot]' &&
       github.actor != 'claude[bot]'
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     permissions:
       contents: read
       issues: read
@@ -68,7 +76,7 @@ jobs:
     name: Link or close issues
     needs: check-eligibility
     if: needs.check-eligibility.outputs.should_run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/issue-linker.yml
+++ b/.github/workflows/issue-linker.yml
@@ -47,7 +47,7 @@ jobs:
       github.actor != 'renovate[bot]' &&
       github.actor != 'dependabot[bot]' &&
       github.actor != 'claude[bot]'
-    runs-on: ${{ inputs.runner_label }}
+    runs-on: ${{ inputs.runner_label || 'ubuntu-latest' }}
     permissions:
       contents: read
       issues: read
@@ -76,7 +76,7 @@ jobs:
     name: Link or close issues
     needs: check-eligibility
     if: needs.check-eligibility.outputs.should_run == 'true'
-    runs-on: ${{ inputs.runner_label }}
+    runs-on: ${{ inputs.runner_label || 'ubuntu-latest' }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/issue-resolver.yml
+++ b/.github/workflows/issue-resolver.yml
@@ -9,6 +9,14 @@ name: Issue Resolver (Claude)
 on:
   workflow_call:
     inputs:
+      runner_label:
+        description: >-
+          GitHub Actions runner label to run the job(s) on. Defaults to
+          ubuntu-latest. Pass a RunsOn label (see runs-on.com job labels
+          docs) to opt the calling repo into self-hosted runners.
+        type: string
+        required: false
+        default: ubuntu-latest
       repo_context:
         description: "Brief description of the repository for Claude's context"
         type: string
@@ -57,7 +65,7 @@ concurrency:
 jobs:
   eligibility-check:
     name: Check eligibility
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     permissions:
       issues: read
       pull-requests: read
@@ -95,7 +103,7 @@ jobs:
     name: Claude Resolve
     needs: eligibility-check
     if: needs.eligibility-check.outputs.should_run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/issue-sweeper.yml
+++ b/.github/workflows/issue-sweeper.yml
@@ -8,6 +8,15 @@ name: Issue Sweeper
 
 on:
   workflow_call:
+    inputs:
+      runner_label:
+        description: >-
+          GitHub Actions runner label to run the job(s) on. Defaults to
+          ubuntu-latest. Pass a RunsOn label (see runs-on.com job labels
+          docs) to opt the calling repo into self-hosted runners.
+        type: string
+        required: false
+        default: ubuntu-latest
   workflow_dispatch:
 
 # Workflow-level permissions set the maximum for all jobs.
@@ -24,7 +33,7 @@ concurrency:
 
 jobs:
   sweep:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/issue-sweeper.yml
+++ b/.github/workflows/issue-sweeper.yml
@@ -33,7 +33,7 @@ concurrency:
 
 jobs:
   sweep:
-    runs-on: ${{ inputs.runner_label }}
+    runs-on: ${{ inputs.runner_label || 'ubuntu-latest' }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -4,6 +4,14 @@ name: "Issue Triage"
 on:
   workflow_call:
     inputs:
+      runner_label:
+        description: >-
+          GitHub Actions runner label to run the job(s) on. Defaults to
+          ubuntu-latest. Pass a RunsOn label (see runs-on.com job labels
+          docs) to opt the calling repo into self-hosted runners.
+        type: string
+        required: false
+        default: ubuntu-latest
       issue_number:
         description: "Issue number to triage (dispatch pattern; 0 = from event payload)"
         type: string
@@ -22,7 +30,7 @@ concurrency:
 
 jobs:
   triage:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -30,7 +30,7 @@ concurrency:
 
 jobs:
   triage:
-    runs-on: ${{ inputs.runner_label }}
+    runs-on: ${{ inputs.runner_label || 'ubuntu-latest' }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   sync:
-    runs-on: ${{ inputs.runner_label }}
+    runs-on: ${{ inputs.runner_label || 'ubuntu-latest' }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -3,6 +3,15 @@ name: "Label Sync"
 
 on:
   workflow_call:
+    inputs:
+      runner_label:
+        description: >-
+          GitHub Actions runner label to run the job(s) on. Defaults to
+          ubuntu-latest. Pass a RunsOn label (see runs-on.com job labels
+          docs) to opt the calling repo into self-hosted runners.
+        type: string
+        required: false
+        default: ubuntu-latest
   workflow_dispatch:
 
 # Workflow-level permissions set the maximum for all jobs.
@@ -17,7 +26,7 @@ concurrency:
 
 jobs:
   sync:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/next-steps.yml
+++ b/.github/workflows/next-steps.yml
@@ -40,7 +40,7 @@ concurrency:
 jobs:
   check-pr-ceiling:
     name: Check bot PR ceiling
-    runs-on: ${{ inputs.runner_label }}
+    runs-on: ${{ inputs.runner_label || 'ubuntu-latest' }}
     permissions:
       pull-requests: read
     outputs:
@@ -63,7 +63,7 @@ jobs:
 
   check-daily-limit:
     name: Check daily run limit
-    runs-on: ${{ inputs.runner_label }}
+    runs-on: ${{ inputs.runner_label || 'ubuntu-latest' }}
     permissions:
       actions: read
     outputs:
@@ -90,7 +90,7 @@ jobs:
   analyze:
     needs: [check-pr-ceiling, check-daily-limit]
     if: needs.check-pr-ceiling.outputs.allowed == 'true' && needs.check-daily-limit.outputs.should_run == 'true'
-    runs-on: ${{ inputs.runner_label }}
+    runs-on: ${{ inputs.runner_label || 'ubuntu-latest' }}
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/next-steps.yml
+++ b/.github/workflows/next-steps.yml
@@ -10,6 +10,14 @@ name: Next Steps
 on:
   workflow_call:
     inputs:
+      runner_label:
+        description: >-
+          GitHub Actions runner label to run the job(s) on. Defaults to
+          ubuntu-latest. Pass a RunsOn label (see runs-on.com job labels
+          docs) to opt the calling repo into self-hosted runners.
+        type: string
+        required: false
+        default: ubuntu-latest
       daily_run_limit:
         description: "Max workflow runs per day (0 to disable)"
         type: string
@@ -32,7 +40,7 @@ concurrency:
 jobs:
   check-pr-ceiling:
     name: Check bot PR ceiling
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     permissions:
       pull-requests: read
     outputs:
@@ -55,7 +63,7 @@ jobs:
 
   check-daily-limit:
     name: Check daily run limit
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     permissions:
       actions: read
     outputs:
@@ -82,7 +90,7 @@ jobs:
   analyze:
     needs: [check-pr-ceiling, check-daily-limit]
     if: needs.check-pr-ceiling.outputs.allowed == 'true' && needs.check-daily-limit.outputs.should_run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/notify-ai-pr.yml
+++ b/.github/workflows/notify-ai-pr.yml
@@ -36,7 +36,7 @@ permissions:
 jobs:
   notify:
     if: github.event.pull_request.user.login == inputs.bot_login
-    runs-on: ${{ inputs.runner_label }}
+    runs-on: ${{ inputs.runner_label || 'ubuntu-latest' }}
     permissions:
       pull-requests: read
     steps:

--- a/.github/workflows/notify-ai-pr.yml
+++ b/.github/workflows/notify-ai-pr.yml
@@ -8,6 +8,14 @@ name: AI PR Notification
 on:
   workflow_call:
     inputs:
+      runner_label:
+        description: >-
+          GitHub Actions runner label to run the job(s) on. Defaults to
+          ubuntu-latest. Pass a RunsOn label (see runs-on.com job labels
+          docs) to opt the calling repo into self-hosted runners.
+        type: string
+        required: false
+        default: ubuntu-latest
       bot_login:
         description: "Bot login to filter PRs for (e.g., claude[bot], copilot[bot])"
         type: string
@@ -28,7 +36,7 @@ permissions:
 jobs:
   notify:
     if: github.event.pull_request.user.login == inputs.bot_login
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     permissions:
       pull-requests: read
     steps:

--- a/.github/workflows/post-merge-docs-review.yml
+++ b/.github/workflows/post-merge-docs-review.yml
@@ -43,7 +43,7 @@ concurrency:
 jobs:
   check-pr-ceiling:
     name: Check bot PR ceiling
-    runs-on: ${{ inputs.runner_label }}
+    runs-on: ${{ inputs.runner_label || 'ubuntu-latest' }}
     permissions:
       pull-requests: read
     outputs:
@@ -66,7 +66,7 @@ jobs:
 
   check-relevance:
     name: Check doc relevance
-    runs-on: ${{ inputs.runner_label }}
+    runs-on: ${{ inputs.runner_label || 'ubuntu-latest' }}
     permissions:
       contents: read
     outputs:
@@ -91,7 +91,7 @@ jobs:
 
   check-daily-limit:
     name: Check daily run limit
-    runs-on: ${{ inputs.runner_label }}
+    runs-on: ${{ inputs.runner_label || 'ubuntu-latest' }}
     permissions:
       actions: read
     outputs:
@@ -119,7 +119,7 @@ jobs:
     name: Review and fix docs
     needs: [check-pr-ceiling, check-relevance, check-daily-limit]
     if: needs.check-pr-ceiling.outputs.allowed == 'true' && needs.check-relevance.outputs.is_relevant == 'true' && needs.check-daily-limit.outputs.should_run == 'true'
-    runs-on: ${{ inputs.runner_label }}
+    runs-on: ${{ inputs.runner_label || 'ubuntu-latest' }}
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/post-merge-docs-review.yml
+++ b/.github/workflows/post-merge-docs-review.yml
@@ -11,6 +11,14 @@ name: Post-Merge Docs Review
 on:
   workflow_call:
     inputs:
+      runner_label:
+        description: >-
+          GitHub Actions runner label to run the job(s) on. Defaults to
+          ubuntu-latest. Pass a RunsOn label (see runs-on.com job labels
+          docs) to opt the calling repo into self-hosted runners.
+        type: string
+        required: false
+        default: ubuntu-latest
       daily_run_limit:
         description: "Max workflow runs per day (0 to disable)"
         type: string
@@ -35,7 +43,7 @@ concurrency:
 jobs:
   check-pr-ceiling:
     name: Check bot PR ceiling
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     permissions:
       pull-requests: read
     outputs:
@@ -58,7 +66,7 @@ jobs:
 
   check-relevance:
     name: Check doc relevance
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     permissions:
       contents: read
     outputs:
@@ -83,7 +91,7 @@ jobs:
 
   check-daily-limit:
     name: Check daily run limit
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     permissions:
       actions: read
     outputs:
@@ -111,7 +119,7 @@ jobs:
     name: Review and fix docs
     needs: [check-pr-ceiling, check-relevance, check-daily-limit]
     if: needs.check-pr-ceiling.outputs.allowed == 'true' && needs.check-relevance.outputs.is_relevant == 'true' && needs.check-daily-limit.outputs.should_run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -43,7 +43,7 @@ concurrency:
 jobs:
   check-pr-ceiling:
     name: Check bot PR ceiling
-    runs-on: ${{ inputs.runner_label }}
+    runs-on: ${{ inputs.runner_label || 'ubuntu-latest' }}
     permissions:
       pull-requests: read
     outputs:
@@ -66,7 +66,7 @@ jobs:
 
   check-test-infra:
     name: Check test infrastructure
-    runs-on: ${{ inputs.runner_label }}
+    runs-on: ${{ inputs.runner_label || 'ubuntu-latest' }}
     permissions:
       contents: read
     outputs:
@@ -91,7 +91,7 @@ jobs:
 
   check-daily-limit:
     name: Check daily run limit
-    runs-on: ${{ inputs.runner_label }}
+    runs-on: ${{ inputs.runner_label || 'ubuntu-latest' }}
     permissions:
       actions: read
     outputs:
@@ -119,7 +119,7 @@ jobs:
     name: Analyze and create tests
     needs: [check-pr-ceiling, check-test-infra, check-daily-limit]
     if: needs.check-pr-ceiling.outputs.allowed == 'true' && needs.check-test-infra.outputs.has_tests == 'true' && needs.check-daily-limit.outputs.should_run == 'true'
-    runs-on: ${{ inputs.runner_label }}
+    runs-on: ${{ inputs.runner_label || 'ubuntu-latest' }}
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -11,6 +11,14 @@ name: Post-Merge Tests
 on:
   workflow_call:
     inputs:
+      runner_label:
+        description: >-
+          GitHub Actions runner label to run the job(s) on. Defaults to
+          ubuntu-latest. Pass a RunsOn label (see runs-on.com job labels
+          docs) to opt the calling repo into self-hosted runners.
+        type: string
+        required: false
+        default: ubuntu-latest
       daily_run_limit:
         description: "Max workflow runs per day (0 to disable)"
         type: string
@@ -35,7 +43,7 @@ concurrency:
 jobs:
   check-pr-ceiling:
     name: Check bot PR ceiling
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     permissions:
       pull-requests: read
     outputs:
@@ -58,7 +66,7 @@ jobs:
 
   check-test-infra:
     name: Check test infrastructure
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     permissions:
       contents: read
     outputs:
@@ -83,7 +91,7 @@ jobs:
 
   check-daily-limit:
     name: Check daily run limit
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     permissions:
       actions: read
     outputs:
@@ -111,7 +119,7 @@ jobs:
     name: Analyze and create tests
     needs: [check-pr-ceiling, check-test-infra, check-daily-limit]
     if: needs.check-pr-ceiling.outputs.allowed == 'true' && needs.check-test-infra.outputs.has_tests == 'true' && needs.check-daily-limit.outputs.should_run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/project-router.yml
+++ b/.github/workflows/project-router.yml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   route:
-    runs-on: ${{ inputs.runner_label }}
+    runs-on: ${{ inputs.runner_label || 'ubuntu-latest' }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/project-router.yml
+++ b/.github/workflows/project-router.yml
@@ -3,6 +3,15 @@ name: "Project Router"
 
 on:
   workflow_call:
+    inputs:
+      runner_label:
+        description: >-
+          GitHub Actions runner label to run the job(s) on. Defaults to
+          ubuntu-latest. Pass a RunsOn label (see runs-on.com job labels
+          docs) to opt the calling repo into self-hosted runners.
+        type: string
+        required: false
+        default: ubuntu-latest
   workflow_dispatch:
 
 # Workflow-level permissions set the maximum for all jobs.
@@ -18,7 +27,7 @@ concurrency:
 
 jobs:
   route:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/repo-orchestrator.yml
+++ b/.github/workflows/repo-orchestrator.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   orchestrate:
-    runs-on: ${{ inputs.runner_label }}
+    runs-on: ${{ inputs.runner_label || 'ubuntu-latest' }}
     permissions:
       actions: write
       contents: read

--- a/.github/workflows/repo-orchestrator.yml
+++ b/.github/workflows/repo-orchestrator.yml
@@ -3,6 +3,15 @@ name: "Repository Orchestrator"
 
 on:
   workflow_call:
+    inputs:
+      runner_label:
+        description: >-
+          GitHub Actions runner label to run the job(s) on. Defaults to
+          ubuntu-latest. Pass a RunsOn label (see runs-on.com job labels
+          docs) to opt the calling repo into self-hosted runners.
+        type: string
+        required: false
+        default: ubuntu-latest
   workflow_dispatch:
 
 # Workflow-level permissions set the maximum for all jobs.
@@ -17,7 +26,7 @@ concurrency:
 
 jobs:
   orchestrate:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner_label }}
     permissions:
       actions: write
       contents: read

--- a/.github/workflows/suite-all.yml
+++ b/.github/workflows/suite-all.yml
@@ -64,7 +64,7 @@ jobs:
       inputs.caller_event == 'check_suite'
     uses: ./.github/workflows/suite-pr.yml
     with:
-      runner_label: ${{ inputs.runner_label }}
+      runner_label: ${{ inputs.runner_label || 'ubuntu-latest' }}
       caller_event: ${{ inputs.caller_event }}
       allowed_bots: ${{ inputs.allowed_bots }}
     secrets: inherit
@@ -74,6 +74,6 @@ jobs:
     if: inputs.caller_event == 'workflow_dispatch'
     uses: ./.github/workflows/suite-post-merge.yml
     with:
-      runner_label: ${{ inputs.runner_label }}
+      runner_label: ${{ inputs.runner_label || 'ubuntu-latest' }}
       commit_sha: ${{ inputs.commit_sha }}
     secrets: inherit

--- a/.github/workflows/suite-all.yml
+++ b/.github/workflows/suite-all.yml
@@ -22,6 +22,14 @@ name: "Suite: All"
 on:
   workflow_call:
     inputs:
+      runner_label:
+        description: >-
+          GitHub Actions runner label to run the job(s) on. Defaults to
+          ubuntu-latest. Pass a RunsOn label (see runs-on.com job labels
+          docs) to opt the calling repo into self-hosted runners.
+        type: string
+        required: false
+        default: ubuntu-latest
       caller_event:
         description: "Event that triggered the caller (pass github.event_name)"
         type: string
@@ -56,6 +64,7 @@ jobs:
       inputs.caller_event == 'check_suite'
     uses: ./.github/workflows/suite-pr.yml
     with:
+      runner_label: ${{ inputs.runner_label }}
       caller_event: ${{ inputs.caller_event }}
       allowed_bots: ${{ inputs.allowed_bots }}
     secrets: inherit
@@ -65,5 +74,6 @@ jobs:
     if: inputs.caller_event == 'workflow_dispatch'
     uses: ./.github/workflows/suite-post-merge.yml
     with:
+      runner_label: ${{ inputs.runner_label }}
       commit_sha: ${{ inputs.commit_sha }}
     secrets: inherit

--- a/.github/workflows/suite-ci.yml
+++ b/.github/workflows/suite-ci.yml
@@ -20,6 +20,14 @@ name: "Suite: CI Failures"
 on:
   workflow_call:
     inputs:
+      runner_label:
+        description: >-
+          GitHub Actions runner label to run the job(s) on. Defaults to
+          ubuntu-latest. Pass a RunsOn label (see runs-on.com job labels
+          docs) to opt the calling repo into self-hosted runners.
+        type: string
+        required: false
+        default: ubuntu-latest
       repo_context:
         description: "Brief description of the repository"
         type: string
@@ -55,6 +63,7 @@ jobs:
       github.event.workflow_run.head_repository.full_name == github.repository
     uses: ./.github/workflows/ci-fix.yml
     with:
+      runner_label: ${{ inputs.runner_label }}
       repo_context: ${{ inputs.repo_context }}
       ci_structure: ${{ inputs.ci_structure }}
       extra_tools: ${{ inputs.extra_tools }}
@@ -66,5 +75,6 @@ jobs:
       github.event.workflow_run.head_branch == 'main'
     uses: ./.github/workflows/ci-fail-issue.yml
     with:
+      runner_label: ${{ inputs.runner_label }}
       workflow_name: ${{ inputs.workflow_name }}
     secrets: inherit

--- a/.github/workflows/suite-ci.yml
+++ b/.github/workflows/suite-ci.yml
@@ -63,7 +63,7 @@ jobs:
       github.event.workflow_run.head_repository.full_name == github.repository
     uses: ./.github/workflows/ci-fix.yml
     with:
-      runner_label: ${{ inputs.runner_label }}
+      runner_label: ${{ inputs.runner_label || 'ubuntu-latest' }}
       repo_context: ${{ inputs.repo_context }}
       ci_structure: ${{ inputs.ci_structure }}
       extra_tools: ${{ inputs.extra_tools }}
@@ -75,6 +75,6 @@ jobs:
       github.event.workflow_run.head_branch == 'main'
     uses: ./.github/workflows/ci-fail-issue.yml
     with:
-      runner_label: ${{ inputs.runner_label }}
+      runner_label: ${{ inputs.runner_label || 'ubuntu-latest' }}
       workflow_name: ${{ inputs.workflow_name }}
     secrets: inherit

--- a/.github/workflows/suite-post-merge.yml
+++ b/.github/workflows/suite-post-merge.yml
@@ -42,13 +42,13 @@ jobs:
   docs-review:
     uses: ./.github/workflows/post-merge-docs-review.yml
     with:
-      runner_label: ${{ inputs.runner_label }}
+      runner_label: ${{ inputs.runner_label || 'ubuntu-latest' }}
       commit_sha: ${{ inputs.commit_sha }}
     secrets: inherit
 
   tests-review:
     uses: ./.github/workflows/post-merge-tests.yml
     with:
-      runner_label: ${{ inputs.runner_label }}
+      runner_label: ${{ inputs.runner_label || 'ubuntu-latest' }}
       commit_sha: ${{ inputs.commit_sha }}
     secrets: inherit

--- a/.github/workflows/suite-post-merge.yml
+++ b/.github/workflows/suite-post-merge.yml
@@ -16,6 +16,14 @@ name: "Suite: Post-Merge Reviews"
 on:
   workflow_call:
     inputs:
+      runner_label:
+        description: >-
+          GitHub Actions runner label to run the job(s) on. Defaults to
+          ubuntu-latest. Pass a RunsOn label (see runs-on.com job labels
+          docs) to opt the calling repo into self-hosted runners.
+        type: string
+        required: false
+        default: ubuntu-latest
       commit_sha:
         description: "Commit SHA to review (pass inputs.commit_sha from workflow_dispatch)"
         type: string
@@ -34,11 +42,13 @@ jobs:
   docs-review:
     uses: ./.github/workflows/post-merge-docs-review.yml
     with:
+      runner_label: ${{ inputs.runner_label }}
       commit_sha: ${{ inputs.commit_sha }}
     secrets: inherit
 
   tests-review:
     uses: ./.github/workflows/post-merge-tests.yml
     with:
+      runner_label: ${{ inputs.runner_label }}
       commit_sha: ${{ inputs.commit_sha }}
     secrets: inherit

--- a/.github/workflows/suite-pr.yml
+++ b/.github/workflows/suite-pr.yml
@@ -52,6 +52,6 @@ jobs:
       inputs.caller_event == 'check_suite'
     uses: ./.github/workflows/final-pr-review.yml
     with:
-      runner_label: ${{ inputs.runner_label }}
+      runner_label: ${{ inputs.runner_label || 'ubuntu-latest' }}
       allowed_bots: ${{ inputs.allowed_bots }}
     secrets: inherit

--- a/.github/workflows/suite-pr.yml
+++ b/.github/workflows/suite-pr.yml
@@ -16,6 +16,14 @@ name: "Suite: PR Reviews"
 on:
   workflow_call:
     inputs:
+      runner_label:
+        description: >-
+          GitHub Actions runner label to run the job(s) on. Defaults to
+          ubuntu-latest. Pass a RunsOn label (see runs-on.com job labels
+          docs) to opt the calling repo into self-hosted runners.
+        type: string
+        required: false
+        default: ubuntu-latest
       caller_event:
         description: "Event that triggered the caller (pass github.event_name)"
         type: string
@@ -44,5 +52,6 @@ jobs:
       inputs.caller_event == 'check_suite'
     uses: ./.github/workflows/final-pr-review.yml
     with:
+      runner_label: ${{ inputs.runner_label }}
       allowed_bots: ${{ inputs.allowed_bots }}
     secrets: inherit


### PR DESCRIPTION
## Summary

- Plumbs `runner_label` input (default `ubuntu-latest`) through every reusable `workflow_call` and through the `suite-*` orchestrators so consumer repos can opt into RunsOn self-hosted runners by passing a single label.
- Mirrors the pattern already in `JacobPEvans/.github/_*.yml` (see e.g. `_nix-validate.yml`).
- No behavior change for existing callers — they still fall through to `ubuntu-latest`.

## Why

GitHub Actions free-tier private-repo minutes are being burned on `ubuntu-latest`. The org-wide tf-runs-on infrastructure can already host these jobs on EC2 spot for ~15x less cost. The blocker for consumer repos that use `JacobPEvans/ai-workflows/*` reusables is that none of them currently expose a runner override — this PR closes that gap.

After this lands, the consumer change in (e.g.) `nix-screenpipe` is purely passing `runner_label:` to each `with:` block, mirroring how `nix-ai` and `nix-darwin` already opt in for the `JacobPEvans/.github` reusables.

## Files changed

- 21 reusables: `_ai-merge-gate`, `_copilot-setup-steps`, `best-practices`, `ci-fail-issue`, `ci-fix`, `claude-review`, `code-simplifier`, `copilot-setup-steps`, `final-pr-review`, `issue-hygiene`, `issue-linker`, `issue-resolver`, `issue-sweeper`, `issue-triage`, `label-sync`, `next-steps`, `notify-ai-pr`, `post-merge-docs-review`, `post-merge-tests`, `project-router`, `repo-orchestrator`.
- 4 suites with pass-through to children: `suite-all`, `suite-ci`, `suite-pr`, `suite-post-merge`.

Out of scope: `dogfood-*`, `smoke-test`, `test`, `update-version-tags`, `gh-aw-sync-upstream`, `*.lock.yml` — these are ai-workflows-internal utilities, not consumer-facing reusables.

## Test plan

- [ ] CI Gate green
- [ ] `dogfood-*` workflows (which do NOT pass `runner_label`) succeed — confirms the `ubuntu-latest` default is load-bearing.
- [ ] Spot-check one reusable in the Actions UI to confirm the `inputs.runner_label` block renders without errors.
- [ ] After merge: consumer migration in `JacobPEvans/nix-screenpipe` (separate PR) can pass `runner_label` to each delegated workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)