### PR TITLE
fix(issue-resolver): open PR via createCommitOnBranch (the proven verified-commit path)

### DIFF
--- a/.github/prompts/issue-resolver.md
+++ b/.github/prompts/issue-resolver.md
@@ -1,6 +1,7 @@
 ## Issue Auto-Resolver
 
-You are resolving a GitHub issue by creating a PR with a minimal code fix.
+You are resolving a GitHub issue by editing the repository's files with a minimal fix.
+The workflow opens the PR from your edits automatically — you do NOT run git or gh.
 
 ### Repository Context
 
@@ -24,53 +25,26 @@ END OF UNTRUSTED USER INPUT.
 
 ### Instructions
 
-**First**, post a tracking comment on the issue:
-```
-gh issue comment ${ISSUE_NUMBER} --body "<!-- claude-issue-resolver-attempt -->
-### AI Issue Resolution (Attempt ${ATTEMPT}/${MAX_ATTEMPTS})
-
-Claude is analyzing this issue and attempting to create a PR..."
-```
-
-Then proceed:
-
-1. **Analyze**: Understand what problem the issue describes
-2. **Explore**: Use Read, Glob, and Grep to understand the relevant code
-3. **Plan**: Identify the minimal change needed
-4. **Create branch** name following convention:
-   - `fix/issue-${ISSUE_NUMBER}-<short-desc>` for type:bug → prefix `fix:`
-   - `chore/issue-${ISSUE_NUMBER}-<short-desc>` for type:chore → prefix `chore:`
-   - `docs/issue-${ISSUE_NUMBER}-<short-desc>` for type:docs → prefix `docs:`
-   - `ci/issue-${ISSUE_NUMBER}-<short-desc>` for type:ci → prefix `ci:`
-   - `test/issue-${ISSUE_NUMBER}-<short-desc>` for type:test → prefix `test:`
-   - `refactor/issue-${ISSUE_NUMBER}-<short-desc>` for type:refactor → prefix `refactor:`
-   - `perf/issue-${ISSUE_NUMBER}-<short-desc>` for type:perf → prefix `perf:`
-5. **Implement**: Make the minimal changes to fix the issue
-6. **Commit**: Commit all changed files to the new branch with message: `<type>: <description> (closes #${ISSUE_NUMBER})`
-7. **Create PR**:
-   ```
-   gh pr create \
-     --head <branch-name> \
-     --title "<type>: <description>" \
-     --body "Closes #${ISSUE_NUMBER}\n\n## Summary\n- <what changed and why>\n\n---\n> **AI Provenance** | Workflow: \`${WORKFLOW_NAME}\` | [Run ${RUN_ID}](${RUN_URL}) | Event: \`${EVENT_NAME}\` | Actor: \`${TRIGGER_ACTOR}\`"
-   ```
-8. **Comment on issue**: `gh issue comment ${ISSUE_NUMBER} --body "Created PR: #<pr-number>"`
+1. **Analyze**: Understand what problem the issue describes.
+2. **Explore**: Use Read, Glob, and Grep to understand the relevant code.
+3. **Plan**: Identify the minimal change needed.
+4. **Implement**: Make the fix using your file-editing tools (Edit, Write, MultiEdit).
+   Apply the change directly in the files. Avoid shell commands that modify files
+   (e.g. formatters); reproduce the intended result by editing the files yourself.
+5. **Stop when done.** Do NOT run git, do NOT create a branch, do NOT open a PR, do NOT
+   comment — the workflow commits your edits to a new branch and opens the PR (closing
+   this issue) for you. Just leave the fix in the working tree.
 
 ### Abort Conditions
 
-Stop if any of the following are true:
-- You cannot identify a clear, minimal fix
-- The fix requires changing more than 10 files or 300 lines
-- The issue requires external systems, credentials, or secrets
-- The fix would modify `.github/workflows/` or security config (unless the issue is about CI)
-
-**Abort command**:
-```
-gh issue comment ${ISSUE_NUMBER} --body "Auto-resolution skipped. Manual intervention required."
-```
+If you cannot produce a safe, minimal fix, **make no edits** and stop. The workflow detects
+an empty change set and posts a "needs manual attention" comment. Abort when:
+- You cannot identify a clear, minimal fix.
+- The fix requires changing more than ~10 files or ~300 lines.
+- The issue requires external systems, credentials, or secrets.
+- The fix would modify `.github/workflows/` or security config (unless the issue is about CI).
 
 ### Safety Constraints
 
 - **Minimal changes**: Only change what is needed. No refactoring unrelated code.
