### PR TITLE
feat: parameterize AI provider auth

### DIFF
--- a/.github/actions/run-claude-code/action.yml
+++ b/.github/actions/run-claude-code/action.yml
@@ -24,15 +24,27 @@ inputs:
       Full --allowedTools value forwarded inside `claude_args`. Each caller
       owns its own tool scope so the policy stays visible in the workflow.
     required: true
-  anthropic_api_key:
-    description: API key for the LLM provider (e.g. OpenRouter). Pass-through; treat as secret at the caller.
+  ai_provider:
+    description: >-
+      AI provider routing mode. Supported values: claude_oauth, anthropic_api,
+      openrouter, anthropic_compatible.
+    required: false
+    default: claude_oauth
+  ai_token:
+    description: Provider credential passed from the caller's AI_TOKEN secret.
     required: true
+  ai_base_url:
+    description: Optional Anthropic-compatible base URL for routed providers.
+    required: false
+    default: ""
   app_id:
     description: JacobPEvans-claude App ID, e.g. the caller's `vars.GH_APP_CLAUDE_BOT_ID`.
-    required: true
+    required: false
+    default: ""
   app_private_key:
     description: JacobPEvans-claude App private key PEM, e.g. the caller's `secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY`.
-    required: true
+    required: false
+    default: ""
   allowed_bots:
     description: Comma-separated bot logins claude-code-action may process.
     required: false
@@ -44,12 +56,44 @@ inputs:
       commits.
     required: false
     default: "true"
+  track_progress:
+    description: Forwarded to claude-code-action for review-style workflows.
+    required: false
+    default: "false"
 
 runs:
   using: composite
   steps:
+    - name: Validate AI provider configuration
+      shell: bash
+      env:
+        AI_PROVIDER: ${{ inputs.ai_provider }}
+        AI_TOKEN: ${{ inputs.ai_token }}
+        AI_BASE_URL: ${{ inputs.ai_base_url }}
+      run: |
+        case "$AI_PROVIDER" in
+          claude_oauth|anthropic_api)
+            ;;
+          openrouter|anthropic_compatible)
+            if [ -z "$AI_BASE_URL" ]; then
+              echo "::error::AI_BASE_URL is required when AI_PROVIDER is $AI_PROVIDER"
+              exit 1
+            fi
+            ;;
+          *)
+            echo "::error::Unsupported AI_PROVIDER: $AI_PROVIDER"
+            exit 1
+            ;;
+        esac
+
+        if [ -z "$AI_TOKEN" ]; then
+          echo "::error::AI_TOKEN secret is required"
+          exit 1
+        fi
+
     - name: Mint JacobPEvans-claude installation token
       id: app-token
+      if: inputs.app_id != '' && inputs.app_private_key != ''
       uses: actions/create-github-app-token@v3
       with:
         app-id: ${{ inputs.app_id }}
@@ -57,13 +101,45 @@ runs:
         owner: ${{ github.repository_owner }}
         repositories: ${{ github.event.repository.name }}
 
-    - name: Run Claude Code
+    - name: Run Claude Code with Claude OAuth
+      if: inputs.ai_provider == 'claude_oauth'
       uses: anthropics/claude-code-action@v1
       with:
-        github_token: ${{ steps.app-token.outputs.token }}
-        anthropic_api_key: ${{ inputs.anthropic_api_key }}
+        github_token: ${{ steps.app-token.outputs.token || github.token }}
+        claude_code_oauth_token: ${{ inputs.ai_token }}
         allowed_bots: ${{ inputs.allowed_bots }}
         use_commit_signing: ${{ inputs.use_commit_signing }}
+        track_progress: ${{ inputs.track_progress }}
+        prompt: ${{ inputs.prompt }}
+        claude_args: >-
+          --allowedTools "${{ inputs.allowed_tools }}"
+          --model ${{ inputs.model }}
+
+    - name: Run Claude Code with Anthropic API
+      if: inputs.ai_provider == 'anthropic_api'
+      uses: anthropics/claude-code-action@v1
+      with:
+        github_token: ${{ steps.app-token.outputs.token || github.token }}
+        anthropic_api_key: ${{ inputs.ai_token }}
+        allowed_bots: ${{ inputs.allowed_bots }}
+        use_commit_signing: ${{ inputs.use_commit_signing }}
+        track_progress: ${{ inputs.track_progress }}
+        prompt: ${{ inputs.prompt }}
+        claude_args: >-
+          --allowedTools "${{ inputs.allowed_tools }}"
+          --model ${{ inputs.model }}
+
+    - name: Run Claude Code with routed Anthropic-compatible API
+      if: inputs.ai_provider == 'openrouter' || inputs.ai_provider == 'anthropic_compatible'
+      uses: anthropics/claude-code-action@v1
+      env:
+        ANTHROPIC_BASE_URL: ${{ inputs.ai_base_url }}
+      with:
+        github_token: ${{ steps.app-token.outputs.token || github.token }}
+        anthropic_api_key: ${{ inputs.ai_token }}
+        allowed_bots: ${{ inputs.allowed_bots }}
+        use_commit_signing: ${{ inputs.use_commit_signing }}
+        track_progress: ${{ inputs.track_progress }}
         prompt: ${{ inputs.prompt }}
         claude_args: >-
           --allowedTools "${{ inputs.allowed_tools }}"

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -64,7 +64,9 @@ Rendered via `.github/scripts/render-prompt.sh` + `envsubst` in workflow steps.
 
 ## Authentication
 
-Use `OPENROUTER_API_KEY` for all Claude Code workflows, routed via `OPENROUTER_BASE_URL` (repo secret). Do not create aliases.
+Use `AI_TOKEN` for all Claude Code workflows. Select providers with `AI_PROVIDER`
+and `AI_BASE_URL`; default to `claude_oauth` and `sonnet`. Do not add provider-specific
+secret names to reusable workflows.
 
 ## Version Tags
 

--- a/.github/workflows/best-practices.yml
+++ b/.github/workflows/best-practices.yml
@@ -96,8 +96,6 @@ jobs:
       issues: write
       pull-requests: read
     timeout-minutes: 5
-    env:
-      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL || secrets.OPENROUTER_BASE_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -116,11 +114,13 @@ jobs:
         run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/best-practices.md
 
       - name: Run Claude
-        uses: anthropics/claude-code-action@v1
+        uses: dryvist/ai-workflows/.github/actions/run-claude-code@main
         with:
-          anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          ai_provider: ${{ vars.AI_PROVIDER || 'claude_oauth' }}
+          ai_token: ${{ secrets.AI_TOKEN }}
+          ai_base_url: ${{ vars.AI_BASE_URL || secrets.AI_BASE_URL || '' }}
           allowed_bots: "github-actions"
+          use_commit_signing: "false"
           prompt: ${{ steps.prompt.outputs.content }}
-          claude_args: >-
-            --allowedTools "Read,Glob,Grep,LS,Bash(gh issue:*),Bash(gh api:*),Bash(gh search:*)"
-            --model ${{ vars.AI_MODEL }}
+          allowed_tools: "Read,Glob,Grep,LS,Bash(gh issue:*),Bash(gh api:*),Bash(gh search:*)"
+          model: ${{ vars.AI_MODEL_DOCS || vars.AI_MODEL || 'sonnet' }}

--- a/.github/workflows/ci-fix.yml
+++ b/.github/workflows/ci-fix.yml
@@ -191,8 +191,6 @@ jobs:
       id-token: write
       pull-requests: write
     timeout-minutes: 15
-    env:
-      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL || secrets.OPENROUTER_BASE_URL }}
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@v6
@@ -227,9 +225,11 @@ jobs:
         uses: dryvist/ai-workflows/.github/actions/run-claude-code@main
         with:
           prompt: ${{ steps.prompt.outputs.content }}
-          model: ${{ vars.AI_MODEL_CODE || vars.AI_MODEL }}
+          model: ${{ vars.AI_MODEL_CODE || vars.AI_MODEL || 'sonnet' }}
           allowed_tools: "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),Bash(git branch:*)${{ inputs.extra_tools != '' && format(',{0}', inputs.extra_tools) || '' }}"
