### PR TITLE
fix(auth)!: authenticate via Claude Code OAuth token, not API key

### DIFF
--- a/.github/actions/run-claude-code/action.yml
+++ b/.github/actions/run-claude-code/action.yml
@@ -24,10 +24,10 @@ inputs:
       Full --allowedTools value forwarded inside `claude_args`. Each caller
       owns its own tool scope so the policy stays visible in the workflow.
     required: true
-  anthropic_api_key:
+  claude_code_oauth_token:
     description: >-
-      API key for the LLM provider, sourced from the caller's
-      `secrets.GH_ACTION_AI_API_KEY`. Pass-through; treat as secret at the caller.
+      Claude Code OAuth token, sourced from the caller's
+      `secrets.GH_ACTION_AI_OAUTH_TOKEN`. Pass-through; treat as secret at the caller.
     required: true
   app_id:
     description: JacobPEvans-claude App ID, e.g. the caller's `vars.GH_APP_CLAUDE_BOT_ID`.
@@ -55,13 +55,13 @@ runs:
     - name: Validate configuration
       shell: bash
       env:
-        API_KEY: ${{ inputs.anthropic_api_key }}
+        OAUTH_TOKEN: ${{ inputs.claude_code_oauth_token }}
         APP_ID: ${{ inputs.app_id }}
         APP_PRIVATE_KEY: ${{ inputs.app_private_key }}
         USE_COMMIT_SIGNING: ${{ inputs.use_commit_signing }}
       run: |
-        if [ -z "$API_KEY" ]; then
-          echo "::error::anthropic_api_key is required (map the caller's secrets.GH_ACTION_AI_API_KEY)"
+        if [ -z "$OAUTH_TOKEN" ]; then
+          echo "::error::claude_code_oauth_token is required (map the caller's secrets.GH_ACTION_AI_OAUTH_TOKEN)"
           exit 1
         fi
 
@@ -95,7 +95,7 @@ runs:
       uses: anthropics/claude-code-action@v1
       with:
         github_token: ${{ steps.app-token.outputs.token || github.token }}
-        anthropic_api_key: ${{ inputs.anthropic_api_key }}
+        claude_code_oauth_token: ${{ inputs.claude_code_oauth_token }}
         allowed_bots: ${{ inputs.allowed_bots }}
         use_commit_signing: ${{ inputs.use_commit_signing }}
         prompt: ${{ inputs.prompt }}

--- a/.github/workflows/best-practices.yml
+++ b/.github/workflows/best-practices.yml
@@ -118,7 +118,7 @@ jobs:
       - name: Run Claude
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.GH_ACTION_AI_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.GH_ACTION_AI_OAUTH_TOKEN }}
           allowed_bots: "github-actions"
           prompt: ${{ steps.prompt.outputs.content }}
           claude_args: >-

--- a/.github/workflows/cc-ci-fix.yml
+++ b/.github/workflows/cc-ci-fix.yml
@@ -228,7 +228,7 @@ jobs:
           prompt: ${{ steps.prompt.outputs.content }}
           model: ${{ vars.GH_ACTION_AI_MODEL_CODE || vars.GH_ACTION_AI_MODEL }}
           allowed_tools: "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),Bash(git branch:*)${{ inputs.extra_tools != '' && format(',{0}', inputs.extra_tools) || '' }}"
-          anthropic_api_key: ${{ secrets.GH_ACTION_AI_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.GH_ACTION_AI_OAUTH_TOKEN }}
           app_id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
           app_private_key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}
           allowed_bots: "github-actions,claude"

--- a/.github/workflows/cc-code-simplifier.yml
+++ b/.github/workflows/cc-code-simplifier.yml
@@ -126,6 +126,6 @@ jobs:
           prompt: ${{ steps.prompt.outputs.content }}
           model: ${{ vars.GH_ACTION_AI_MODEL_CODE || vars.GH_ACTION_AI_MODEL }}
           allowed_tools: "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),Bash(git branch:*),Bash(gh pr:*),Bash(gh api:*)"
-          anthropic_api_key: ${{ secrets.GH_ACTION_AI_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.GH_ACTION_AI_OAUTH_TOKEN }}
           app_id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
           app_private_key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}

--- a/.github/workflows/cc-issue-resolver.yml
+++ b/.github/workflows/cc-issue-resolver.yml
@@ -150,7 +150,7 @@ jobs:
           prompt: ${{ steps.prompt.outputs.content }}
           model: ${{ inputs.model || vars.GH_ACTION_AI_MODEL_PLAN || vars.GH_ACTION_AI_MODEL }}
           allowed_tools: "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),Bash(git branch:*),Bash(gh pr create:*),Bash(gh issue comment:*)${{ inputs.extra_tools != '' && format(',{0}', inputs.extra_tools) || '' }}"
-          anthropic_api_key: ${{ secrets.GH_ACTION_AI_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.GH_ACTION_AI_OAUTH_TOKEN }}
           app_id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
           app_private_key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}
 

--- a/.github/workflows/cc-next-steps.yml
+++ b/.github/workflows/cc-next-steps.yml
@@ -125,7 +125,7 @@ jobs:
       - name: Execute Claude Code
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.GH_ACTION_AI_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.GH_ACTION_AI_OAUTH_TOKEN }}
           allowed_bots: "github-actions"
           use_commit_signing: "true"
           prompt: ${{ steps.prompt.outputs.content }}

--- a/.github/workflows/cc-post-merge-docs-review.yml
+++ b/.github/workflows/cc-post-merge-docs-review.yml
@@ -167,6 +167,6 @@ jobs:
           prompt: ${{ steps.prompt.outputs.content }}
           model: ${{ vars.GH_ACTION_AI_MODEL }}
           allowed_tools: "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),Bash(git branch:*),Bash(gh pr:*),Bash(gh api:*),Bash(gh search:*)"
