### PR TITLE
fix(cc-ci-fix): restore createCommitOnBranch (native use_commit_signing proven dead under workflow_run)

### DIFF
--- a/.github/scripts/ci-fix/commit-fix.js
+++ b/.github/scripts/ci-fix/commit-fix.js
@@ -1,0 +1,73 @@
+// Commit Claude's working-tree changes to the PR branch via the GitHub
+// `createCommitOnBranch` GraphQL mutation. The octokit passed in is authed with
+// the JacobPEvans-claude App installation token, so the resulting commit is
+// GitHub-VERIFIED (satisfies `required_signatures` rulesets), attributed to the
+// bot, and re-triggers CI on the PR.
+//
+// This is the workflow_run-compatible replacement for claude-code-action's own
+// `use_commit_signing`: that path can only target a branch when the trigger
+// event carries PR context (pull_request/issue_comment), which workflow_run does
+// not. Here we supply the branch (the failing PR's head) explicitly.
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+
+module.exports = async ({ github, context, core }) => {
+  const branch = process.env.HEAD_BRANCH;
+  const message = process.env.COMMIT_MESSAGE;
+  if (!branch) {
+    core.setFailed('HEAD_BRANCH env var is required');
+    return;
+  }
+
+  const git = (args) => execFileSync('git', args, { encoding: 'utf8' });
+
+  // Stage everything except the ai-workflows checkout that lives in the
+  // consumer workspace (it must never be committed into the consumer repo).
+  git(['add', '-A', '--', ':(exclude).ai-workflows']);
+
+  const status = git(['diff', '--cached', '--name-status']).trim();
+  if (!status) {
+    core.info('Claude made no file changes — nothing to commit.');
+    core.setOutput('committed', 'false');
+    return;
+  }
+
+  const additions = [];
+  const deletions = [];
+  const stage = (p) => additions.push({ path: p, contents: fs.readFileSync(p).toString('base64') });
+  // ponytail: --name-status quotes paths with spaces/special chars; the tab-split
+  // below assumes plain paths. Switch to `-z` parsing if a consumer hits that.
+  for (const line of status.split('\n')) {
+    const parts = line.split('\t');
+    const code = parts[0][0];
+    if (code === 'D') {
+      deletions.push({ path: parts[1] });
+    } else if (code === 'R' || code === 'C') {
+      if (code === 'R') deletions.push({ path: parts[1] });
+      stage(parts[2]);
+    } else {
+      stage(parts[1]); // A (added) or M (modified)
+    }
+  }
+
+  const expectedHeadOid = git(['rev-parse', 'HEAD']).trim();
+  const { owner, repo } = context.repo;
+  const result = await github.graphql(
+    `mutation ($input: CreateCommitOnBranchInput!) {
+       createCommitOnBranch(input: $input) { commit { oid url } }
+     }`,
+    {
+      input: {
+        branch: { repositoryNameWithOwner: `${owner}/${repo}`, branchName: branch },
+        message: { headline: message },
+        expectedHeadOid,
+        fileChanges: { additions, deletions },
+      },
+    },
+  );
+
+  const commit = result.createCommitOnBranch.commit;
+  core.info(`Committed ${additions.length} change(s), ${deletions.length} deletion(s) to ${branch}: ${commit.url}`);
+  core.setOutput('committed', 'true');
+  core.setOutput('commit_oid', commit.oid);
+};

--- a/.github/workflows/cc-ci-fix.yml
+++ b/.github/workflows/cc-ci-fix.yml
@@ -221,22 +221,40 @@ jobs:
           FAILURE_LOGS: ${{ needs.get-failure-details.outputs.failure_logs }}
         run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/ci-fix.md FAILURE_LOGS REPO_CONTEXT CI_STRUCTURE
 