-          anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          ai_provider: ${{ vars.AI_PROVIDER || 'claude_oauth' }}
+          ai_token: ${{ secrets.AI_TOKEN }}
+          ai_base_url: ${{ vars.AI_BASE_URL || secrets.AI_BASE_URL || '' }}
           app_id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
           app_private_key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}
           allowed_bots: "github-actions,claude"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -90,8 +90,6 @@ jobs:
       issues: read
       id-token: write
     timeout-minutes: 10
-    env:
-      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL || secrets.OPENROUTER_BASE_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -141,14 +139,17 @@ jobs:
             contains(inputs.allowed_bots, github.event.pull_request.user.login) ||
             contains(inputs.allowed_bots, '*')
           )
-        uses: anthropics/claude-code-action@v1
+        uses: dryvist/ai-workflows/.github/actions/run-claude-code@main
         with:
-          anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          ai_provider: ${{ vars.AI_PROVIDER || 'claude_oauth' }}
+          ai_token: ${{ secrets.AI_TOKEN }}
+          ai_base_url: ${{ vars.AI_BASE_URL || secrets.AI_BASE_URL || '' }}
           allowed_bots: "github-actions"
+          use_commit_signing: "false"
           track_progress: true
           prompt: ${{ steps.prompt.outputs.content }}
-          claude_args: |
-            --model ${{ inputs.model || vars.AI_MODEL }} --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+          allowed_tools: "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+          model: ${{ inputs.model || vars.AI_MODEL_REVIEW || vars.AI_MODEL || 'sonnet' }}
 
   interactive:
     if: false
@@ -163,16 +164,18 @@ jobs:
       issues: write
       id-token: write
     timeout-minutes: 10
-    env:
-      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL || secrets.OPENROUTER_BASE_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
 
       - name: Run Claude Interactive
-        uses: anthropics/claude-code-action@v1
+        uses: dryvist/ai-workflows/.github/actions/run-claude-code@main
         with:
-          anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          ai_provider: ${{ vars.AI_PROVIDER || 'claude_oauth' }}
+          ai_token: ${{ secrets.AI_TOKEN }}
+          ai_base_url: ${{ vars.AI_BASE_URL || secrets.AI_BASE_URL || '' }}
           allowed_bots: "github-actions"
-          claude_args: |
-            --model ${{ vars.AI_MODEL }} --allowedTools "Read,Glob,Grep,LS,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh issue comment:*)"
+          use_commit_signing: "false"
+          prompt: ${{ github.event.comment.body }}
+          allowed_tools: "Read,Glob,Grep,LS,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh issue comment:*)"
+          model: ${{ vars.AI_MODEL_REVIEW || vars.AI_MODEL || 'sonnet' }}

--- a/.github/workflows/code-simplifier.yml
+++ b/.github/workflows/code-simplifier.yml
@@ -95,8 +95,6 @@ jobs:
       id-token: write
       pull-requests: write
     timeout-minutes: 15
-    env:
-      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL || secrets.OPENROUTER_BASE_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -124,8 +122,10 @@ jobs:
         uses: dryvist/ai-workflows/.github/actions/run-claude-code@main
         with:
           prompt: ${{ steps.prompt.outputs.content }}
-          model: ${{ vars.AI_MODEL_CODE || vars.AI_MODEL }}
+          model: ${{ vars.AI_MODEL_CODE || vars.AI_MODEL || 'sonnet' }}
           allowed_tools: "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),Bash(git branch:*),Bash(gh pr:*),Bash(gh api:*)"
-          anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          ai_provider: ${{ vars.AI_PROVIDER || 'claude_oauth' }}
+          ai_token: ${{ secrets.AI_TOKEN }}
+          ai_base_url: ${{ vars.AI_BASE_URL || secrets.AI_BASE_URL || '' }}
           app_id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
           app_private_key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}

--- a/.github/workflows/final-pr-review.yml
+++ b/.github/workflows/final-pr-review.yml
@@ -110,8 +110,6 @@ jobs:
       issues: read
       pull-requests: write
     timeout-minutes: 10
-    env:
-      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL || secrets.OPENROUTER_BASE_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -144,9 +142,11 @@ jobs:
         uses: dryvist/ai-workflows/.github/actions/run-claude-code@main
         with:
           prompt: ${{ steps.prompt.outputs.content }}
-          model: ${{ vars.AI_MODEL }}
+          model: ${{ vars.AI_MODEL_REVIEW || vars.AI_MODEL || 'sonnet' }}
           allowed_tools: "Read,Glob,Grep,LS,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*)"
-          anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          ai_provider: ${{ vars.AI_PROVIDER || 'claude_oauth' }}
+          ai_token: ${{ secrets.AI_TOKEN }}
+          ai_base_url: ${{ vars.AI_BASE_URL || secrets.AI_BASE_URL || '' }}
           app_id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
           app_private_key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}
           use_commit_signing: "false"

--- a/.github/workflows/issue-hygiene.yml
+++ b/.github/workflows/issue-hygiene.yml
@@ -41,8 +41,6 @@ jobs:
       issues: write
       pull-requests: read
     timeout-minutes: 5
-    env:
-      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL || secrets.OPENROUTER_BASE_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -61,11 +59,13 @@ jobs:
         run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/issue-hygiene.md
 
       - name: Execute Claude Code
-        uses: anthropics/claude-code-action@v1
+        uses: dryvist/ai-workflows/.github/actions/run-claude-code@main
         with:
-          anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          ai_provider: ${{ vars.AI_PROVIDER || 'claude_oauth' }}
+          ai_token: ${{ secrets.AI_TOKEN }}
+          ai_base_url: ${{ vars.AI_BASE_URL || secrets.AI_BASE_URL || '' }}
           allowed_bots: "github-actions"
+          use_commit_signing: "false"
           prompt: ${{ steps.prompt.outputs.content }}
-          claude_args: >-
-            --allowedTools "Read,Glob,Grep,LS,Bash(gh issue:*),Bash(gh pr:*),Bash(gh search:*)"
-            --model ${{ vars.AI_MODEL_ISSUES || vars.AI_MODEL }}
+          allowed_tools: "Read,Glob,Grep,LS,Bash(gh issue:*),Bash(gh pr:*),Bash(gh search:*)"
+          model: ${{ vars.AI_MODEL_ISSUES || vars.AI_MODEL || 'sonnet' }}

--- a/.github/workflows/issue-linker.yml
+++ b/.github/workflows/issue-linker.yml
@@ -83,8 +83,6 @@ jobs:
       issues: write
       pull-requests: write
     timeout-minutes: 10
-    env:
-      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL || secrets.OPENROUTER_BASE_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -110,11 +108,13 @@ jobs:
           github.event.pull_request.user.type != 'Bot' ||
           contains(inputs.allowed_bots, github.event.pull_request.user.login) ||
           contains(inputs.allowed_bots, '*')
-        uses: anthropics/claude-code-action@v1
+        uses: dryvist/ai-workflows/.github/actions/run-claude-code@main
         with:
-          anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          ai_provider: ${{ vars.AI_PROVIDER || 'claude_oauth' }}
+          ai_token: ${{ secrets.AI_TOKEN }}
+          ai_base_url: ${{ vars.AI_BASE_URL || secrets.AI_BASE_URL || '' }}
           allowed_bots: "github-actions"
-          model: ${{ inputs.model || vars.AI_MODEL_ISSUES || vars.AI_MODEL }}
+          use_commit_signing: "false"
           prompt: ${{ steps.render-prompt.outputs.content }}
-          claude_args: >-
-            --allowedTools "Read,Glob,Grep,LS,Bash(gh pr:*),Bash(gh issue:*),Bash(gh search:*),Bash(gh api:*)"
+          allowed_tools: "Read,Glob,Grep,LS,Bash(gh pr:*),Bash(gh issue:*),Bash(gh search:*),Bash(gh api:*)"
+          model: ${{ inputs.model || vars.AI_MODEL_ISSUES || vars.AI_MODEL || 'sonnet' }}

--- a/.github/workflows/issue-resolver.yml
+++ b/.github/workflows/issue-resolver.yml
@@ -110,8 +110,6 @@ jobs:
       issues: write
       pull-requests: write
     timeout-minutes: 15
