### PR TITLE
ci(dogfood): pin dogfood-ci suite-ci to @main

### DIFF
--- a/.github/workflows/dogfood-ci.yml
+++ b/.github/workflows/dogfood-ci.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   ci-suite:
-    uses: dryvist/ai-workflows/.github/workflows/suite-ci.yml@v0.16.0
+    uses: dryvist/ai-workflows/.github/workflows/suite-ci.yml@main
     with:
       repo_context: "Reusable GitHub Actions workflows for AI-powered CI/CD automation (prompts, scripts, YAML workflows)"
       ci_structure: "test.yml (bun test for JavaScript scripts)"


### PR DESCRIPTION
Bumps the dogfood-ci suite-ci reference from the stale `@v0.16.0` to `@main` so the repo's self-test exercises the current (post-#251) cc-ci-fix + generic-auth chain. Enables live validation of the auto-fix loop.