### PR TITLE
fix(cc-ci-fix): commit all working-tree changes (capture formatter fixes)

### DIFF
--- a/.github/prompts/ci-fix.md
+++ b/.github/prompts/ci-fix.md
@@ -1,21 +1,23 @@
-## CI Failure Auto-Fix
+# CI Failure Auto-Fix
 
 You are fixing a CI failure. Context: ${REPO_CONTEXT}
 
-### CI Structure
+## CI Structure
+
 ${CI_STRUCTURE}
 
-### Failure Logs
-```
+## Failure Logs
+
+```text
 ${FAILURE_LOGS}
 ```
 
-### Instructions
-1. Analyze the failure logs to identify the root cause
-2. Fix the issue in the source files
-3. Commit all changed files to the PR branch with message:
-   ```
-   fix: resolve CI failure (auto-fix attempt ${ATTEMPT_NUM})
-   ```
+## Instructions
 
-Only fix what the CI is complaining about. Do not refactor or improve unrelated code.
+1. Analyze the failure logs to identify the root cause
+2. Fix the issue in the source files (use your edit tools or shell tools such as
+   formatters as appropriate)
+
+Do NOT run `git add`, `git commit`, or `git push` — the workflow commits and
+pushes your working-tree changes automatically after you finish. Only fix what
+the CI is complaining about; do not refactor or improve unrelated code.

--- a/.github/scripts/ci-fix/commit-fix.sh
+++ b/.github/scripts/ci-fix/commit-fix.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Commit Claude's working-tree changes and push to the PR branch.
+#
+# cc-ci-fix runs claude-code-action with use_commit_signing=false, so Claude
+# applies its fix to the working tree but commits nothing. This captures ALL of
+# those changes — whether made via the Edit/Write tools or via Bash tools like
+# formatters (tofu fmt, prettier, ruff) — which the commit-signing path misses.
+#
+# Env: APP_TOKEN, BOT_SLUG, ATTEMPT_NUM, BRANCH, REPO, GH_TOKEN.
+
+cd "${GITHUB_WORKSPACE}"
+
+# Stage everything except the ai-workflows sparse checkout mounted at .ai-workflows.
+git add -A -- ':!.ai-workflows'
+
+if git diff --cached --quiet; then
+  echo "No changes staged — Claude produced no fix to commit."
+  exit 0
+fi
+
+bot="${BOT_SLUG}[bot]"
+user_id="$(gh api "/users/${bot}" --jq .id 2>/dev/null || echo "")"
+git config user.name "${bot}"
+if [ -n "${user_id}" ]; then
+  git config user.email "${user_id}+${bot}@users.noreply.github.com"
+else
+  git config user.email "${bot}@users.noreply.github.com"
+fi
+
+git commit -m "fix: resolve CI failure (auto-fix attempt ${ATTEMPT_NUM})"
+git push "https://x-access-token:${APP_TOKEN}@github.com/${REPO}.git" "HEAD:${BRANCH}"
+echo "Pushed fix commit to ${BRANCH} as ${bot}"

--- a/.github/workflows/cc-ci-fix.yml
+++ b/.github/workflows/cc-ci-fix.yml
@@ -219,19 +219,39 @@ jobs:
           REPO_CONTEXT: ${{ inputs.repo_context }}
           CI_STRUCTURE: ${{ inputs.ci_structure }}
           FAILURE_LOGS: ${{ needs.get-failure-details.outputs.failure_logs }}
-          ATTEMPT_NUM: ${{ needs.should-fix.outputs.attempt }}
-        run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/ci-fix.md FAILURE_LOGS REPO_CONTEXT CI_STRUCTURE ATTEMPT_NUM
+        run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/ci-fix.md FAILURE_LOGS REPO_CONTEXT CI_STRUCTURE
 
-      - name: Run Claude Code with bot attribution
+      # Claude applies the fix to the working tree but commits nothing
+      # (use_commit_signing=false). The commit step below captures ALL changes —
+      # including formatter/shell fixes that the commit-signing path would miss.
+      - name: Run Claude Code
         uses: dryvist/ai-workflows/.github/actions/run-claude-code@main
         with:
           prompt: ${{ steps.prompt.outputs.content }}
           model: ${{ vars.GH_ACTION_AI_MODEL_CODE || vars.GH_ACTION_AI_MODEL }}
           allowed_tools: "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),Bash(git branch:*)${{ inputs.extra_tools != '' && format(',{0}', inputs.extra_tools) || '' }}"
           claude_code_oauth_token: ${{ secrets.GH_ACTION_AI_API_KEY }}
-          app_id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
-          app_private_key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}
+          use_commit_signing: "false"
           allowed_bots: "github-actions,claude"
+
+      - name: Mint bot token for commit
+        id: commit-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
+          private-key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+
+      - name: Commit and push fix
+        env:
+          APP_TOKEN: ${{ steps.commit-token.outputs.token }}
+          BOT_SLUG: ${{ steps.commit-token.outputs.app-slug }}
+          ATTEMPT_NUM: ${{ needs.should-fix.outputs.attempt }}
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
+          REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: bash .ai-workflows/.github/scripts/ci-fix/commit-fix.sh
 
       - name: Comment on failure
         if: failure()


### PR DESCRIPTION
cc-ci-fix ran Claude with `use_commit_signing: true`, which only commits Edit/Write tool changes — fixes applied via Bash tools (formatters like `tofu fmt`) were made but never committed (validated empirically on tofu-aws-templates + the dogfood). 

Now: Claude runs with `use_commit_signing: false` (applies the fix to the working tree), then a post-step commits **all** working-tree changes and pushes via the bot App token (`commit-fix.sh`), attributed to JacobPEvans-claude[bot] so CI re-triggers. The `.ai-workflows` sparse checkout is excluded. Prompt updated so Claude doesn't attempt its own commit.

actionlint + shellcheck clean.