-      # The PR branch is checked out above as a real branch, so claude-code-action's
-      # native use_commit_signing path commits Claude's Edit/Write changes to it via
-      # GitHub's web-flow API — GitHub-VERIFIED (satisfies required_signatures),
-      # attributed to JacobPEvans-claude[bot], and re-triggers CI. No custom commit
-      # step or signing key needed.
-      - name: Run Claude Code with bot attribution
+      # Claude only EDITS files (use_commit_signing: false) — claude-code-action's
+      # own commit path can't target a PR branch from a workflow_run trigger (no
+      # PR context in the event payload), so the edits stay in the working tree
+      # and the "Commit fix" step below commits them to the known PR branch.
+      - name: Run Claude Code
         uses: dryvist/ai-workflows/.github/actions/run-claude-code@main
         with:
           prompt: ${{ steps.prompt.outputs.content }}
           model: ${{ vars.GH_ACTION_AI_MODEL_CODE || vars.GH_ACTION_AI_MODEL }}
           allowed_tools: "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),Bash(git branch:*)${{ inputs.extra_tools != '' && format(',{0}', inputs.extra_tools) || '' }}"
           claude_code_oauth_token: ${{ secrets.GH_ACTION_AI_API_KEY }}
-          app_id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
-          app_private_key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}
-          use_commit_signing: "true"
+          use_commit_signing: "false"
           allowed_bots: "github-actions,claude"
+
+      # Mint an App token so the commit is authored by JacobPEvans-claude[bot] and
+      # GitHub-VERIFIED (createCommitOnBranch web-flow), satisfying
+      # required_signatures rulesets and re-triggering CI on the PR.
+      - name: Mint commit token
+        id: commit-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
+          private-key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}
+
+      - name: Commit fix to PR branch
+        uses: actions/github-script@v9
+        env:
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          COMMIT_MESSAGE: "fix: resolve CI failure (auto-fix attempt ${{ needs.should-fix.outputs.attempt }})"
+        with:
+          github-token: ${{ steps.commit-token.outputs.token }}
+          script: |
+            const run = require('./.ai-workflows/.github/scripts/ci-fix/commit-fix.js');
+            await run({ github, context, core });
 
       - name: Comment on failure
         if: failure()

