### PR TITLE
fix(actions): remove expression syntax from action input descriptions

### DIFF
--- a/.github/actions/run-claude-code/action.yml
+++ b/.github/actions/run-claude-code/action.yml
@@ -8,7 +8,11 @@ description: >-
 
 inputs:
   prompt:
-    description: Rendered prompt content sent to Claude (typically `${{ steps.prompt.outputs.content }}`).
+    # NOTE: descriptions must not contain `${{ ... }}` expression syntax — the
+    # runner evaluates expressions inside action metadata and fails the job at
+    # load time with "Unrecognized named-value" for contexts (steps/vars/
+    # secrets) that do not exist there.
+    description: Rendered prompt content sent to Claude (typically the caller's `steps.prompt.outputs.content`).
     required: true
   model:
     description: >-
@@ -24,10 +28,10 @@ inputs:
     description: API key for the LLM provider (e.g. OpenRouter). Pass-through; treat as secret at the caller.
     required: true
   app_id:
-    description: JacobPEvans-claude App ID, e.g. `${{ vars.GH_APP_CLAUDE_BOT_ID }}`.
+    description: JacobPEvans-claude App ID, e.g. the caller's `vars.GH_APP_CLAUDE_BOT_ID`.
     required: true
   app_private_key:
-    description: JacobPEvans-claude App private key PEM, e.g. `${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}`.
+    description: JacobPEvans-claude App private key PEM, e.g. the caller's `secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY`.
     required: true
   allowed_bots:
     description: Comma-separated bot logins claude-code-action may process.


### PR DESCRIPTION
## Summary

- `run-claude-code/action.yml` input descriptions contained literal `${{ steps.prompt.outputs.content }}`, `${{ vars.GH_APP_CLAUDE_BOT_ID }}`, and `${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}` examples. The Actions runner evaluates expressions inside action metadata at load time, and those contexts do not exist there, so every job consuming the action dies during "Prepare all required actions" with `Unrecognized named-value: 'steps'/'vars'/'secrets'`.
- Observed impact: the `workflow_dispatch` (review) path of dryvist/docs **Post-Merge Docs Review** has failed on every run since this file landed (e.g. run [27390713317](https://github.com/dryvist/docs/actions/runs/27390713317)). The `push` path only re-dispatches, so it kept reporting success.
- Fix: reword the three descriptions to reference the expressions by name without `${{ }}` syntax, plus a guard comment explaining why.

## Test plan

- After merge, `gh workflow run "Post-Merge Docs Review" -R dryvist/docs` must get past action load (verified as part of the docs repo workflow-repoint effort).

🤖 Generated with [Claude Code](https://claude.com/claude-code)