-    env:
-      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL || secrets.OPENROUTER_BASE_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -148,9 +146,11 @@ jobs:
         uses: dryvist/ai-workflows/.github/actions/run-claude-code@main
         with:
           prompt: ${{ steps.prompt.outputs.content }}
-          model: ${{ inputs.model || vars.AI_MODEL_PLAN || vars.AI_MODEL }}
+          model: ${{ inputs.model || vars.AI_MODEL_PLAN || vars.AI_MODEL || 'sonnet' }}
           allowed_tools: "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),Bash(git branch:*),Bash(gh pr create:*),Bash(gh issue comment:*)${{ inputs.extra_tools != '' && format(',{0}', inputs.extra_tools) || '' }}"
-          anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          ai_provider: ${{ vars.AI_PROVIDER || 'claude_oauth' }}
+          ai_token: ${{ secrets.AI_TOKEN }}
+          ai_base_url: ${{ vars.AI_BASE_URL || secrets.AI_BASE_URL || '' }}
           app_id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
           app_private_key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}
 

--- a/.github/workflows/issue-sweeper.yml
+++ b/.github/workflows/issue-sweeper.yml
@@ -40,8 +40,6 @@ jobs:
       issues: write
       pull-requests: read
     timeout-minutes: 5
-    env:
-      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL || secrets.OPENROUTER_BASE_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -60,11 +58,13 @@ jobs:
         run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/issue-sweeper.md
 
       - name: Execute Claude Code
-        uses: anthropics/claude-code-action@v1
+        uses: dryvist/ai-workflows/.github/actions/run-claude-code@main
         with:
-          anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          ai_provider: ${{ vars.AI_PROVIDER || 'claude_oauth' }}
+          ai_token: ${{ secrets.AI_TOKEN }}
+          ai_base_url: ${{ vars.AI_BASE_URL || secrets.AI_BASE_URL || '' }}
           allowed_bots: "github-actions"
+          use_commit_signing: "false"
           prompt: ${{ steps.prompt.outputs.content }}
-          claude_args: >-
-            --allowedTools "Read,Glob,Grep,LS,Bash(gh issue:*),Bash(gh pr:*),Bash(gh search:*),Bash(gh api:*)"
-            --model ${{ vars.AI_MODEL_ISSUES || vars.AI_MODEL }}
+          allowed_tools: "Read,Glob,Grep,LS,Bash(gh issue:*),Bash(gh pr:*),Bash(gh search:*),Bash(gh api:*)"
+          model: ${{ vars.AI_MODEL_ISSUES || vars.AI_MODEL || 'sonnet' }}

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -36,8 +36,6 @@ jobs:
       id-token: write
       issues: write
     timeout-minutes: 5
-    env:
-      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL || secrets.OPENROUTER_BASE_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -58,11 +56,13 @@ jobs:
         run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/issue-triage.md ISSUE_NUMBER
 
       - name: Run Claude
-        uses: anthropics/claude-code-action@v1
+        uses: dryvist/ai-workflows/.github/actions/run-claude-code@main
         with:
-          anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          ai_provider: ${{ vars.AI_PROVIDER || 'claude_oauth' }}
+          ai_token: ${{ secrets.AI_TOKEN }}
+          ai_base_url: ${{ vars.AI_BASE_URL || secrets.AI_BASE_URL || '' }}
           allowed_bots: "github-actions"
+          use_commit_signing: "false"
           prompt: ${{ steps.prompt.outputs.content }}
-          claude_args: >-
-            --allowedTools "Read,Glob,Grep,LS,Bash(gh issue:*),Bash(gh search:*)"
-            --model ${{ vars.AI_MODEL_ISSUES || vars.AI_MODEL }}
+          allowed_tools: "Read,Glob,Grep,LS,Bash(gh issue:*),Bash(gh search:*)"
+          model: ${{ vars.AI_MODEL_ISSUES || vars.AI_MODEL || 'sonnet' }}

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -32,8 +32,6 @@ jobs:
       id-token: write
       issues: write
     timeout-minutes: 5
-    env:
-      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL || secrets.OPENROUTER_BASE_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -52,11 +50,13 @@ jobs:
         run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/label-sync.md
 
       - name: Run Claude
-        uses: anthropics/claude-code-action@v1
+        uses: dryvist/ai-workflows/.github/actions/run-claude-code@main
         with:
-          anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          ai_provider: ${{ vars.AI_PROVIDER || 'claude_oauth' }}
+          ai_token: ${{ secrets.AI_TOKEN }}
+          ai_base_url: ${{ vars.AI_BASE_URL || secrets.AI_BASE_URL || '' }}
           allowed_bots: "github-actions"
+          use_commit_signing: "false"
           prompt: ${{ steps.prompt.outputs.content }}
-          claude_args: >-
-            --allowedTools "Read,Glob,Grep,LS,Bash(gh label:*),Bash(gh search:*),Bash(gh api:*)"
-            --model ${{ vars.AI_MODEL }}
+          allowed_tools: "Read,Glob,Grep,LS,Bash(gh label:*),Bash(gh search:*),Bash(gh api:*)"
+          model: ${{ vars.AI_MODEL_OPS || vars.AI_MODEL || 'sonnet' }}

--- a/.github/workflows/next-steps.yml
+++ b/.github/workflows/next-steps.yml
@@ -97,8 +97,6 @@ jobs:
       issues: write
       pull-requests: write
     timeout-minutes: 15
-    env:
-      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL || secrets.OPENROUTER_BASE_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -123,12 +121,15 @@ jobs:
         run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/next-steps.md WORKFLOW_NAME RUN_ID RUN_URL EVENT_NAME TRIGGER_ACTOR
 
       - name: Execute Claude Code
-        uses: anthropics/claude-code-action@v1
+        uses: dryvist/ai-workflows/.github/actions/run-claude-code@main
         with:
-          anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          ai_provider: ${{ vars.AI_PROVIDER || 'claude_oauth' }}
+          ai_token: ${{ secrets.AI_TOKEN }}
+          ai_base_url: ${{ vars.AI_BASE_URL || secrets.AI_BASE_URL || '' }}
           allowed_bots: "github-actions"
           use_commit_signing: "true"
           prompt: ${{ steps.prompt.outputs.content }}
-          claude_args: >-
-            --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),Bash(git branch:*),Bash(gh pr:*),Bash(gh issue:*),Bash(gh api:*),Bash(gh search:*)"
-            --model ${{ vars.AI_MODEL }}
+          allowed_tools: "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),Bash(git branch:*),Bash(gh pr:*),Bash(gh issue:*),Bash(gh api:*),Bash(gh search:*)"
+          model: ${{ vars.AI_MODEL_DOCS || vars.AI_MODEL || 'sonnet' }}
+          app_id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
+          app_private_key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}

--- a/.github/workflows/post-merge-docs-review.yml
+++ b/.github/workflows/post-merge-docs-review.yml
@@ -125,18 +125,7 @@ jobs:
       id-token: write
       pull-requests: write
     timeout-minutes: 15
-    env:
-      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL || secrets.OPENROUTER_BASE_URL }}
     steps:
-      - name: Validate model configuration
-        env:
-          AI_MODEL_VAR: ${{ vars.AI_MODEL }}
-        run: |
-          if [ -z "$AI_MODEL_VAR" ]; then
-            echo "::error::AI_MODEL must be set as an org/repo variable. See docs/AUTHENTICATION.md for configuration."
-            exit 1
-          fi
-
       - name: Checkout repository
         uses: actions/checkout@v6
 
@@ -165,8 +154,10 @@ jobs:
         uses: dryvist/ai-workflows/.github/actions/run-claude-code@main
         with:
           prompt: ${{ steps.prompt.outputs.content }}
-          model: ${{ vars.AI_MODEL }}
+          model: ${{ vars.AI_MODEL_DOCS || vars.AI_MODEL || 'sonnet' }}
           allowed_tools: "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),Bash(git branch:*),Bash(gh pr:*),Bash(gh api:*),Bash(gh search:*)"
