### PR TITLE
feat(issue-resolver): ai:ready trigger + no size cap + autonomous triage→resolve chain

### DIFF
--- a/.github/prompts/issue-triage.md
+++ b/.github/prompts/issue-triage.md
@@ -46,8 +46,19 @@ Otherwise, the issue details are available from the triggering event.
 6. **Respect form selections**: If the issue was created from a form template and already
    has type/size/priority labels set, do not override them.
 
-7. **Comment with triage summary**: Post a brief comment with:
+7. **Mark auto-resolvable** with the `ai:ready` label. Apply `ai:ready` when ALL of these hold:
+   - the `type:*` is one of `bug`, `chore`, `docs`, `ci`, `test`, `refactor`, `perf`
+     (NEVER for `type:security`, `type:feature`, or `type:breaking` — those need human design);
+   - none of `duplicate`, `invalid`, `wontfix`, `question` apply;
+   - the issue describes a concrete, self-contained change (not a vague discussion).
+
+   `ai:ready` is the trigger for autonomous resolution — apply it independently of `size:*`
+   (there is no size cap). If the issue is real but not safe to auto-resolve, label it fully
+   but withhold `ai:ready` and say why in the comment.
+
+8. **Comment with triage summary**: Post a brief comment with:
    - Applied labels and reasoning
+   - Whether `ai:ready` was applied (and, if withheld, why)
    - Duplicate reference if found
 
 ## Rules
@@ -55,5 +66,6 @@ Otherwise, the issue details are available from the triggering event.
 - Apply exactly one `type:*` label per issue.
 - Apply exactly one `size:*` label per issue (unless one already exists).
 - Apply exactly one `priority:*` label per issue (unless one already exists).
+- Apply `ai:ready` only when the step-7 criteria all hold.
 - Never remove existing labels.
 - Keep triage comments concise (under 200 words).

--- a/.github/scripts/issue-resolver/check-eligibility.js
+++ b/.github/scripts/issue-resolver/check-eligibility.js
@@ -60,7 +60,7 @@ module.exports = async ({ github, context, core }) => {
     }
   }
 