--- a/tests/commit-fix.test.js
+++ b/tests/commit-fix.test.js
@@ -1,0 +1,115 @@
+const { describe, it, expect, beforeEach, afterEach, mock } = require('bun:test');
+const { createMockCore, createMockContext } = require('./helpers.js');
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const run = require('../.github/scripts/ci-fix/commit-fix.js');
+
+const git = (cwd, args) => execFileSync('git', args, { cwd, encoding: 'utf8' });
+
+function initRepo() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'commitfix-'));
+  git(dir, ['init', '-q', '-b', 'main']);
+  git(dir, ['config', 'user.email', 't@example.com']);
+  git(dir, ['config', 'user.name', 'tester']);
+  fs.writeFileSync(path.join(dir, 'main.tf'), 'orig\n');
+  fs.writeFileSync(path.join(dir, 'old.tf'), 'gone\n');
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-qm', 'init']);
+  return dir;
+}
+
+function makeGithub(commit = { oid: 'newoid', url: 'https://x/commit/newoid' }) {
+  return { graphql: mock(async () => ({ createCommitOnBranch: { commit } })) };
+}
+
+// Run the script with cwd pointed at the temp repo, restoring cwd afterwards.
+async function runIn(dir, deps) {
+  const prev = process.cwd();
+  process.chdir(dir);
+  try {
+    await run(deps);
+  } finally {
+    process.chdir(prev);
+  }
+}
+
+describe('commit-fix', () => {
+  let core, context, dir;
+
+  beforeEach(() => {
+    core = createMockCore();
+    context = createMockContext();
+    dir = initRepo();
+    process.env.HEAD_BRANCH = 'feat/x';
+    process.env.COMMIT_MESSAGE = 'fix: resolve CI failure (auto-fix attempt 1)';
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('commits modified + added files via createCommitOnBranch', async () => {
+    fs.writeFileSync(path.join(dir, 'main.tf'), 'fixed\n'); // modify
+    fs.writeFileSync(path.join(dir, 'vars.tf'), 'new\n'); // add
+    const github = makeGithub();
+
+    await runIn(dir, { github, context, core });
+
+    expect(github.graphql).toHaveBeenCalledTimes(1);
+    const input = github.graphql.mock.calls[0][1].input;
+    expect(input.branch).toEqual({ repositoryNameWithOwner: 'test-owner/test-repo', branchName: 'feat/x' });
+    expect(input.expectedHeadOid).toBe(git(dir, ['rev-parse', 'HEAD']).trim());
+    const adds = Object.fromEntries(input.fileChanges.additions.map((a) => [a.path, a.contents]));
+    expect(Object.keys(adds).sort()).toEqual(['main.tf', 'vars.tf']);
+    expect(adds['main.tf']).toBe(Buffer.from('fixed\n').toString('base64'));
+    expect(input.fileChanges.deletions).toEqual([]);
+    expect(core.getOutput('committed')).toBe('true');
+    expect(core.getOutput('commit_oid')).toBe('newoid');
+  });
+
+  it('handles deletions and renames', async () => {
+    fs.rmSync(path.join(dir, 'old.tf')); // delete
+    fs.renameSync(path.join(dir, 'main.tf'), path.join(dir, 'renamed.tf')); // rename (content identical → R100)
+    const github = makeGithub();
+
+    await runIn(dir, { github, context, core });
+
+    const input = github.graphql.mock.calls[0][1].input;
+    expect(input.fileChanges.deletions.map((d) => d.path).sort()).toEqual(['main.tf', 'old.tf']);
+    expect(input.fileChanges.additions.map((a) => a.path)).toEqual(['renamed.tf']);
+  });
+
+  it('never stages the .ai-workflows checkout', async () => {
+    fs.writeFileSync(path.join(dir, 'main.tf'), 'fixed\n');
+    fs.mkdirSync(path.join(dir, '.ai-workflows', 'scripts'), { recursive: true });
+    fs.writeFileSync(path.join(dir, '.ai-workflows', 'scripts', 'x.js'), 'leak\n');
+    const github = makeGithub();
+
+    await runIn(dir, { github, context, core });
+
+    const paths = github.graphql.mock.calls[0][1].input.fileChanges.additions.map((a) => a.path);
+    expect(paths).toEqual(['main.tf']);
+  });
+
+  it('no-ops when Claude made no changes', async () => {
+    const github = makeGithub();
+
+    await runIn(dir, { github, context, core });
+
+    expect(github.graphql).not.toHaveBeenCalled();
+    expect(core.getOutput('committed')).toBe('false');
+  });
+
+  it('fails when HEAD_BRANCH is missing', async () => {
+    delete process.env.HEAD_BRANCH;
+    const github = makeGithub();
+
+    await runIn(dir, { github, context, core });
+
+    expect(core.failures.length).toBe(1);
+    expect(github.graphql).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Reverts #267. Empirically proven via controlled A/B on tofu-aws-templates (identical fixture + workflow_run trigger):

| Mechanism | base_branch | Result |
| --- | --- | --- |
| `createCommitOnBranch` (#265, PR #16) | explicit | verified bot commit, CI green |
| native `use_commit_signing` (#267, PR #17) | `""` | no commit, no branch |

The #267 run was clean (`is_error: false`, `num_turns: 3`, `permission_denials_count: 0`) yet claude-code-action reported `base_branch: ""` and committed nothing — it cannot resolve the PR branch from a `workflow_run` event. Since `workflow_run` is the security-correct trigger for this privileged operation (fork PRs get no secrets), `createCommitOnBranch` (official GitHub API via first-party `actions/github-script`, no new deps) is the right primitive.

`bun test` green (152 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)