-          anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          ai_provider: ${{ vars.AI_PROVIDER || 'claude_oauth' }}
+          ai_token: ${{ secrets.AI_TOKEN }}
+          ai_base_url: ${{ vars.AI_BASE_URL || secrets.AI_BASE_URL || '' }}
           app_id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
           app_private_key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -125,18 +125,7 @@ jobs:
       id-token: write
       pull-requests: write
     timeout-minutes: 15
-    env:
-      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL || secrets.OPENROUTER_BASE_URL }}
     steps:
-      - name: Validate model configuration
-        env:
-          AI_MODEL_VAR: ${{ vars.AI_MODEL_CODE || vars.AI_MODEL }}
-        run: |
-          if [ -z "$AI_MODEL_VAR" ]; then
-            echo "::error::AI_MODEL_CODE or AI_MODEL must be set as an org/repo variable. See docs/AUTHENTICATION.md for configuration."
-            exit 1
-          fi
-
       - name: Checkout repository
         uses: actions/checkout@v6
 
@@ -165,8 +154,10 @@ jobs:
         uses: dryvist/ai-workflows/.github/actions/run-claude-code@main
         with:
           prompt: ${{ steps.prompt.outputs.content }}
-          model: ${{ vars.AI_MODEL_CODE || vars.AI_MODEL }}
+          model: ${{ vars.AI_MODEL_CODE || vars.AI_MODEL || 'sonnet' }}
           allowed_tools: "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),Bash(git branch:*),Bash(gh pr:*),Bash(gh api:*),Bash(gh search:*)"
-          anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          ai_provider: ${{ vars.AI_PROVIDER || 'claude_oauth' }}
+          ai_token: ${{ secrets.AI_TOKEN }}
+          ai_base_url: ${{ vars.AI_BASE_URL || secrets.AI_BASE_URL || '' }}
           app_id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
           app_private_key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}

--- a/.github/workflows/repo-orchestrator.yml
+++ b/.github/workflows/repo-orchestrator.yml
@@ -32,8 +32,6 @@ jobs:
       contents: read
       id-token: write
     timeout-minutes: 5
-    env:
-      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL || secrets.OPENROUTER_BASE_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -52,11 +50,13 @@ jobs:
         run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/repo-orchestrator.md
 
       - name: Run Claude
-        uses: anthropics/claude-code-action@v1
+        uses: dryvist/ai-workflows/.github/actions/run-claude-code@main
         with:
-          anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          ai_provider: ${{ vars.AI_PROVIDER || 'claude_oauth' }}
+          ai_token: ${{ secrets.AI_TOKEN }}
+          ai_base_url: ${{ vars.AI_BASE_URL || secrets.AI_BASE_URL || '' }}
           allowed_bots: "github-actions"
+          use_commit_signing: "false"
           prompt: ${{ steps.prompt.outputs.content }}
-          claude_args: >-
-            --allowedTools "Read,Glob,Grep,LS,Bash(gh issue:*),Bash(gh pr:*),Bash(gh run:*),Bash(gh workflow:*),Bash(gh api:*),Bash(gh search:*)"
-            --model ${{ vars.AI_MODEL }}
+          allowed_tools: "Read,Glob,Grep,LS,Bash(gh issue:*),Bash(gh pr:*),Bash(gh run:*),Bash(gh workflow:*),Bash(gh api:*),Bash(gh search:*)"
+          model: ${{ vars.AI_MODEL_OPS || vars.AI_MODEL || 'sonnet' }}

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,13 +1,12 @@
 # Smoke Test
 #
-# Lightweight workflow to validate API provider auth and model routing.
-# No PR or issue context needed — runs a trivial Claude prompt and verifies the response.
+# Lightweight workflow to validate AI provider auth and model routing.
+# No PR or issue context needed; runs a trivial prompt and verifies the action completes.
 #
 # Usage:
-#   gh workflow run smoke-test.yml -f provider=openrouter
-#   gh workflow run smoke-test.yml -f provider=openrouter -f model=openrouter/free
-#   gh workflow run smoke-test.yml -f provider=anthropic -f model=anthropic/claude-haiku-4
-#   gh workflow run smoke-test.yml -f provider=chutes
+#   gh workflow run smoke-test.yml
+#   gh workflow run smoke-test.yml -f provider=openrouter -f model=anthropic/claude-sonnet-4
+#   gh workflow run smoke-test.yml -f provider=anthropic_api -f model=claude-sonnet-4
 
 name: Smoke Test
 
@@ -15,19 +14,20 @@ on:
   workflow_dispatch:
     inputs:
       provider:
-        description: "API provider to test"
+        description: "AI provider to test"
         type: choice
         options:
+          - claude_oauth
+          - anthropic_api
           - openrouter
-          - anthropic
-          - chutes
-        default: openrouter
+          - anthropic_compatible
+        default: claude_oauth
       model:
-        description: "Model to use (empty = use AI_MODEL var fallback)"
+        description: "Model to use (empty = AI_MODEL or Claude default)"
         type: string
         default: ""
       prompt:
-        description: "Test prompt (default validates exact output)"
+        description: "Test prompt"
         type: string
         default: "Respond with exactly this text and nothing else: SMOKE_TEST_PASS"
 
@@ -40,23 +40,22 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  smoke-openrouter:
-    name: "openrouter / ${{ inputs.model || 'default' }}"
-    if: inputs.provider == 'openrouter'
+  smoke:
+    name: "${{ inputs.provider }} / ${{ inputs.model || 'default' }}"
     runs-on: ubuntu-latest
-    env:
-      ANTHROPIC_BASE_URL: ${{ vars.OPENROUTER_BASE_URL || secrets.OPENROUTER_BASE_URL }}
     timeout-minutes: 5
     steps:
-      - name: Run Claude
-        uses: anthropics/claude-code-action@v1
+      - name: Run Claude Code
+        uses: dryvist/ai-workflows/.github/actions/run-claude-code@main
         with:
-          anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          ai_provider: ${{ inputs.provider }}
+          ai_token: ${{ secrets.AI_TOKEN }}
+          ai_base_url: ${{ vars.AI_BASE_URL || secrets.AI_BASE_URL || '' }}
           allowed_bots: "github-actions"
+          use_commit_signing: "false"
           prompt: ${{ inputs.prompt }}
-          claude_args: >-
-            --model ${{ inputs.model || vars.AI_MODEL }}
-            --allowedTools "Bash(echo:*)"
+          allowed_tools: "Bash(echo:*)"
+          model: ${{ inputs.model || vars.AI_MODEL || 'sonnet' }}
 
       - name: Verify response
         env:
@@ -64,75 +63,11 @@ jobs:
           ACTUAL_PROMPT: ${{ inputs.prompt }}
         run: |
           echo "=== Smoke Test Results ==="
-          echo "Provider: openrouter"
-          echo "Model: ${{ inputs.model || vars.AI_MODEL }}"
-          echo "Status: Claude action completed successfully"
+          echo "Provider: ${{ inputs.provider }}"
+          echo "Model: ${{ inputs.model || vars.AI_MODEL || 'sonnet' }}"
+          echo "Status: Claude Code action completed successfully"
           if [[ "$ACTUAL_PROMPT" == "$DEFAULT_PROMPT" ]]; then
             echo "=== SMOKE_TEST_PASS ==="
           else