-  // Gates 3-7: Label checks — skip for manual triggers (human judged the issue appropriate)
+  // Gates 3-6: Label checks — skip for manual triggers (human judged the issue appropriate)
   if (!isManualTrigger) {
     // Gate 3: Required labels present — triage must have run
     const hasTypeLabel = labels.some(l => l.startsWith('type:'));
@@ -68,6 +68,15 @@ module.exports = async ({ github, context, core }) => {
     if (!hasTypeLabel || !hasSizeLabel) {
       core.setOutput('should_run', 'false');
       core.info(`Issue #${issueNumber} missing type: or size: labels — triage may not have run`);
+      return;
+    }
+
+    // Gate 3b: ai:ready present — the explicit trigger for autonomous resolution.
+    // Triage applies it to auto-resolvable issues; a human may apply it manually.
+    // No size cap: ai:ready resolves issues of any size.
+    if (!labels.includes('ai:ready')) {
+      core.setOutput('should_run', 'false');
+      core.info(`Issue #${issueNumber} not labeled ai:ready — skipping autonomous resolution`);
       return;
     }
 
@@ -103,15 +112,7 @@ module.exports = async ({ github, context, core }) => {
       core.info(`Issue #${issueNumber} type "${issueType}" not in allowed types`);
       return;
     }
-
-    // Gate 7: Allowed sizes — only xs and s are safe for auto-resolution
-    const allowedSizes = ['size:xs', 'size:s'];
-    const issueSize = labels.find(l => l.startsWith('size:'));
-    if (!allowedSizes.includes(issueSize)) {
-      core.setOutput('should_run', 'false');
-      core.info(`Issue #${issueNumber} size "${issueSize}" not in allowed sizes`);
-      return;
-    }
+    // No size gate: ai:ready (Gate 3b) authorizes resolution regardless of size:* label.
   }
 
   // Gate 8: No existing open PR already referencing this issue (always runs)

--- a/.github/workflows/cc-issue-resolver.yml
+++ b/.github/workflows/cc-issue-resolver.yml
@@ -32,7 +32,7 @@ on:
       excluded_labels:
         description: "Comma-separated labels that block auto-resolution"
         type: string
-        default: "type:security,type:feature,type:breaking,size:l,size:xl"
+        default: "type:security,type:feature,type:breaking"
       max_attempts:
         description: "Max resolution attempts per issue"
         type: string

--- a/examples/issue-auto-resolve-caller.yml
+++ b/examples/issue-auto-resolve-caller.yml
@@ -1,0 +1,71 @@
+# Example consumer caller for autonomous issue resolution.
+#
+# Drop this in your repo at .github/workflows/issue-auto-resolve.yml.
+#
+# Flow:
+#   - New/reopened issue  -> Claude triage labels it (type/size/priority, and ai:ready
+#     when auto-resolvable) -> if ai:ready, Claude (Opus) opens a PR that fully resolves it.
+#   - A human adding the `ai:ready` label re-triggers resolution directly.
+#   - workflow_dispatch with an issue_number resolves that issue manually (bypasses gates).
+#
+# Why triage and resolve chain in ONE run: a label added by GITHUB_TOKEN does NOT fire a
+# downstream `issues: labeled` workflow (GitHub loop-prevention), so we cannot rely on
+# triage's ai:ready label to start a separate resolver run. Chaining triage -> resolve
+# here is what makes the new-issue path autonomous.
+#
+# Required org/repo config (already set org-wide on dryvist):
+#   - secret  GH_ACTION_AI_API_KEY            Claude Code OAuth token
+#   - var     GH_ACTION_AI_MODEL_PLAN         e.g. "claude-opus-4-8" (resolver model)
+#   - var     GH_APP_CLAUDE_BOT_ID            GitHub App id (bot attribution)
+#   - secret  GH_APP_CLAUDE_BOT_PRIVATE_KEY   GitHub App private key (PEM)
+#   - label   ai:ready + type:*/size:*/priority:* present in the repo (see label-sync)
+
+name: Issue Auto-Resolve (Claude)
+
+on:
+  issues:
+    types: [opened, reopened, labeled]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Issue number to resolve"
+        required: true
+        type: string
+
+# Consumer callers must declare permissions explicitly.
+permissions:
+  contents: write
+  id-token: write
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: issue-auto-resolve-${{ github.event.issue.number || inputs.issue_number }}
+  cancel-in-progress: false # Never cancel — queue instead to avoid wasting AI tokens
+
+jobs:
+  # Triage only new/reopened issues. On a manual ai:ready label or workflow_dispatch the
+  # issue was already judged, so triage is skipped and resolve runs directly.
+  triage:
+    if: >-
+      github.event_name == 'issues' &&
+      (github.event.action == 'opened' || github.event.action == 'reopened')
+    uses: dryvist/ai-workflows/.github/workflows/issue-triage.yml@v0
+    secrets: inherit
+
+  resolve:
+    needs: [triage]
+    # Run after triage (new-issue path), when a human adds ai:ready, or on manual dispatch.
+    # Skip when a label OTHER than ai:ready was the trigger.
+    if: >-
+      always() &&
+      (needs.triage.result == 'success' || needs.triage.result == 'skipped') &&
+      !(github.event_name == 'issues' &&
+        github.event.action == 'labeled' &&
+        github.event.label.name != 'ai:ready')
+    uses: dryvist/ai-workflows/.github/workflows/cc-issue-resolver.yml@v0
+    secrets: inherit
+    with:
+      # Describe your repo so Claude has context (language, frameworks, how it builds).
+      repo_context: "<DESCRIBE THIS REPO: language, frameworks, how it builds and tests>"
+      issue_number: ${{ github.event.issue.number || inputs.issue_number || '0' }}

--- a/tests/issue-resolver-check-eligibility.test.js
+++ b/tests/issue-resolver-check-eligibility.test.js
@@ -10,7 +10,7 @@ describe('check-eligibility', () => {
       title: 'Test issue',
       body: 'Test body',
       author_association: 'OWNER',
-      labels: [{ name: 'type:bug' }, { name: 'size:xs' }],
+      labels: [{ name: 'type:bug' }, { name: 'size:xs' }, { name: 'ai:ready' }],
       ...overrides,
     };
   }
@@ -72,10 +72,18 @@ describe('check-eligibility', () => {
     expect(core.getOutput('should_run')).toBe('false');
   });
 
+  it('sets should_run=false when ai:ready is missing (gate 3b)', async () => {
+    github.rest.issues.get.mockResolvedValue({
+      data: buildIssue({ labels: [{ name: 'type:bug' }, { name: 'size:xs' }] }),
+    });
+    await run({ github, context, core });
+    expect(core.getOutput('should_run')).toBe('false');
+  });
+
   it('sets should_run=false when excluded label present (gate 4)', async () => {
     process.env.EXCLUDED_LABELS = 'blocked';
     github.rest.issues.get.mockResolvedValue({
-      data: buildIssue({ labels: [{ name: 'type:bug' }, { name: 'size:xs' }, { name: 'blocked' }] }),
+      data: buildIssue({ labels: [{ name: 'type:bug' }, { name: 'size:xs' }, { name: 'ai:ready' }, { name: 'blocked' }] }),
     });
     await run({ github, context, core });
     expect(core.getOutput('should_run')).toBe('false');
@@ -83,7 +91,7 @@ describe('check-eligibility', () => {
 
   it('sets should_run=false for triage skip labels (gate 5)', async () => {
     github.rest.issues.get.mockResolvedValue({
-      data: buildIssue({ labels: [{ name: 'type:bug' }, { name: 'size:xs' }, { name: 'duplicate' }] }),
+      data: buildIssue({ labels: [{ name: 'type:bug' }, { name: 'size:xs' }, { name: 'ai:ready' }, { name: 'duplicate' }] }),
     });
     await run({ github, context, core });
     expect(core.getOutput('should_run')).toBe('false');
@@ -91,18 +99,18 @@ describe('check-eligibility', () => {
 
   it('sets should_run=false for disallowed type (gate 6)', async () => {
     github.rest.issues.get.mockResolvedValue({
-      data: buildIssue({ labels: [{ name: 'type:feature' }, { name: 'size:xs' }] }),
+      data: buildIssue({ labels: [{ name: 'type:feature' }, { name: 'size:xs' }, { name: 'ai:ready' }] }),
     });
     await run({ github, context, core });
     expect(core.getOutput('should_run')).toBe('false');
   });
 
-  it('sets should_run=false for disallowed size (gate 7)', async () => {
+  it('resolves an ai:ready issue of ANY size — no size cap (gate 7 removed)', async () => {
     github.rest.issues.get.mockResolvedValue({
-      data: buildIssue({ labels: [{ name: 'type:bug' }, { name: 'size:xl' }] }),
+      data: buildIssue({ labels: [{ name: 'type:bug' }, { name: 'size:xl' }, { name: 'ai:ready' }] }),
     });
     await run({ github, context, core });
-    expect(core.getOutput('should_run')).toBe('false');
+    expect(core.getOutput('should_run')).toBe('true');
   });
 
   it('sets should_run=false when PR already references issue (gate 8)', async () => {
@@ -285,7 +293,7 @@ describe('check-eligibility', () => {
       expect(core.getOutput('issue_number')).toBe('5');
       expect(core.getOutput('issue_title')).toBe('Test issue');
       expect(core.getOutput('issue_body')).toBe('Test body');
-      expect(core.getOutput('issue_labels')).toBe('type:bug, size:xs');
+      expect(core.getOutput('issue_labels')).toBe('type:bug, size:xs, ai:ready');
       expect(core.getOutput('attempt')).toBe('1');
     });
   });


### PR DESCRIPTION
## Part A of the autonomous issue→PR plan

Makes `cc-issue-resolver` actually usable. It has never run successfully anywhere — consumer callers reference the pre-rename `issue-resolver.yml` and fail daily.

### Changes
- **Triage applies `ai:ready`** (`issue-triage.md`) to auto-resolvable issues (allowed type; not duplicate/invalid/wontfix/question; never security/feature/breaking), alongside type/size/priority — the loop self-drives from issue creation.
- **`ai:ready` is the trigger, no size cap** (`check-eligibility.js`): new Gate 3b requires `ai:ready` on the auto path; removed the size:xs/s cap (Gate 7). Manual dispatch still bypasses label gates.
- **`excluded_labels` default** drops `size:l,size:xl` (keeps security/feature/breaking).
- **Canonical caller** (`examples/issue-auto-resolve-caller.yml`): chains triage→resolve in **one run** — a label applied by `GITHUB_TOKEN` does not fire a downstream `issues: labeled` workflow, so triage's `ai:ready` can't start a separate resolver run. Human `ai:ready` label + `workflow_dispatch` are the manual paths. Uses the correct `cc-issue-resolver` name.

Resolver model = `GH_ACTION_AI_MODEL_PLAN` chain (`claude-opus-4-8` today → Opus).

### Tests
`bun test` green (153). Updated `issue-resolver-check-eligibility.test.js` for the `ai:ready` gate + no-size-cap.

### Follow-ups (separate PRs)
- Part B: nightly backlog sweeper (top-3 repos, AI-clustered, reuses resolver in cluster mode).
- Part C: roll the corrected caller to the 14 consumer repos + ensure `ai:ready` in label-sync.

### Validation note
CI here only runs `bun test`. The live loop (triage labels `ai:ready` → Opus opens a resolving PR) will be smoke-tested on nix-ai after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)