-          anthropic_api_key: ${{ secrets.GH_ACTION_AI_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.GH_ACTION_AI_OAUTH_TOKEN }}
           app_id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
           app_private_key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}

--- a/.github/workflows/cc-post-merge-tests.yml
+++ b/.github/workflows/cc-post-merge-tests.yml
@@ -167,6 +167,6 @@ jobs:
           prompt: ${{ steps.prompt.outputs.content }}
           model: ${{ vars.GH_ACTION_AI_MODEL_CODE || vars.GH_ACTION_AI_MODEL }}
           allowed_tools: "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),Bash(git branch:*),Bash(gh pr:*),Bash(gh api:*),Bash(gh search:*)"
-          anthropic_api_key: ${{ secrets.GH_ACTION_AI_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.GH_ACTION_AI_OAUTH_TOKEN }}
           app_id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
           app_private_key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -143,7 +143,7 @@ jobs:
           )
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.GH_ACTION_AI_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.GH_ACTION_AI_OAUTH_TOKEN }}
           allowed_bots: "github-actions"
           track_progress: true
           prompt: ${{ steps.prompt.outputs.content }}
@@ -172,7 +172,7 @@ jobs:
       - name: Run Claude Interactive
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.GH_ACTION_AI_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.GH_ACTION_AI_OAUTH_TOKEN }}
           allowed_bots: "github-actions"
           claude_args: |
             --model ${{ vars.GH_ACTION_AI_MODEL }} --allowedTools "Read,Glob,Grep,LS,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh issue comment:*)"

--- a/.github/workflows/final-pr-review.yml
+++ b/.github/workflows/final-pr-review.yml
@@ -146,7 +146,7 @@ jobs:
           prompt: ${{ steps.prompt.outputs.content }}
           model: ${{ vars.GH_ACTION_AI_MODEL }}
           allowed_tools: "Read,Glob,Grep,LS,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*)"
-          anthropic_api_key: ${{ secrets.GH_ACTION_AI_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.GH_ACTION_AI_OAUTH_TOKEN }}
           app_id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
           app_private_key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}
           use_commit_signing: "false"

--- a/.github/workflows/issue-hygiene.yml
+++ b/.github/workflows/issue-hygiene.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Execute Claude Code
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.GH_ACTION_AI_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.GH_ACTION_AI_OAUTH_TOKEN }}
           allowed_bots: "github-actions"
           prompt: ${{ steps.prompt.outputs.content }}
           claude_args: >-

--- a/.github/workflows/issue-linker.yml
+++ b/.github/workflows/issue-linker.yml
@@ -112,7 +112,7 @@ jobs:
           contains(inputs.allowed_bots, '*')
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.GH_ACTION_AI_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.GH_ACTION_AI_OAUTH_TOKEN }}
           allowed_bots: "github-actions"
           model: ${{ inputs.model || vars.GH_ACTION_AI_MODEL_ISSUES || vars.GH_ACTION_AI_MODEL }}
           prompt: ${{ steps.render-prompt.outputs.content }}

--- a/.github/workflows/issue-sweeper.yml
+++ b/.github/workflows/issue-sweeper.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Execute Claude Code
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.GH_ACTION_AI_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.GH_ACTION_AI_OAUTH_TOKEN }}
           allowed_bots: "github-actions"
           prompt: ${{ steps.prompt.outputs.content }}
           claude_args: >-

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Run Claude
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.GH_ACTION_AI_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.GH_ACTION_AI_OAUTH_TOKEN }}
           allowed_bots: "github-actions"
           prompt: ${{ steps.prompt.outputs.content }}
           claude_args: >-

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Run Claude
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.GH_ACTION_AI_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.GH_ACTION_AI_OAUTH_TOKEN }}
           allowed_bots: "github-actions"
           prompt: ${{ steps.prompt.outputs.content }}
           claude_args: >-

--- a/.github/workflows/repo-orchestrator.yml
+++ b/.github/workflows/repo-orchestrator.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Run Claude
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.GH_ACTION_AI_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.GH_ACTION_AI_OAUTH_TOKEN }}
           allowed_bots: "github-actions"
           prompt: ${{ steps.prompt.outputs.content }}
           claude_args: >-


### PR DESCRIPTION
## Root cause

The `run-claude-code` composite passed the credential as `anthropic_api_key` (→ `x-api-key` header). A Claude Code **OAuth token** sent on that header is rejected by `api.anthropic.com` with an instant 401 (`is_error: true`, `duration_ms: ~168`, `total_cost_usd: 0`) — which is exactly what the dogfood cc-ci-fix runs showed. Token freshness was never the issue; the **header** was.

## Fix

- Composite: input `anthropic_api_key` → `claude_code_oauth_token`, forwarded to claude-code-action's `claude_code_oauth_token` input; validation updated.
- All workflows: `claude_code_oauth_token: ${{ secrets.GH_ACTION_AI_OAUTH_TOKEN }}`.

## ⚠️ BREAKING

Create org secret **`GH_ACTION_AI_OAUTH_TOKEN`** = a fresh Claude Code OAuth token (`sk-ant-oat-…`, e.g. from `claude setup-token`). The old `GH_ACTION_AI_API_KEY` is no longer read. For OAuth, leaving `GH_ACTION_AI_BASE_URL` empty (or at `https://api.anthropic.com`) is fine.

Validation: `bun test` 147/0; actionlint clean on cc-ci-fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)