-            echo "=== Custom prompt used — manual output verification required ==="
-          fi
-
-  smoke-anthropic:
-    name: "anthropic / ${{ inputs.model || 'default' }}"
-    if: inputs.provider == 'anthropic'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Run Claude
-        uses: anthropics/claude-code-action@v1
-        with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          allowed_bots: "github-actions"
-          prompt: ${{ inputs.prompt }}
-          claude_args: >-
-            --model ${{ inputs.model || 'claude-haiku-4' }}
-            --allowedTools "Bash(echo:*)"
-
-      - name: Verify response
-        env:
-          DEFAULT_PROMPT: "Respond with exactly this text and nothing else: SMOKE_TEST_PASS"
-          ACTUAL_PROMPT: ${{ inputs.prompt }}
-        run: |
-          echo "=== Smoke Test Results ==="
-          echo "Provider: anthropic"
-          echo "Model: ${{ inputs.model || 'claude-haiku-4' }}"
-          echo "Status: Claude action completed successfully"
-          if [[ "$ACTUAL_PROMPT" == "$DEFAULT_PROMPT" ]]; then
-            echo "=== SMOKE_TEST_PASS ==="
-          else
-            echo "=== Custom prompt used — manual output verification required ==="
-          fi
-
-  smoke-chutes:
-    name: "chutes / ${{ inputs.model || 'default' }}"
-    if: inputs.provider == 'chutes'
-    runs-on: ubuntu-latest
-    env:
-      ANTHROPIC_BASE_URL: ${{ vars.CHUTES_BASE_URL }}
-    timeout-minutes: 5
-    steps:
-      - name: Run Claude
-        uses: anthropics/claude-code-action@v1
-        with:
-          anthropic_api_key: ${{ secrets.CHUTES_API_KEY }}
-          allowed_bots: "github-actions"
-          prompt: ${{ inputs.prompt }}
-          claude_args: >-
-            --model ${{ inputs.model || vars.AI_MODEL }}
-            --allowedTools "Bash(echo:*)"
-
-      - name: Verify response
-        env:
-          DEFAULT_PROMPT: "Respond with exactly this text and nothing else: SMOKE_TEST_PASS"
-          ACTUAL_PROMPT: ${{ inputs.prompt }}
-        run: |
-          echo "=== Smoke Test Results ==="
-          echo "Provider: chutes"
-          echo "Model: ${{ inputs.model || vars.AI_MODEL }}"
-          echo "Status: Claude action completed successfully"
-          if [[ "$ACTUAL_PROMPT" == "$DEFAULT_PROMPT" ]]; then
-            echo "=== SMOKE_TEST_PASS ==="
-          else
-            echo "=== Custom prompt used — manual output verification required ==="
+            echo "=== Custom prompt used - manual output verification required ==="
           fi

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Reusable AI agent workflows for GitHub Actions. Consumer repos call these with t
 
 1. [GitHub CLI](https://cli.github.com/) installed and authenticated
 2. One secret configured in each consumer repo:
-   - `OPENROUTER_API_KEY` — [OpenRouter](https://openrouter.ai) API key (required by all workflows)
+   - `AI_TOKEN` — provider credential for Claude Code Action workflows
 
 ### Add a Workflow to Your Repo
 
@@ -85,12 +85,14 @@ See [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md) for the full list of work
 
 ## Authentication
 
-All workflows route through [OpenRouter](https://openrouter.ai) by default. Add two things to each consumer repo:
+Claude Code Action workflows default to Claude OAuth and use AI-agnostic configuration names:
 
-1. **Secret**: `OPENROUTER_API_KEY` — your OpenRouter API key (set a $/day spend limit)
-2. **Secret**: `OPENROUTER_BASE_URL` — set to `https://openrouter.ai/api/v1`
+- **Secret**: `AI_TOKEN` — provider credential
+- **Variable**: `AI_PROVIDER` — `claude_oauth` by default; set `openrouter`, `anthropic_api`, or `anthropic_compatible` to switch providers
+- **Variable or secret**: `AI_BASE_URL` — required only for routed Anthropic-compatible providers such as OpenRouter
+- **Variables**: `AI_MODEL`, or category-specific `AI_MODEL_DOCS`, `AI_MODEL_CODE`, `AI_MODEL_REVIEW`, `AI_MODEL_ISSUES`, `AI_MODEL_OPS`, `AI_MODEL_PLAN`
 
-Most workflows fall back to `openrouter/free` when no model variables are configured. Exceptions: `post-merge-docs-review` and `post-merge-tests` require `AI_MODEL_DOCS`/`AI_MODEL_CODE` or `AI_MODEL` to be set — they fail with a clear error when unconfigured. See [docs/AUTHENTICATION.md](docs/AUTHENTICATION.md) for model configuration and alternative providers.
+Model defaults are Claude (`sonnet`) unless org variables choose a different model. OpenRouter remains supported by setting only secrets and variables; no workflow code changes are required. See [docs/AUTHENTICATION.md](docs/AUTHENTICATION.md) for provider configuration and GH-AW-specific limits.
 
 ---
 
@@ -98,6 +100,7 @@ Most workflows fall back to `openrouter/free` when no model variables are config
 
 ```
 .github/
+  aw/                   # gh-aw import cache and action lock metadata
   prompts/              # Prompt files (one per workflow)
   scripts/
     render-prompt.sh    # Shared: envsubst + GITHUB_OUTPUT
@@ -114,10 +117,14 @@ Most workflows fall back to `openrouter/free` when no model variables are config
     shared/             # Shared scripts (check-daily-limit.js, constants.js)
     verification/       # E2E test script
   workflows/            # Reusable workflow YAML definitions
+    *.md                # GitHub Agentic Workflow source wrappers
+    *.lock.yml          # Generated gh-aw workflows
 docs/                   # Documentation and verification runbook
 ```
 
-All workflows use `claude-code-action@v1` with OIDC auth (`id-token: write`). Prompts are rendered at runtime via `render-prompt.sh` and the cross-repo checkout pattern:
+Reusable `.yml` workflows use `claude-code-action@v1` with OIDC auth
+(`id-token: write`) through the shared `run-claude-code` action. Prompts are
+rendered at runtime via `render-prompt.sh` and the cross-repo checkout pattern:
 
 ```yaml
 - uses: actions/checkout@v6

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -1,232 +1,109 @@
-# Authentication & API Providers
+# Authentication & AI Providers
 
-All workflows use [`anthropics/claude-code-action@v1`](https://github.com/anthropics/claude-code-action), which accepts an API key via the `anthropic_api_key` input. This repo routes requests through **OpenRouter** by default.
+Claude Code Action workflows use AI-agnostic configuration names. Provider and
+model changes should be possible by changing organization or repository secrets
+and variables only.
 
-## How Authentication Works
+## Claude Code Action Workflows
 
-The `claude-code-action` action needs two things to talk to an AI model:
+Use these settings for the reusable `.yml` workflows that call
+`anthropics/claude-code-action@v1` through `.github/actions/run-claude-code`.
 
-1. **An API key** — passed via the `anthropic_api_key` input (a GitHub Secret)
-2. **A base URL** — set via the `ANTHROPIC_BASE_URL` environment variable to point the action at the right provider
+| Setting | Type | Default | Purpose |
+| --- | --- | --- | --- |
+| `AI_TOKEN` | Secret | required | Provider credential. |
+| `AI_PROVIDER` | Variable | `claude_oauth` | Provider route: `claude_oauth`, `anthropic_api`, `openrouter`, or `anthropic_compatible`. |
+| `AI_BASE_URL` | Variable or secret | empty | Anthropic-compatible API base URL for routed providers. |
+| `AI_MODEL` | Variable | `sonnet` | Global model fallback. |
+| `AI_MODEL_DOCS` | Variable | falls back to `AI_MODEL` | Documentation workflows. |
+| `AI_MODEL_CODE` | Variable | falls back to `AI_MODEL` | Code-writing workflows. |
+| `AI_MODEL_REVIEW` | Variable | falls back to `AI_MODEL` | Review workflows. |
+| `AI_MODEL_ISSUES` | Variable | falls back to `AI_MODEL` | Issue workflows. |
+| `AI_MODEL_OPS` | Variable | falls back to `AI_MODEL` | Operational workflows. |
+| `AI_MODEL_PLAN` | Variable | falls back to `AI_MODEL` | Planning workflows. |
 
-When `ANTHROPIC_BASE_URL` points to OpenRouter, the action sends requests to OpenRouter's API, which forwards them to whatever model you specify. The API key authenticates with OpenRouter, not directly with Anthropic.
+### Claude OAuth
 
-```
-Consumer repo                    OpenRouter                      Anthropic
-    |                                |                               |
-    |-- anthropic_api_key ---------> |                               |
-    |-- ANTHROPIC_BASE_URL --------> |                               |
-    |                                |-- forwards to model --------> |
-    |                                |<-- response ------------------|
-    |<-- response -------------------|                               |
-```
+Default path:
 
-## Why Not `CLAUDE_CODE_OAUTH_TOKEN`?
-
-The Claude Code subscription is cheaper per-token, but using a subscription token in **unattended CI** (no human in the loop) **violates the [Claude Code Terms of Service](https://www.anthropic.com/legal/terms)** and risks an account ban.
-
-Key differences:
-
-| | OAuth Token (subscription) | API Key (OpenRouter/Anthropic) |
-|---|---|---|
-| **Intended use** | Interactive CLI sessions | Programmatic access |
-| **Unattended CI** | Prohibited by ToS | Allowed |
-| **Cost control** | Per-subscription | Per-key spend limits |
-| **Account risk** | Ban possible | None |
-
-API providers like OpenRouter and Chutes.ai are purpose-built for programmatic access — no ToS concerns.
-
----
-
-## OpenRouter (default)
-
-[OpenRouter](https://openrouter.ai) provides access to Claude and hundreds of other models via a single API key. For Claude-to-Claude, OpenRouter adds a small platform fee on top of Anthropic's base pricing — but the real value is access to cheaper non-Claude models and free-tier options that dramatically reduce CI costs. You can route expensive planning tasks to Claude Opus while running simpler triage through free models, all from one key.
-
-### Setup
-
-1. Create an account at [openrouter.ai](https://openrouter.ai) ([Quick Start](https://openrouter.ai/docs/quickstart))
-2. Generate a dedicated API key with a **$/day spend limit** (Keys → Create Key → set Credit Limit)
-3. Add the key as `OPENROUTER_API_KEY` in your repo's GitHub Secrets (Settings → Secrets → Actions → New secret)
-4. Add `OPENROUTER_BASE_URL` as a secret set to `https://openrouter.ai/api/v1` (Settings → Secrets → Actions → New secret)
-
-### How It's Wired
-
-Every workflow step follows this pattern:
-
-```yaml
-- name: Run Claude
-  uses: anthropics/claude-code-action@v1
-  env:
-    ANTHROPIC_BASE_URL: ${{ secrets.OPENROUTER_BASE_URL }}
-  with:
-    anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
-    allowed_bots: "github-actions"
-    prompt: ${{ steps.prompt.outputs.content }}
-    claude_args: >-
-      --model ${{ vars.AI_MODEL_REVIEW || vars.AI_MODEL || 'openrouter/free' }}
+```text
+AI_PROVIDER = claude_oauth
+AI_TOKEN    = <Claude Code OAuth token>
+AI_MODEL    = sonnet
 ```
 
-The `env` block redirects the action to OpenRouter. The `anthropic_api_key` authenticates with OpenRouter using your key. The `--model` flag tells OpenRouter which model to use, with a fallback chain (explained in [Model Configuration](#model-configuration) below).
+No `AI_BASE_URL` is needed.
 
-### Cost Controls
+### Direct Anthropic API
 
-OpenRouter offers multiple layers of spend protection:
-
-- **Per-key daily limit** — set during key creation, hard cap per day
-- **Per-key total limit** — lifetime cap on a single key
-- **Account-level credits** — prepaid balance, workflows stop when depleted
-- **Free tier** — `openrouter/free` routes to free models with zero cost (rate-limited to 50 req/day without credits, 1000 req/day with $10+ account balance)
-
----
-
-## Alternative: Chutes.ai
-
-[Chutes.ai](https://chutes.ai) is a subscription-based provider with preset daily request limits — cost is self-limiting by design. Pay a flat subscription and get a fixed number of requests per day, so there's no risk of runaway spend.
-
-### Setup
-
-1. Create an account at [chutes.ai](https://chutes.ai)
-2. Generate an API key from your dashboard
-3. Add the key as `CHUTES_API_KEY` in your repo's GitHub Secrets
-4. Add a repo variable `CHUTES_BASE_URL` set to the Chutes.ai API endpoint (Settings → Variables → Actions → New variable)
-
-### Workflow Wiring
-
-Same pattern as OpenRouter — just swap the secret and variable names:
-
-```yaml
-- name: Run Claude
-  uses: anthropics/claude-code-action@v1
-  env:
-    ANTHROPIC_BASE_URL: ${{ vars.CHUTES_BASE_URL }}
-  with:
-    anthropic_api_key: ${{ secrets.CHUTES_API_KEY }}
-    allowed_bots: "github-actions"
-    prompt: ${{ steps.prompt.outputs.content }}
+```text
+AI_PROVIDER = anthropic_api
+AI_TOKEN    = <Anthropic API key>
+AI_MODEL    = sonnet
 ```
 
----
+No `AI_BASE_URL` is needed.
 
-## Alternative: Direct Anthropic API
+### OpenRouter
 
-The `anthropic_api_key` input also accepts a direct [Anthropic API key](https://console.anthropic.com/) (`sk-ant-*`). This is the officially supported method per Anthropic's documentation. No `ANTHROPIC_BASE_URL` is needed — the action defaults to `https://api.anthropic.com`.
+OpenRouter is still supported, but it is fully parameterized:
 
-```yaml
-- name: Run Claude
-  uses: anthropics/claude-code-action@v1
-  with:
-    anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+```text
+AI_PROVIDER = openrouter
+AI_TOKEN    = <OpenRouter API key>
+AI_BASE_URL = https://openrouter.ai/api/v1
+AI_MODEL    = <OpenRouter model name>
 ```
 
-**Trade-offs vs. OpenRouter:**
+Do not hardcode OpenRouter model names in workflow files. Change `AI_MODEL` or a
+category-specific model variable to switch models.
 
-- Cheapest option for Claude-to-Claude (no platform fee), but locked to Claude models only
-- No access to cheaper non-Claude models or free-tier alternatives
-- No built-in per-key spend limits (use [Anthropic usage limits](https://console.anthropic.com/settings/limits) instead)
-- Simpler setup (one secret, no base URL variable)
+### Other Anthropic-Compatible Routers
 
----
+Use this for Chutes.ai or an internal Anthropic-compatible gateway:
 
-## Model Configuration
-
-### Fallback Chain
-
-Most workflows use a 3-tier fallback chain to determine which model to use:
-
-```
-inputs.model → vars.AI_MODEL_{CATEGORY} → vars.AI_MODEL → 'openrouter/free'
-     |                    |                      |                  |
-  Caller override    Category var          Global var       Hardcoded free
-  (workflow input)   (per-task tier)       (repo-wide)      (safety net)
+```text
+AI_PROVIDER = anthropic_compatible
+AI_TOKEN    = <provider API key>
+AI_BASE_URL = <provider Anthropic-compatible base URL>
+AI_MODEL    = <provider model name>
 ```
 
-**Exceptions** — `post-merge-docs-review` and `post-merge-tests` have no hardcoded fallback.
-They fail with a clear `::error::` message when neither `AI_MODEL_DOCS`/`AI_MODEL_CODE` nor
-`AI_MODEL` is set. Configure at least `AI_MODEL` to enable these workflows.
+## GitHub App Attribution
 
-This means:
-- **If you set nothing**: Most workflows use `openrouter/free`; `post-merge-docs-review` and `post-merge-tests` fail at startup with a configuration error
-- **If you set `AI_MODEL` only**: All workflows use that model as a baseline
-- **If you set category vars**: Each workflow type gets an appropriate model tier
-- **If a caller passes `model`**: That overrides everything
+PR-writing workflows pass GitHub App credentials to the shared action:
 
-### Category Variables
+- `GH_APP_CLAUDE_BOT_ID`
+- `GH_APP_CLAUDE_BOT_PRIVATE_KEY`
 
-Workflows are grouped by the intelligence level they need:
+The shared action mints an installation token and forwards it to
+`claude-code-action` with `use_commit_signing: "true"`, so commits and PR
+comments are attributed to the configured bot.
 
-| Variable | Category | Recommended Value | Why | Workflows |
-|----------|----------|-------------------|-----|-----------|
-| `AI_MODEL` | Global fallback | `openrouter/auto` | Smart router, picks best model per request | All |
-| `AI_MODEL_PLAN` | Deep planning | `anthropic/claude-opus-4` | Architects rich issues that cheaper models execute — needs highest reasoning | issue-resolver |
-| `AI_MODEL_REVIEW` | Code review | `anthropic/claude-sonnet-4` | Reads code, uses gh CLI tools, posts structured review feedback | claude-review, final-pr-review |
-| `AI_MODEL_CODE` | Code generation | `anthropic/claude-sonnet-4` | Writes and modifies code, creates commits and PRs | ci-fix, code-simplifier, post-merge-tests |
-| `AI_MODEL_ISSUES` | Issue management | `anthropic/claude-sonnet-4` | Triages, deduplicates, and manages issues via gh CLI | issue-triage, issue-hygiene, issue-sweeper, issue-linker |
-| `AI_MODEL_DOCS` | Documentation | `anthropic/claude-haiku-4` | Lighter review tasks, cost-effective for text analysis | post-merge-docs-review, best-practices, next-steps |
-| `AI_MODEL_OPS` | Simple operations | `anthropic/claude-haiku-4` | Label sync, routing — classification tasks with minimal reasoning | label-sync, project-router, repo-orchestrator |
+## GitHub Agentic Workflows
 
-### Quick Setup
+The `.md` / `.lock.yml` GitHub Agentic Workflows are separate from the
+Claude Code Action workflows. GH-AW engines have their own authentication
+rules generated by `gh aw compile`.
 
-**Minimal** (zero cost, limited capability):
-```
-# Most workflows fall back to openrouter/free automatically.
-# post-merge-docs-review and post-merge-tests require at least AI_MODEL:
-AI_MODEL = openrouter/free
-```
+Important limits:
 
-**Budget-conscious** (one variable, moderate capability):
-```
-AI_MODEL = openrouter/auto
-```
+- GH-AW Claude does not support Claude OAuth subscription tokens.
+- GH-AW Claude currently expects `ANTHROPIC_API_KEY`, or Anthropic WIF on newer
+  compiler versions that support it.
+- The current imported workflows in this repo use the Copilot engine and the
+  GH-AW-generated Copilot/GitHub token contract.
 
-**Production** (full model tiering):
-```
-AI_MODEL        = openrouter/auto
-AI_MODEL_PLAN   = anthropic/claude-opus-4
-AI_MODEL_REVIEW = anthropic/claude-sonnet-4
-AI_MODEL_CODE   = anthropic/claude-sonnet-4
-AI_MODEL_ISSUES = anthropic/claude-sonnet-4
-AI_MODEL_DOCS   = anthropic/claude-haiku-4
-AI_MODEL_OPS    = anthropic/claude-haiku-4
-```
+Keep the `AI_TOKEN` contract for reusable Claude Code Action workflows. Do not
+rename GH-AW-generated engine secrets by hand in `.lock.yml` files.
 
-All variables are set as GitHub repo variables (Settings → Variables → Actions), not secrets. Model names are not sensitive.
-
-### OpenRouter Model Names
-
-OpenRouter uses the format `provider/model-name`. Common examples:
-
-| Model | OpenRouter Name |
-|-------|----------------|
-| Claude Opus 4 | `anthropic/claude-opus-4` |
-| Claude Sonnet 4 | `anthropic/claude-sonnet-4` |
-| Claude Haiku 4 | `anthropic/claude-haiku-4` |
-| Free auto-router | `openrouter/free` |
-| Smart auto-router | `openrouter/auto` |
-
-The `openrouter/free` router automatically selects from available free models based on your request. The `openrouter/auto` router picks the best model for each request (costs money but optimizes quality).
-
----
-
-## Testing Your Setup
-
-Use the smoke test workflow to verify your provider configuration works:
+## Smoke Test
 
 ```bash
-# Quick validation (uses repo's default provider):
-gh workflow run smoke-test.yml --repo JacobPEvans/ai-workflows
-
-# Test each provider:
-gh workflow run smoke-test.yml -f provider=openrouter
-gh workflow run smoke-test.yml -f provider=anthropic
-gh workflow run smoke-test.yml -f provider=chutes
-
-# Test a specific model:
-gh workflow run smoke-test.yml -f provider=openrouter -f model=openrouter/free
-
-# Watch the result:
-gh run watch
+gh workflow run smoke-test.yml
+gh workflow run smoke-test.yml -f provider=openrouter -f model=<model>
+gh workflow run smoke-test.yml -f provider=anthropic_api -f model=sonnet
 ```
 
-The smoke test runs a trivial Claude prompt and verifies the response. No PR, issue, or branch required.
-
-For full end-to-end workflow testing (issue lifecycle, CI fix, etc.), see [VERIFICATION.md](VERIFICATION.md).
+The smoke test uses `AI_TOKEN`, `AI_PROVIDER`, `AI_BASE_URL`, and `AI_MODEL` the
+same way the reusable workflows do.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -6,7 +6,11 @@ Add ai-workflows reusable workflows to your repository using thin caller files.
 
 1. [GitHub CLI](https://cli.github.com/) installed and authenticated
 2. One secret configured in your repository:
-   - `OPENROUTER_API_KEY` — OpenRouter API key (required by all workflows; see [README — Authentication](../README.md#authentication--api-providers))
+   - `AI_TOKEN` — provider credential for Claude Code Action workflows; see [README — Authentication](../README.md#authentication)
+3. Optional variables when you want to override defaults:
+   - `AI_PROVIDER` — defaults to `claude_oauth`
+   - `AI_BASE_URL` — required for `openrouter` or another Anthropic-compatible router
+   - `AI_MODEL` or category model variables such as `AI_MODEL_DOCS`
 
 ## How It Works
 
@@ -264,6 +268,27 @@ permissions:
   contents: read
   id-token: write
 ```
+
+#### Public docs updater
+The public docs updater is a GitHub Agentic Workflow wrapper importing
+GitHubNext Agentics `doc-updater.md`. GH-AW workflows are not `workflow_call`
+reusable workflows, so the executable `.md` source and compiled `.lock.yml` live
+in the target docs repository that should receive the PR, not in this reusable
+workflow catalog.
+
+```yaml
+on:
+  schedule: daily
+  workflow_dispatch:
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+```
+
+This workflow uses GH-AW engine authentication, not the Claude Code Action
+`AI_TOKEN` contract. With the current pinned GH-AW compiler, the wrapper uses
+the Copilot engine and its GH-AW-managed secrets.
 
 ---
 

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -1,7 +1,9 @@
 # Patterns Reference
 
-All workflows in this repository use `anthropics/claude-code-action@v1` with OIDC auth.
-The following patterns are used across the 15 reusable workflows.
+Reusable workflows in this repository call `anthropics/claude-code-action@v1`
+through `.github/actions/run-claude-code`. The shared action keeps provider
+routing behind `AI_TOKEN`, `AI_PROVIDER`, `AI_BASE_URL`, and model variables.
+The following patterns are used across the reusable workflows and GH-AW imports.
 
 ---
 
@@ -16,7 +18,9 @@ Used by most workflows. Static prompt, read-only tools.
 - `id-token: write` at both workflow-level and job-level permissions
 - Cross-repo checkout of `.github/prompts` and `.github/scripts`
 - `render-prompt.sh` to render the static prompt into a step output
-- `claude-code-action@v1` with `anthropic_api_key:`, `ANTHROPIC_BASE_URL` env (sourced from `secrets.OPENROUTER_BASE_URL`), `allowed_bots:`, and `prompt:`
+- `dryvist/ai-workflows/.github/actions/run-claude-code@main` with `AI_TOKEN`,
+  `AI_PROVIDER`, optional `AI_BASE_URL`, `allowed_bots`, `prompt`, `allowed_tools`,
+  and `model`
 
 ```yaml
 - name: Render prompt
@@ -24,16 +28,16 @@ Used by most workflows. Static prompt, read-only tools.
   run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/<name>.md
 
 - name: Run Claude
-  uses: anthropics/claude-code-action@v1
-  env:
-    ANTHROPIC_BASE_URL: ${{ secrets.OPENROUTER_BASE_URL }}
+  uses: dryvist/ai-workflows/.github/actions/run-claude-code@main
   with:
-    anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+    ai_provider: ${{ vars.AI_PROVIDER || 'claude_oauth' }}
+    ai_token: ${{ secrets.AI_TOKEN }}
+    ai_base_url: ${{ vars.AI_BASE_URL || secrets.AI_BASE_URL || '' }}
     allowed_bots: "github-actions"
+    use_commit_signing: "false"
     prompt: ${{ steps.prompt.outputs.content }}
-    claude_args: >-
-      --allowedTools "Read,Glob,Grep,LS,Bash(gh issue:*)"
-      --model ${{ vars.AI_MODEL_EXAMPLE || vars.AI_MODEL }}
+    allowed_tools: "Read,Glob,Grep,LS,Bash(gh issue:*)"
+    model: ${{ vars.AI_MODEL_EXAMPLE || vars.AI_MODEL || 'sonnet' }}
 ```
 
 ---
@@ -50,25 +54,54 @@ Used by workflows that create commits or PRs. Adds `use_commit_signing: "true"` 
 
 ```yaml
 - name: Run Claude
-  uses: anthropics/claude-code-action@v1
-  env:
-    ANTHROPIC_BASE_URL: ${{ secrets.OPENROUTER_BASE_URL }}
+  uses: dryvist/ai-workflows/.github/actions/run-claude-code@main
   with:
-    anthropic_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+    ai_provider: ${{ vars.AI_PROVIDER || 'claude_oauth' }}
+    ai_token: ${{ secrets.AI_TOKEN }}
+    ai_base_url: ${{ vars.AI_BASE_URL || secrets.AI_BASE_URL || '' }}
     allowed_bots: "github-actions"
     use_commit_signing: "true"
     prompt: ${{ steps.prompt.outputs.content }}
-    claude_args: >-
-      --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git log:*),Bash(git diff:*),
-      Bash(git show:*),Bash(git status:*),Bash(git branch:*),Bash(gh pr:*)"
-      --model ${{ vars.AI_MODEL_EXAMPLE || vars.AI_MODEL }}
+    allowed_tools: "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),Bash(git branch:*),Bash(gh pr:*)"
+    model: ${{ vars.AI_MODEL_EXAMPLE || vars.AI_MODEL || 'sonnet' }}
+    app_id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
+    app_private_key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}
 ```
-
-The `--allowedTools` value above spans two lines for readability; in production workflow files, keep it on
-a single line within the `>-` block (or consult `.github/workflows/*.yml` for the canonical form).
 
 Uses GitHub API commit signing. Commits are automatically verified as the Claude GitHub App.
 `Bash(git:*)` is restricted to read-only subcommands to prevent unsigned CLI commits.
+
+## GitHub Agentic Workflow Import Pattern
+
+Used for GitHubNext Agentics workflows. These are authored as `.md` files and
+compiled to generated `.lock.yml` files.
+
+**Example**: public-docs-updater, installed in `dryvist/docs`
+
+```yaml
+---
+engine: copilot
+imports:
+  - githubnext/agentics/workflows/doc-updater.md@main
+on:
+  schedule: daily
+  workflow_dispatch:
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+---
+```
+
+Run:
+
+```bash
+gh aw compile public-docs-updater --action-tag v0.68.3
+```
+
+Commit the `.md`, generated `.lock.yml`, and `.github/aw/imports/**` cache
+together in the repository where the workflow should run. Do not edit
+`.lock.yml` by hand.
 
 ---
 
@@ -224,7 +257,7 @@ Four layers of bot filtering apply, depending on workflow type.
 `claude-code-action@v1` internally rejects Bot-type `github.actor` values. All dispatch patterns
 (`gh workflow run` with `GITHUB_TOKEN`) set `github.actor` to `github-actions[bot]`, which would cause "Workflow initiated by non-human actor" failures.
 
-**Fix**: Every `claude-code-action@v1` step includes `allowed_bots: "github-actions"`. This allows the trusted internal dispatch actor while blocking external bots.
+**Fix**: Every shared `run-claude-code` call includes `allowed_bots: "github-actions"`. This allows the trusted internal dispatch actor while blocking external bots.
 
 **Exception**: ci-fix uses `allowed_bots: "github-actions,claude"` because `workflow_run` events propagate the original actor.
 When `claude[bot]` pushes a commit, `github.actor` is `claude[bot]` — the action strips `[bot]` and checks against `allowed_bots`.
@@ -233,7 +266,7 @@ Loop prevention is handled by the attempt counter (max 2), not by blocking the a
 ### Layer 2: PR author pre-check (`if:` on action steps)
 
 When a bot creates a PR (e.g., the `claude` GitHub App), `claude-code-action@v1`'s built-in bot guard hard-fails the step —
-producing a red CI failure. The fix: add an `if:` condition directly on the `claude-code-action` step
+producing a red CI failure. The fix: add an `if:` condition directly on the shared action step
 (and any steps that depend on its output) to check the PR author type *before* the action runs.
 
 ```yaml
@@ -245,7 +278,7 @@ producing a red CI failure. The fix: add an `if:` condition directly on the `cla
             contains(inputs.allowed_bots, github.event.pull_request.user.login) ||
             contains(inputs.allowed_bots, '*')
           )
-        uses: anthropics/claude-code-action@v1
+        uses: dryvist/ai-workflows/.github/actions/run-claude-code@main
 ```
 
 When a bot creates the PR and isn't in `allowed_bots`, the step shows as **skipped** (grey) — not failed (red). CI stays green.

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -1,13 +1,14 @@
 # Verification Runbook
 
-This document describes how to verify all 15 workflows are operational after deployment.
+This document describes how to verify the core workflow set after deployment.
 Run via `.github/scripts/verification/e2e-test.sh` or manually using the steps below.
 
 ## Prerequisites
 
 - `gh` CLI authenticated with sufficient scopes
 - All consumer repos updated to `@v0.5.0`
-- Secrets configured: `OPENROUTER_API_KEY`, `ANTHROPIC_API_KEY`, or `CHUTES_API_KEY` (depending on your provider)
+- Secret configured: `AI_TOKEN`
+- Optional provider variables: `AI_PROVIDER`, `AI_BASE_URL`, `AI_MODEL`
 
 ## Consumer Repos
 
@@ -22,18 +23,19 @@ Run via `.github/scripts/verification/e2e-test.sh` or manually using the steps b
 The fastest way to verify auth and model routing. No PR or issue needed.
 
 ```bash
-# Test OpenRouter (default provider):
+# Test default Claude OAuth provider:
 gh workflow run smoke-test.yml
 gh run watch
 
 # Test with a specific model:
-gh workflow run smoke-test.yml -f provider=openrouter -f model=openrouter/free
+gh workflow run smoke-test.yml -f model=sonnet
 
-# Test Anthropic direct:
-gh workflow run smoke-test.yml -f provider=anthropic -f model=anthropic/claude-haiku-4
+# Test direct Anthropic API:
+gh workflow run smoke-test.yml -f provider=anthropic_api -f model=sonnet
 
-# Test Chutes.ai:
-gh workflow run smoke-test.yml -f provider=chutes
+# Test OpenRouter or another Anthropic-compatible router:
+gh workflow run smoke-test.yml -f provider=openrouter -f model=<model>
+gh workflow run smoke-test.yml -f provider=anthropic_compatible -f model=<model>
 ```
 
 **Pass condition**: Workflow completes with `conclusion: success`. The default prompt verifies the model can respond coherently.
@@ -225,7 +227,7 @@ done
 | D: CI Fix | ci-fix | Run triggered, fix attempted |
 | E: Scheduled (next run) | best-practices, code-simplifier, next-steps, issue-sweeper, issue-hygiene | conclusion != failure |
 
-**Total**: 12 of 15 workflows verified via real triggers. (claude-review and final-pr-review are indirectly covered via Tests A and B.)
+**Total**: 12 core workflows verified via real triggers. (claude-review and final-pr-review are indirectly covered via Tests A and B.)
 
 ---
 


### PR DESCRIPTION
## Summary

- route Claude Code workflows through AI-agnostic `AI_TOKEN`, `AI_PROVIDER`, `AI_BASE_URL`, and model variables
- default reusable workflows to Claude (`claude_oauth` + `sonnet`) while keeping OpenRouter fully configurable by org secrets/variables
- document GH-AW authentication limits and the correct install pattern for target-repo `.md` + `.lock.yml` workflows

## Validation

- `bun test`
- `git diff --check`

## Companion

- Refs: dryvist/docs#75
