### PR TITLE
fix(ci): retarget reusable-workflow uses: refs to current org homes

### DIFF
--- a/.github/workflows/ci-fix.yml
+++ b/.github/workflows/ci-fix.yml
@@ -224,7 +224,7 @@ jobs:
         run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/ci-fix.md FAILURE_LOGS REPO_CONTEXT CI_STRUCTURE ATTEMPT_NUM WORKFLOW_NAME RUN_ID RUN_URL EVENT_NAME TRIGGER_ACTOR
 
       - name: Run Claude Code with bot attribution
-        uses: JacobPEvans/ai-workflows/.github/actions/run-claude-code@main
+        uses: dryvist/ai-workflows/.github/actions/run-claude-code@main
         with:
           prompt: ${{ steps.prompt.outputs.content }}
           model: ${{ vars.AI_MODEL_CODE || vars.AI_MODEL || 'openrouter/free' }}

--- a/.github/workflows/code-simplifier.yml
+++ b/.github/workflows/code-simplifier.yml
@@ -121,7 +121,7 @@ jobs:
         run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/code-simplifier.md WORKFLOW_NAME RUN_ID RUN_URL EVENT_NAME TRIGGER_ACTOR
 
       - name: Run Claude Code with bot attribution
-        uses: JacobPEvans/ai-workflows/.github/actions/run-claude-code@main
+        uses: dryvist/ai-workflows/.github/actions/run-claude-code@main
         with:
           prompt: ${{ steps.prompt.outputs.content }}
           model: ${{ vars.AI_MODEL_CODE || vars.AI_MODEL || 'openrouter/free' }}

--- a/.github/workflows/dogfood-best-practices.yml
+++ b/.github/workflows/dogfood-best-practices.yml
@@ -12,5 +12,5 @@ permissions:
   pull-requests: read
 jobs:
   best-practices:
-    uses: JacobPEvans/ai-workflows/.github/workflows/best-practices.yml@v0.16.0
+    uses: dryvist/ai-workflows/.github/workflows/best-practices.yml@v0.16.0
     secrets: inherit

--- a/.github/workflows/dogfood-ci.yml
+++ b/.github/workflows/dogfood-ci.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   ci-suite:
-    uses: JacobPEvans/ai-workflows/.github/workflows/suite-ci.yml@v0.16.0
+    uses: dryvist/ai-workflows/.github/workflows/suite-ci.yml@v0.16.0
     with:
       repo_context: "Reusable GitHub Actions workflows for AI-powered CI/CD automation (prompts, scripts, YAML workflows)"
       ci_structure: "test.yml (bun test for JavaScript scripts)"

--- a/.github/workflows/dogfood-issue-hygiene.yml
+++ b/.github/workflows/dogfood-issue-hygiene.yml
@@ -12,5 +12,5 @@ permissions:
   pull-requests: read
 jobs:
   hygiene:
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-hygiene.yml@v0.16.0
+    uses: dryvist/ai-workflows/.github/workflows/issue-hygiene.yml@v0.16.0
     secrets: inherit

--- a/.github/workflows/dogfood-issue-sweeper.yml
+++ b/.github/workflows/dogfood-issue-sweeper.yml
@@ -12,5 +12,5 @@ permissions:
   pull-requests: read
 jobs:
   sweep:
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-sweeper.yml@v0.16.0
+    uses: dryvist/ai-workflows/.github/workflows/issue-sweeper.yml@v0.16.0
     secrets: inherit

--- a/.github/workflows/final-pr-review.yml
+++ b/.github/workflows/final-pr-review.yml
@@ -141,7 +141,7 @@ jobs:
 
       - name: Run Claude Code with bot attribution
         if: steps.bot-check.outputs.run == 'true'
-        uses: JacobPEvans/ai-workflows/.github/actions/run-claude-code@main
+        uses: dryvist/ai-workflows/.github/actions/run-claude-code@main
         with:
           prompt: ${{ steps.prompt.outputs.content }}
           model: ${{ vars.AI_MODEL_REVIEW || vars.AI_MODEL || 'openrouter/free' }}

--- a/.github/workflows/gh-aw-pin-refresh.yml
+++ b/.github/workflows/gh-aw-pin-refresh.yml
@@ -25,7 +25,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: JacobPEvans/.github/.github/workflows/_gh-aw-pin-refresh.yml@main
+    uses: JacobPEvans-personal/.github/.github/workflows/_gh-aw-pin-refresh.yml@main
     with:
       operation: ${{ inputs.operation || 'compile' }}
     secrets:

--- a/.github/workflows/issue-resolver.yml
+++ b/.github/workflows/issue-resolver.yml
@@ -145,7 +145,7 @@ jobs:
         run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/issue-resolver.md REPO_CONTEXT ISSUE_NUMBER ISSUE_TITLE ISSUE_BODY ISSUE_LABELS ATTEMPT MAX_ATTEMPTS WORKFLOW_NAME RUN_ID RUN_URL EVENT_NAME TRIGGER_ACTOR
 
       - name: Run Claude Code with bot attribution
-        uses: JacobPEvans/ai-workflows/.github/actions/run-claude-code@main
+        uses: dryvist/ai-workflows/.github/actions/run-claude-code@main
         with:
           prompt: ${{ steps.prompt.outputs.content }}
           model: ${{ inputs.model || vars.AI_MODEL_PLAN || vars.AI_MODEL || 'openrouter/free' }}

--- a/.github/workflows/post-merge-docs-review.yml
+++ b/.github/workflows/post-merge-docs-review.yml
@@ -162,7 +162,7 @@ jobs:
         run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/post-merge-docs-review.md COMMIT_SHA REPO_NAME WORKFLOW_NAME RUN_ID RUN_URL EVENT_NAME TRIGGER_ACTOR
 
       - name: Run Claude Code with bot attribution
-        uses: JacobPEvans/ai-workflows/.github/actions/run-claude-code@main
+        uses: dryvist/ai-workflows/.github/actions/run-claude-code@main
         with:
           prompt: ${{ steps.prompt.outputs.content }}
           model: ${{ vars.AI_MODEL_DOCS || vars.AI_MODEL }}

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -162,7 +162,7 @@ jobs:
         run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/post-merge-tests.md MERGE_SHA REPO_FULL_NAME WORKFLOW_NAME RUN_ID RUN_URL EVENT_NAME TRIGGER_ACTOR
 
       - name: Run Claude Code with bot attribution
-        uses: JacobPEvans/ai-workflows/.github/actions/run-claude-code@main
+        uses: dryvist/ai-workflows/.github/actions/run-claude-code@main
         with:
           prompt: ${{ steps.prompt.outputs.content }}
           model: ${{ vars.AI_MODEL_CODE || vars.AI_MODEL }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,6 +11,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: JacobPEvans/.github/.github/workflows/_release-please.yml@main
+    uses: JacobPEvans-personal/.github/.github/workflows/_release-please.yml@main
     secrets:
       GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Root cause

`uses:` in GitHub Actions does not follow repo-transfer or org-rename redirects, and cannot reference variables. All `uses: JacobPEvans/...` lines were hard-coded to the old owner and would fail at workflow parse time now that the repos have moved.

## Changes

Corrected the literal owner on all 12 real (non-comment) `uses:` lines:

| Old | New |
|-----|-----|
| `JacobPEvans/ai-workflows/` | `dryvist/ai-workflows/` |
| `JacobPEvans/.github/` | `JacobPEvans-personal/.github/` |

Skipped: 6 comment lines (`#   uses: ...`) left untouched; `./`-local reusable workflow refs left untouched.

Part of an org-wide sweep fixing the same class of breakage across all consumer repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)