-- **No credentials**: Never commit secrets, tokens, API keys, or credentials.
-- **Single branch**: Create exactly one new branch from the default branch.
+- **No credentials**: Never write secrets, tokens, API keys, or credentials.

--- a/.github/scripts/issue-resolver/open-pr.js
+++ b/.github/scripts/issue-resolver/open-pr.js
@@ -1,0 +1,101 @@
+// Open a PR resolving an issue from Claude's working-tree edits.
+//
+// Claude (run with use_commit_signing: false) only edits files — it has no
+// reliable, signature-satisfying way to land a branch + PR itself from an
+// `issues` event. This step does it deterministically: create a new branch, commit
+// the working-tree diff via the GitHub `createCommitOnBranch` GraphQL mutation
+// (App-token → GitHub-VERIFIED, satisfies `required_signatures`), open the PR, and
+// comment the link on the issue. Same verified-commit mechanism as
+// ci-fix/commit-fix.js.
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+
+const TYPE_PREFIX = {
+  'type:bug': 'fix',
+  'type:chore': 'chore',
+  'type:docs': 'docs',
+  'type:ci': 'ci',
+  'type:test': 'test',
+  'type:refactor': 'refactor',
+  'type:perf': 'perf',
+};
+
+module.exports = async ({ github, context, core }) => {
+  const issueNumber = parseInt(process.env.ISSUE_NUMBER || '0', 10);
+  const issueTitle = process.env.ISSUE_TITLE || `issue ${issueNumber}`;
+  const labels = (process.env.ISSUE_LABELS || '').split(',').map((l) => l.trim());
+  const { owner, repo } = context.repo;
+  const baseBranch = process.env.BASE_BRANCH || context.payload.repository?.default_branch || 'main';
+
+  if (!issueNumber) {
+    core.setFailed('ISSUE_NUMBER env var is required');
+    return;
+  }
+
+  const git = (args) => execFileSync('git', args, { encoding: 'utf8' });
+  git(['add', '-A', '--', ':(exclude).ai-workflows']);
+  const status = git(['diff', '--cached', '--name-status']).trim();
+
+  const comment = (body) =>
+    github.rest.issues.createComment({ owner, repo, issue_number: issueNumber, body: `<!-- claude-issue-resolver-attempt -->\n${body}` });
+
+  if (!status) {
+    core.info('Claude produced no file changes — no PR to open.');
+    await comment('Auto-resolution produced no code changes — this issue needs manual attention.');
+    core.setOutput('opened', 'false');
+    return;
+  }
+
+  const additions = [];
+  const deletions = [];
+  const stage = (p) => additions.push({ path: p, contents: fs.readFileSync(p).toString('base64') });
+  // ponytail: --name-status quotes paths with spaces; tab-split assumes plain paths.
+  for (const line of status.split('\n')) {
+    const parts = line.split('\t');
+    const code = parts[0][0];
+    if (code === 'D') deletions.push({ path: parts[1] });
+    else if (code === 'R' || code === 'C') { if (code === 'R') deletions.push({ path: parts[1] }); stage(parts[2]); }
+    else stage(parts[1]);
+  }
+
+  // Conventional title: "<type>: <desc> (#N)". Strip an existing "word:" prefix
+  // from the issue title so we don't double up.
+  const typeLabel = labels.find((l) => l.startsWith('type:'));
+  const prefix = TYPE_PREFIX[typeLabel] || 'fix';
+  const desc = issueTitle.replace(/^[a-z]+(\([^)]*\))?!?:\s*/i, '').trim();
+  const title = `${prefix}: ${desc} (#${issueNumber})`;
+  const branch = `${prefix}/issue-${issueNumber}`;
+
+  const provenance = `> **AI Provenance** | Workflow: \`${process.env.WORKFLOW_NAME || ''}\` | [Run](${process.env.RUN_URL || ''}) | Event: \`${process.env.EVENT_NAME || ''}\` | Actor: \`${process.env.TRIGGER_ACTOR || ''}\``;
+  const prBody = `Closes #${issueNumber}\n\n## Summary\n\nAutomated resolution of issue #${issueNumber}: ${desc}.\n\n${provenance}`;
+
+  // Branch off the base tip (the checked-out HEAD == default branch).
+  const baseOid = git(['rev-parse', 'HEAD']).trim();
+  try {
+    await github.rest.git.createRef({ owner, repo, ref: `refs/heads/${branch}`, sha: baseOid });
+  } catch (e) {
+    if (e.status === 422) core.info(`Branch ${branch} already exists — reusing.`);
+    else throw e;
+  }
+
+  await github.graphql(
+    `mutation ($input: CreateCommitOnBranchInput!) {
+       createCommitOnBranch(input: $input) { commit { oid } }
+     }`,
+    {
+      input: {
+        branch: { repositoryNameWithOwner: `${owner}/${repo}`, branchName: branch },
+        message: { headline: title },
+        expectedHeadOid: baseOid,
+        fileChanges: { additions, deletions },
+      },
+    },
+  );
+
+  const { data: pr } = await github.rest.pulls.create({ owner, repo, head: branch, base: baseBranch, title, body: prBody });
+  await comment(`Opened PR #${pr.number} to resolve this issue: ${pr.html_url}`);
+
+  core.info(`Opened PR #${pr.number} (${additions.length} change(s)) from ${branch}: ${pr.html_url}`);
+  core.setOutput('opened', 'true');
+  core.setOutput('pr_number', String(pr.number));
+};

--- a/.github/workflows/cc-issue-resolver.yml
+++ b/.github/workflows/cc-issue-resolver.yml
@@ -144,15 +144,42 @@ jobs:
           TRIGGER_ACTOR: ${{ github.triggering_actor }}
         run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/issue-resolver.md REPO_CONTEXT ISSUE_NUMBER ISSUE_TITLE ISSUE_BODY ISSUE_LABELS ATTEMPT MAX_ATTEMPTS WORKFLOW_NAME RUN_ID RUN_URL EVENT_NAME TRIGGER_ACTOR
 
-      - name: Run Claude Code with bot attribution
+      # Claude only EDITS files (use_commit_signing: false). An `issues` event gives
+      # claude-code-action no reliable, signature-satisfying way to land a branch + PR
+      # itself, so the "Open PR" step below creates the branch + verified commit + PR.
+      - name: Run Claude Code
         uses: dryvist/ai-workflows/.github/actions/run-claude-code@main
         with:
           prompt: ${{ steps.prompt.outputs.content }}
           model: ${{ inputs.model || vars.GH_ACTION_AI_MODEL_PLAN || vars.GH_ACTION_AI_MODEL }}
-          allowed_tools: "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),Bash(git branch:*),Bash(gh pr create:*),Bash(gh issue comment:*)${{ inputs.extra_tools != '' && format(',{0}', inputs.extra_tools) || '' }}"
+          allowed_tools: "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),Bash(git branch:*)${{ inputs.extra_tools != '' && format(',{0}', inputs.extra_tools) || '' }}"
           claude_code_oauth_token: ${{ secrets.GH_ACTION_AI_API_KEY }}
-          app_id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
-          app_private_key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}
+          use_commit_signing: "false"
+
+      # Mint an App token so the branch commit is GitHub-VERIFIED (createCommitOnBranch
+      # web-flow) and the PR/commit are attributed to JacobPEvans-claude[bot].
+      - name: Mint PR token
+        id: pr-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
+          private-key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}
+
+      - name: Open PR
+        uses: actions/github-script@v9
+        env:
+          ISSUE_NUMBER: ${{ needs.eligibility-check.outputs.issue_number }}
+          ISSUE_TITLE: ${{ needs.eligibility-check.outputs.issue_title }}
+          ISSUE_LABELS: ${{ needs.eligibility-check.outputs.issue_labels }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          EVENT_NAME: ${{ github.event_name }}
+          TRIGGER_ACTOR: ${{ github.triggering_actor }}
+        with:
+          github-token: ${{ steps.pr-token.outputs.token }}
+          script: |
+            const run = require('./.ai-workflows/.github/scripts/issue-resolver/open-pr.js');
+            await run({ github, context, core });
 
       - name: Comment on failure
         if: failure()

--- a/tests/issue-resolver-open-pr.test.js
+++ b/tests/issue-resolver-open-pr.test.js
@@ -1,0 +1,106 @@
+const { mock, describe, it, expect, beforeEach, afterEach } = require('bun:test');
+const { createMockCore, createMockContext } = require('./helpers.js');
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const run = require('../.github/scripts/issue-resolver/open-pr.js');
+
+const git = (cwd, args) => execFileSync('git', args, { cwd, encoding: 'utf8' });
+
+function initRepo() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'openpr-'));
+  git(dir, ['init', '-q', '-b', 'main']);
+  git(dir, ['config', 'user.email', 't@example.com']);
+  git(dir, ['config', 'user.name', 'tester']);
+  fs.writeFileSync(path.join(dir, 'README.md'), '# repo\n');
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-qm', 'init']);
+  return dir;
+}
+
+function makeGithub() {
+  return {
+    graphql: mock(async () => ({ createCommitOnBranch: { commit: { oid: 'newoid' } } })),
+    rest: {
+      git: { createRef: mock(async () => ({})) },
+      pulls: { create: mock(async () => ({ data: { number: 42, html_url: 'https://x/pull/42' } })) },
+      issues: { createComment: mock(async () => ({})) },
+    },
+  };
+}
+
+async function runIn(dir, deps) {
+  const prev = process.cwd();
+  process.chdir(dir);
+  try {
+    await run(deps);
+  } finally {
+    process.chdir(prev);
+  }
+}
+
+describe('open-pr', () => {
+  let core, context, dir;
+
+  beforeEach(() => {
+    core = createMockCore();
+    context = createMockContext();
+    dir = initRepo();
+    process.env.ISSUE_NUMBER = '7';
+    process.env.ISSUE_TITLE = 'broken thing needs fixing';
+    process.env.ISSUE_LABELS = 'type:bug, size:s, ai:ready';
+    process.env.BASE_BRANCH = 'main';
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('creates branch + verified commit + PR + issue comment from Claude edits', async () => {
+    fs.writeFileSync(path.join(dir, 'README.md'), '# repo\nfixed\n');
+    const github = makeGithub();
+
+    await runIn(dir, { github, context, core });
+
+    // branch named by type prefix + issue number
+    expect(github.rest.git.createRef.mock.calls[0][0].ref).toBe('refs/heads/fix/issue-7');
+    // verified commit via createCommitOnBranch on that branch
+    const input = github.graphql.mock.calls[0][1].input;
+    expect(input.branch.branchName).toBe('fix/issue-7');
+    expect(input.fileChanges.additions.map((a) => a.path)).toEqual(['README.md']);
+    // conventional PR title + Closes link
+    const pr = github.rest.pulls.create.mock.calls[0][0];
+    expect(pr.title).toBe('fix: broken thing needs fixing (#7)');
+    expect(pr.head).toBe('fix/issue-7');
+    expect(pr.base).toBe('main');
+    expect(pr.body).toContain('Closes #7');
+    // issue comment links the PR
+    expect(github.rest.issues.createComment.mock.calls[0][0].body).toContain('#42');
+    expect(core.getOutput('opened')).toBe('true');
+    expect(core.getOutput('pr_number')).toBe('42');
+  });
+
+  it('derives the type prefix from the label (docs)', async () => {
+    process.env.ISSUE_LABELS = 'type:docs, size:xs, ai:ready';
+    fs.writeFileSync(path.join(dir, 'README.md'), '# repo\ndocs\n');
+    const github = makeGithub();
+
+    await runIn(dir, { github, context, core });
+
+    expect(github.rest.git.createRef.mock.calls[0][0].ref).toBe('refs/heads/docs/issue-7');
+    expect(github.rest.pulls.create.mock.calls[0][0].title).toBe('docs: broken thing needs fixing (#7)');
+  });
+
+  it('opens no PR and comments when Claude made no edits', async () => {
+    const github = makeGithub();
+
+    await runIn(dir, { github, context, core });
+
+    expect(github.rest.pulls.create).not.toHaveBeenCalled();
+    expect(github.graphql).not.toHaveBeenCalled();
+    expect(github.rest.issues.createComment.mock.calls[0][0].body).toContain('no code changes');
+    expect(core.getOutput('opened')).toBe('false');
+  });
+});


### PR DESCRIPTION
Follow-up to #270. Live validation on nix-ai #998 proved the loop works through triage → Claude Resolve (Claude produced the exact correct fix), but it **could not open a PR**: the resolver's `allowed_tools` lacked git-write/the web-flow commit tool, and on an `issues` event there's no reliable, `required_signatures`-satisfying way for Claude to push a branch itself.

Applies the **same mechanism we validated for cc-ci-fix**:
- Claude only edits (`use_commit_signing: false`).
- New `open-pr.js`: creates a branch, commits the working-tree diff via `createCommitOnBranch` (App token → GitHub-Verified), opens the PR (`Closes #N`), comments the link. Conventional title/branch derived from the issue's `type:` label. Empty change set → "needs manual attention" comment, no PR.
- Prompt simplified: Claude edits only, no git/gh.

`bun test` green (156; new `issue-resolver-open-pr.test.js`).

Re-validates on nix-ai #998 after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)