### PR TITLE
refactor(write-workflows): one documented Verified Commit & PR pattern for all flows

### DIFF
--- a/.github/prompts/code-simplifier.md
+++ b/.github/prompts/code-simplifier.md
@@ -52,15 +52,16 @@ If an open PR already covers the same changes, exit without action.
 
 ## Output
 
-Pick up to 3 high-impact improvements from different categories. Create one PR addressing the selected improvements that:
+Pick up to 3 high-impact improvements from different categories and apply them by editing
+files (Edit/Write/MultiEdit). Keep the change minimal — change the fewest files needed and do
+not introduce new functionality or change behavior.
 
-- Changes the minimum number of files needed
-- Has a clear title describing the improvement
-- Includes a body explaining what was found and why the change helps
-- Does not introduce new functionality or change behavior
-- Includes this provenance footer at the bottom of the PR body:
+Then write your PR description to a file named `.claude-pr.md` in the repo root:
 
-  ```text
-  ---
-  > **AI Provenance** | Workflow: `${WORKFLOW_NAME}` | [Run ${RUN_ID}](${RUN_URL}) | Event: `${EVENT_NAME}` | Actor: `${TRIGGER_ACTOR}`
-  ```
+- **First line**: a clear conventional-commit PR title, e.g. `refactor: extract duplicated X helper`.
+- **Remaining lines**: a body explaining what was found and why the change helps.
+
+Do **not** run git, do **not** `gh pr create`, do **not** push — the workflow commits your edits
+and opens a verified PR from `.claude-pr.md` automatically (and appends the AI Provenance footer).
+If you find nothing worth changing, make no edits and write no `.claude-pr.md` — the workflow then
+opens no PR.

--- a/.github/prompts/next-steps.md
+++ b/.github/prompts/next-steps.md
@@ -56,15 +56,12 @@ Choose exactly ONE action based on impact:
 
 If the fix is straightforward (< 150 lines changed, <= 6 files):
 
-- Create a PR with the fix
-- Title format: `chore: [description of next step]`
-- Body must explain: what was detected, why this is the logical next step, what changed
-- PR body must include this provenance footer at the bottom:
-
-  ```text
-  ---
-  > **AI Provenance** | Workflow: `${WORKFLOW_NAME}` | [Run ${RUN_ID}](${RUN_URL}) | Event: `${EVENT_NAME}` | Actor: `${TRIGGER_ACTOR}`
-  ```
+- Apply the fix by editing files (Edit/Write/MultiEdit).
+- Write your PR description to a file named `.claude-pr.md` in the repo root:
+  - **First line**: `chore: [description of next step]`
+  - **Remaining lines**: what was detected, why this is the logical next step, what changed.
+- Do **not** run git, do **not** `gh pr create`, do **not** push — the workflow commits your edits
+  and opens a verified PR from `.claude-pr.md` automatically (and appends the AI Provenance footer).
 
 ### Option B: Issue (for complex work)
 

--- a/.github/prompts/post-merge-docs-review.md
+++ b/.github/prompts/post-merge-docs-review.md
@@ -58,18 +58,15 @@ If an open PR already addresses the same documentation problems, exit without ac
 
 If threshold is met:
 
-1. Create a new branch from main with name `docs/fix-{short-description}`
-2. Fix the identified issues directly in the documentation files
-3. Create a PR with:
-   - Title: `docs: fix {brief description of issues}`
-   - Body listing each issue found, its category (critical/non-critical), and what was fixed
-   - Include a "Detection Trigger" section explaining which merge prompted this review
-4. Include this provenance footer at the bottom of the PR body:
+1. Fix the identified issues directly in the documentation files (Edit/Write/MultiEdit).
+2. Write your PR description to a file named `.claude-pr.md` in the repo root:
+   - **First line**: `docs: fix {brief description of issues}`
+   - **Remaining lines**: list each issue found, its category (critical/non-critical), what was
+     fixed, and a "Detection Trigger" line naming the merge that prompted this review.
 
-   ```text
-   ---
-   > **AI Provenance** | Workflow: `${WORKFLOW_NAME}` | [Run ${RUN_ID}](${RUN_URL}) | Event: `${EVENT_NAME}` | Actor: `${TRIGGER_ACTOR}`
-   ```
+Do **not** run git, do **not** `gh pr create`, do **not** push — the workflow commits your edits
+and opens a verified PR from `.claude-pr.md` automatically (and appends the AI Provenance footer).
+If the threshold is NOT met, make no edits and write no `.claude-pr.md` — the workflow opens no PR.
 
 ## Rules
 

--- a/.github/prompts/post-merge-tests.md
+++ b/.github/prompts/post-merge-tests.md
@@ -36,21 +36,20 @@ If an open PR already adds tests for the same files or functions, exit without a
 
 If you find uncovered testable code:
 
-1. Create a new branch from `main` with name `chore/add-tests-<short-description>`
-2. Write 1-4 targeted test files following the EXACT patterns found in existing tests:
+1. Write 1-4 targeted test files (Edit/Write) following the EXACT patterns found in existing tests:
    - Same test framework and assertion style
    - Same file naming convention
    - Same directory structure
    - Same import patterns and test utilities
-3. Create a PR with:
-   - Title: `test: add coverage for <what was merged>`
-   - Body explaining: what merge triggered this, what's being tested, what existing patterns were followed
-4. Include this provenance footer at the bottom of the PR body:
+2. Write your PR description to a file named `.claude-pr.md` in the repo root:
+   - **First line**: `test: add coverage for <what was merged>`
+   - **Remaining lines**: what merge triggered this, what's being tested, what existing patterns
+     were followed.
 
-   ```text
-   ---
-   > **AI Provenance** | Workflow: `${WORKFLOW_NAME}` | [Run ${RUN_ID}](${RUN_URL}) | Event: `${EVENT_NAME}` | Actor: `${TRIGGER_ACTOR}`
-   ```
+Do **not** run git, do **not** `gh pr create`, do **not** push — the workflow commits your edits
+and opens a verified PR from `.claude-pr.md` automatically (and appends the AI Provenance footer).
+If existing coverage is already comprehensive, make no edits and write no `.claude-pr.md` — the
+workflow opens no PR.
 
 ## Rules
 

--- a/.github/scripts/ci-fix/commit-fix.js
+++ b/.github/scripts/ci-fix/commit-fix.js
@@ -1,73 +1,15 @@
-// Commit Claude's working-tree changes to the PR branch via the GitHub
-// `createCommitOnBranch` GraphQL mutation. The octokit passed in is authed with
-// the JacobPEvans-claude App installation token, so the resulting commit is
-// GitHub-VERIFIED (satisfies `required_signatures` rulesets), attributed to the
-// bot, and re-triggers CI on the PR.
-//
-// This is the workflow_run-compatible replacement for claude-code-action's own
-// `use_commit_signing`: that path can only target a branch when the trigger
-// event carries PR context (pull_request/issue_comment), which workflow_run does
-// not. Here we supply the branch (the failing PR's head) explicitly.
-const { execFileSync } = require('child_process');
-const fs = require('fs');
+// Commit Claude's working-tree changes to the failing PR's branch. Thin wrapper
+// over the shared verified-commit helper (App-token createCommitOnBranch →
+// GitHub-VERIFIED, satisfies required_signatures, re-triggers CI). See
+// shared/verified-commit.js and docs/PATTERNS.md "Verified Commit & PR Pattern".
+const { commitToBranch } = require('../shared/verified-commit.js');
 
 module.exports = async ({ github, context, core }) => {
-  const branch = process.env.HEAD_BRANCH;
-  const message = process.env.COMMIT_MESSAGE;
-  if (!branch) {
-    core.setFailed('HEAD_BRANCH env var is required');
-    return;
-  }
-
-  const git = (args) => execFileSync('git', args, { encoding: 'utf8' });
-
-  // Stage everything except the ai-workflows checkout that lives in the
-  // consumer workspace (it must never be committed into the consumer repo).
-  git(['add', '-A', '--', ':(exclude).ai-workflows']);
-
-  const status = git(['diff', '--cached', '--name-status']).trim();
-  if (!status) {
-    core.info('Claude made no file changes — nothing to commit.');
-    core.setOutput('committed', 'false');
-    return;
-  }
-
-  const additions = [];
-  const deletions = [];
-  const stage = (p) => additions.push({ path: p, contents: fs.readFileSync(p).toString('base64') });
-  // ponytail: --name-status quotes paths with spaces/special chars; the tab-split
-  // below assumes plain paths. Switch to `-z` parsing if a consumer hits that.
-  for (const line of status.split('\n')) {
-    const parts = line.split('\t');
-    const code = parts[0][0];
-    if (code === 'D') {
-      deletions.push({ path: parts[1] });
-    } else if (code === 'R' || code === 'C') {
-      if (code === 'R') deletions.push({ path: parts[1] });
-      stage(parts[2]);
-    } else {
-      stage(parts[1]); // A (added) or M (modified)
-    }
-  }
-
-  const expectedHeadOid = git(['rev-parse', 'HEAD']).trim();
-  const { owner, repo } = context.repo;
-  const result = await github.graphql(
-    `mutation ($input: CreateCommitOnBranchInput!) {
-       createCommitOnBranch(input: $input) { commit { oid url } }
-     }`,
-    {
-      input: {
-        branch: { repositoryNameWithOwner: `${owner}/${repo}`, branchName: branch },
-        message: { headline: message },
-        expectedHeadOid,
-        fileChanges: { additions, deletions },
-      },
-    },
-  );
-
-  const commit = result.createCommitOnBranch.commit;
-  core.info(`Committed ${additions.length} change(s), ${deletions.length} deletion(s) to ${branch}: ${commit.url}`);
-  core.setOutput('committed', 'true');
-  core.setOutput('commit_oid', commit.oid);
+  await commitToBranch({
+    github,
+    context,
+    core,
+    branch: process.env.HEAD_BRANCH,
+    message: process.env.COMMIT_MESSAGE,
+  });
 };

--- a/.github/scripts/issue-resolver/open-pr.js
+++ b/.github/scripts/issue-resolver/open-pr.js
@@ -1,14 +1,9 @@
-// Open a PR resolving an issue from Claude's working-tree edits.
-//
-// Claude (run with use_commit_signing: false) only edits files — it has no
-// reliable, signature-satisfying way to land a branch + PR itself from an
-// `issues` event. This step does it deterministically: create a new branch, commit
-// the working-tree diff via the GitHub `createCommitOnBranch` GraphQL mutation
-// (App-token → GitHub-VERIFIED, satisfies `required_signatures`), open the PR, and
-// comment the link on the issue. Same verified-commit mechanism as
-// ci-fix/commit-fix.js.
-const { execFileSync } = require('child_process');
-const fs = require('fs');
+// Open a PR resolving an issue from Claude's working-tree edits. Composes a
+// conventional title/branch from the issue's type label, then delegates to the
+// shared verified-commit helper (App-token createCommitOnBranch → GitHub-VERIFIED,
+// satisfies required_signatures) and comments the PR link on the issue.
+// See shared/verified-commit.js and docs/PATTERNS.md "Verified Commit & PR Pattern".
+const { openPr } = require('../shared/verified-commit.js');
 
 const TYPE_PREFIX = {
   'type:bug': 'fix',
@@ -25,77 +20,35 @@ module.exports = async ({ github, context, core }) => {
   const issueTitle = process.env.ISSUE_TITLE || `issue ${issueNumber}`;
   const labels = (process.env.ISSUE_LABELS || '').split(',').map((l) => l.trim());
   const { owner, repo } = context.repo;
-  const baseBranch = process.env.BASE_BRANCH || context.payload.repository?.default_branch || 'main';
-
   if (!issueNumber) {
     core.setFailed('ISSUE_NUMBER env var is required');
     return;
   }
 
-  const git = (args) => execFileSync('git', args, { encoding: 'utf8' });
-  git(['add', '-A', '--', ':(exclude).ai-workflows']);
-  const status = git(['diff', '--cached', '--name-status']).trim();
-
   const comment = (body) =>
     github.rest.issues.createComment({ owner, repo, issue_number: issueNumber, body: `<!-- claude-issue-resolver-attempt -->\n${body}` });
 
-  if (!status) {
-    core.info('Claude produced no file changes — no PR to open.');
-    await comment('Auto-resolution produced no code changes — this issue needs manual attention.');
-    core.setOutput('opened', 'false');
-    return;
-  }
-
-  const additions = [];
-  const deletions = [];
-  const stage = (p) => additions.push({ path: p, contents: fs.readFileSync(p).toString('base64') });
-  // ponytail: --name-status quotes paths with spaces; tab-split assumes plain paths.
-  for (const line of status.split('\n')) {
-    const parts = line.split('\t');
-    const code = parts[0][0];
-    if (code === 'D') deletions.push({ path: parts[1] });
-    else if (code === 'R' || code === 'C') { if (code === 'R') deletions.push({ path: parts[1] }); stage(parts[2]); }
-    else stage(parts[1]);
-  }
-
-  // Conventional title: "<type>: <desc> (#N)". Strip an existing "word:" prefix
-  // from the issue title so we don't double up.
-  const typeLabel = labels.find((l) => l.startsWith('type:'));
-  const prefix = TYPE_PREFIX[typeLabel] || 'fix';
+  // Conventional title "<type>: <desc> (#N)" — strip any existing "word:" prefix.
+  const prefix = TYPE_PREFIX[labels.find((l) => l.startsWith('type:'))] || 'fix';
   const desc = issueTitle.replace(/^[a-z]+(\([^)]*\))?!?:\s*/i, '').trim();
   const title = `${prefix}: ${desc} (#${issueNumber})`;
   const branch = `${prefix}/issue-${issueNumber}`;
-
   const provenance = `> **AI Provenance** | Workflow: \`${process.env.WORKFLOW_NAME || ''}\` | [Run](${process.env.RUN_URL || ''}) | Event: \`${process.env.EVENT_NAME || ''}\` | Actor: \`${process.env.TRIGGER_ACTOR || ''}\``;
-  const prBody = `Closes #${issueNumber}\n\n## Summary\n\nAutomated resolution of issue #${issueNumber}: ${desc}.\n\n${provenance}`;
+  const body = `Closes #${issueNumber}\n\n## Summary\n\nAutomated resolution of issue #${issueNumber}: ${desc}.\n\n${provenance}`;
 
-  // Branch off the base tip (the checked-out HEAD == default branch).
-  const baseOid = git(['rev-parse', 'HEAD']).trim();
-  try {
-    await github.rest.git.createRef({ owner, repo, ref: `refs/heads/${branch}`, sha: baseOid });
-  } catch (e) {
-    if (e.status === 422) core.info(`Branch ${branch} already exists — reusing.`);
-    else throw e;
-  }
+  const { opened, pr } = await openPr({
+    github,
+    context,
+    core,
+    branch,
+    title,
+    body,
+    baseBranch: process.env.BASE_BRANCH,
+  });
 
-  await github.graphql(
-    `mutation ($input: CreateCommitOnBranchInput!) {
-       createCommitOnBranch(input: $input) { commit { oid } }
-     }`,
-    {
-      input: {
-        branch: { repositoryNameWithOwner: `${owner}/${repo}`, branchName: branch },
-        message: { headline: title },
-        expectedHeadOid: baseOid,
-        fileChanges: { additions, deletions },
-      },
-    },
+  await comment(
+    opened
+      ? `Opened PR #${pr.number} to resolve this issue: ${pr.html_url}`
+      : 'Auto-resolution produced no code changes — this issue needs manual attention.',
   );
-
-  const { data: pr } = await github.rest.pulls.create({ owner, repo, head: branch, base: baseBranch, title, body: prBody });
-  await comment(`Opened PR #${pr.number} to resolve this issue: ${pr.html_url}`);
-
-  core.info(`Opened PR #${pr.number} (${additions.length} change(s)) from ${branch}: ${pr.html_url}`);
-  core.setOutput('opened', 'true');
-  core.setOutput('pr_number', String(pr.number));
 };

--- a/.github/scripts/shared/pr-from-file.js
+++ b/.github/scripts/shared/pr-from-file.js
@@ -1,0 +1,45 @@
+// Open a PR from Claude's working-tree edits + a Claude-authored PR description.
+//
+// For write-workflows that aren't issue-driven (code-simplifier, next-steps,
+// post-merge-*): Claude edits files and writes its PR title (first line) + body
+// (rest) to a file (default `.claude-pr.md`). This step opens the PR via the
+// shared verified-commit helper (App-token createCommitOnBranch → GitHub-VERIFIED)
+// and excludes the PR-description file from the commit. No file → Claude declined,
+// so no PR.
+const fs = require('fs');
+const { openPr } = require('./verified-commit.js');
+
+module.exports = async ({ github, context, core }) => {
+  const prFile = process.env.PR_FILE || '.claude-pr.md';
+  const branch = process.env.PR_BRANCH;
+  if (!branch) {
+    core.setFailed('PR_BRANCH env var is required');
+    return;
+  }
+  if (!fs.existsSync(prFile)) {
+    core.info(`Claude wrote no ${prFile} — declined to open a PR.`);
+    core.setOutput('opened', 'false');
+    return;
+  }
+
+  const content = fs.readFileSync(prFile, 'utf8').trim();
+  const nl = content.indexOf('\n');
+  const title = (nl === -1 ? content : content.slice(0, nl)).trim();
+  const body = nl === -1 ? '' : content.slice(nl + 1).trim();
+  if (!title) {
+    core.info(`${prFile} has no title line — declined to open a PR.`);
+    core.setOutput('opened', 'false');
+    return;
+  }
+
+  const provenance = `> **AI Provenance** | Workflow: \`${process.env.WORKFLOW_NAME || ''}\` | [Run](${process.env.RUN_URL || ''}) | Event: \`${process.env.EVENT_NAME || ''}\` | Actor: \`${process.env.TRIGGER_ACTOR || ''}\``;
+  await openPr({
+    github,
+    context,
+    core,
+    branch,
+    title,
+    body: `${body}\n\n${provenance}`,
+    extraExcludes: [prFile],
+  });
+};

--- a/.github/scripts/shared/verified-commit.js
+++ b/.github/scripts/shared/verified-commit.js
@@ -1,0 +1,92 @@
+// Verified Commit & PR helper — the ONE way every write-workflow lands changes.
+//
+// Why this exists: claude-code-action's native commit path (`use_commit_signing`)
+// only targets a branch when the TRIGGER event carries PR context
+// (pull_request / issue_comment). Our write-workflows fire on workflow_run,
+// issues, schedule, and workflow_dispatch — none of which give it a branch — and
+// dryvist's org-wide `required_signatures` ruleset rejects unsigned pushes. So
+// Claude only EDITS files (use_commit_signing: false), and these helpers commit
+// the working-tree diff through the GitHub `createCommitOnBranch` GraphQL mutation
+// using the JacobPEvans-claude App token. Those commits are GitHub-VERIFIED
+// (satisfy required_signatures), attributed to the bot, and re-trigger CI.
+//
+// Two shapes:
+//   commitToBranch — commit the diff onto an EXISTING branch (e.g. cc-ci-fix).
+//   openPr         — create a NEW branch, commit the diff, open a PR (resolver,
+//                    code-simplifier, next-steps, post-merge-*).
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+
+const git = (args) => execFileSync('git', args, { encoding: 'utf8' });
+
+// Stage all working-tree changes except the ai-workflows checkout (and any extra
+// excludes, e.g. a Claude-authored PR-body file) and return GraphQL fileChanges,
+// or null when there is nothing to commit.
+// ponytail: --name-status quotes paths with spaces; tab-split assumes plain paths.
+function stageChanges(extraExcludes = []) {
+  const excludes = ['.ai-workflows', ...extraExcludes].map((p) => `:(exclude)${p}`);
+  git(['add', '-A', '--', ...excludes]);
+  const status = git(['diff', '--cached', '--name-status']).trim();
+  if (!status) return null;
+
+  const additions = [];
+  const deletions = [];
+  const stage = (p) => additions.push({ path: p, contents: fs.readFileSync(p).toString('base64') });
+  for (const line of status.split('\n')) {
+    const parts = line.split('\t');
+    const code = parts[0][0];
+    if (code === 'D') deletions.push({ path: parts[1] });
+    else if (code === 'R' || code === 'C') { if (code === 'R') deletions.push({ path: parts[1] }); stage(parts[2]); }
+    else stage(parts[1]); // A or M
+  }
+  return { additions, deletions };
+}
+
+async function createCommitOnBranch(github, repoWithOwner, branch, headline, expectedHeadOid, fileChanges) {
+  const res = await github.graphql(
+    `mutation ($input: CreateCommitOnBranchInput!) {
+       createCommitOnBranch(input: $input) { commit { oid url } }
+     }`,
+    { input: { branch: { repositoryNameWithOwner: repoWithOwner, branchName: branch }, message: { headline }, expectedHeadOid, fileChanges } },
+  );
+  return res.createCommitOnBranch.commit;
+}
+
+// Shape 1: commit the working-tree diff onto an existing branch.
+async function commitToBranch({ github, context, core, branch, message, extraExcludes }) {
+  if (!branch) { core.setFailed('commitToBranch: branch is required'); return { committed: false }; }
+  const changes = stageChanges(extraExcludes);
+  if (!changes) { core.info('No file changes — nothing to commit.'); core.setOutput('committed', 'false'); return { committed: false }; }
+  const { owner, repo } = context.repo;
+  const commit = await createCommitOnBranch(github, `${owner}/${repo}`, branch, message, git(['rev-parse', 'HEAD']).trim(), changes);
+  core.info(`Committed ${changes.additions.length} change(s), ${changes.deletions.length} deletion(s) to ${branch}: ${commit.url}`);
+  core.setOutput('committed', 'true');
+  core.setOutput('commit_oid', commit.oid);
+  return { committed: true, commit };
+}
+
+// Shape 2: create a new branch off the checked-out HEAD, verified-commit the diff,
+// and open a PR. Returns { opened, pr } (opened: false when there were no changes).
+async function openPr({ github, context, core, branch, title, body, baseBranch, extraExcludes }) {
+  if (!branch || !title) { core.setFailed('openPr: branch and title are required'); return { opened: false }; }
+  const { owner, repo } = context.repo;
+  const base = baseBranch || context.payload.repository?.default_branch || 'main';
+  const changes = stageChanges(extraExcludes);
+  if (!changes) { core.info('No file changes — no PR to open.'); core.setOutput('opened', 'false'); return { opened: false }; }
+
+  const baseOid = git(['rev-parse', 'HEAD']).trim();
+  try {
+    await github.rest.git.createRef({ owner, repo, ref: `refs/heads/${branch}`, sha: baseOid });
+  } catch (e) {
+    if (e.status === 422) core.info(`Branch ${branch} already exists — reusing.`);
+    else throw e;
+  }
+  await createCommitOnBranch(github, `${owner}/${repo}`, branch, title, baseOid, changes);
+  const { data: pr } = await github.rest.pulls.create({ owner, repo, head: branch, base, title, body });
+  core.info(`Opened PR #${pr.number} (${changes.additions.length} change(s)) from ${branch}: ${pr.html_url}`);
+  core.setOutput('opened', 'true');
+  core.setOutput('pr_number', String(pr.number));
+  return { opened: true, pr };
+}
+
+module.exports = { stageChanges, commitToBranch, openPr };

--- a/.github/workflows/cc-code-simplifier.yml
+++ b/.github/workflows/cc-code-simplifier.yml
@@ -120,12 +120,34 @@ jobs:
           TRIGGER_ACTOR: ${{ github.triggering_actor }}
         run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/code-simplifier.md WORKFLOW_NAME RUN_ID RUN_URL EVENT_NAME TRIGGER_ACTOR
 
-      - name: Run Claude Code with bot attribution
+      # Verified Commit & PR Pattern (docs/PATTERNS.md): Claude only edits + writes its
+      # PR description to .claude-pr.md; the steps below open a VERIFIED PR from it.
+      - name: Run Claude Code
         uses: dryvist/ai-workflows/.github/actions/run-claude-code@main
         with:
           prompt: ${{ steps.prompt.outputs.content }}
           model: ${{ vars.GH_ACTION_AI_MODEL_CODE || vars.GH_ACTION_AI_MODEL }}
-          allowed_tools: "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),Bash(git branch:*),Bash(gh pr:*),Bash(gh api:*)"
+          allowed_tools: "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),Bash(git branch:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh search:*)"
           claude_code_oauth_token: ${{ secrets.GH_ACTION_AI_API_KEY }}
-          app_id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
-          app_private_key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}
+          use_commit_signing: "false"
+
+      - name: Mint PR token
+        id: pr-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
+          private-key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}
+
+      - name: Open PR
+        uses: actions/github-script@v9
+        env:
+          PR_BRANCH: claude/code-simplifier-${{ github.run_id }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          EVENT_NAME: ${{ github.event_name }}
+          TRIGGER_ACTOR: ${{ github.triggering_actor }}
+        with:
+          github-token: ${{ steps.pr-token.outputs.token }}
+          script: |
+            const run = require('./.ai-workflows/.github/scripts/shared/pr-from-file.js');
+            await run({ github, context, core });

--- a/.github/workflows/cc-next-steps.yml
+++ b/.github/workflows/cc-next-steps.yml
@@ -122,13 +122,37 @@ jobs:
           TRIGGER_ACTOR: ${{ github.triggering_actor }}
         run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/next-steps.md WORKFLOW_NAME RUN_ID RUN_URL EVENT_NAME TRIGGER_ACTOR
 
+      # Verified Commit & PR Pattern (docs/PATTERNS.md): Claude only edits (and may create an
+      # issue for Option B). For Option A it writes .claude-pr.md; the steps below open a
+      # VERIFIED PR from it. gh issue:* stays allowed for the issue-creation path.
       - name: Execute Claude Code
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.GH_ACTION_AI_API_KEY }}
           allowed_bots: "github-actions"
-          use_commit_signing: "true"
+          use_commit_signing: "false"
           prompt: ${{ steps.prompt.outputs.content }}
           claude_args: >-
-            --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),Bash(git branch:*),Bash(gh pr:*),Bash(gh issue:*),Bash(gh api:*),Bash(gh search:*)"
+            --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),Bash(git branch:*),Bash(gh issue:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh search:*)"
             --model ${{ vars.GH_ACTION_AI_MODEL }}
+
+      - name: Mint PR token
+        id: pr-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
+          private-key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}
+
+      - name: Open PR
+        uses: actions/github-script@v9
+        env:
+          PR_BRANCH: claude/next-steps-${{ github.run_id }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          EVENT_NAME: ${{ github.event_name }}
+          TRIGGER_ACTOR: ${{ github.triggering_actor }}
+        with:
+          github-token: ${{ steps.pr-token.outputs.token }}
+          script: |
+            const run = require('./.ai-workflows/.github/scripts/shared/pr-from-file.js');
+            await run({ github, context, core });

--- a/.github/workflows/cc-post-merge-docs-review.yml
+++ b/.github/workflows/cc-post-merge-docs-review.yml
@@ -161,12 +161,34 @@ jobs:
           TRIGGER_ACTOR: ${{ github.triggering_actor }}
         run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/post-merge-docs-review.md COMMIT_SHA REPO_NAME WORKFLOW_NAME RUN_ID RUN_URL EVENT_NAME TRIGGER_ACTOR
 
-      - name: Run Claude Code with bot attribution
+      # Verified Commit & PR Pattern (docs/PATTERNS.md): Claude only edits + writes its
+      # PR description to .claude-pr.md; the steps below open a VERIFIED PR from it.
+      - name: Run Claude Code
         uses: dryvist/ai-workflows/.github/actions/run-claude-code@main
         with:
           prompt: ${{ steps.prompt.outputs.content }}
           model: ${{ vars.GH_ACTION_AI_MODEL }}
-          allowed_tools: "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),Bash(git branch:*),Bash(gh pr:*),Bash(gh api:*),Bash(gh search:*)"
+          allowed_tools: "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),Bash(git branch:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh search:*)"
           claude_code_oauth_token: ${{ secrets.GH_ACTION_AI_API_KEY }}
-          app_id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
-          app_private_key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}
+          use_commit_signing: "false"
+
+      - name: Mint PR token
+        id: pr-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
+          private-key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}
+
+      - name: Open PR
+        uses: actions/github-script@v9
+        env:
+          PR_BRANCH: claude/post-merge-docs-review-${{ github.run_id }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          EVENT_NAME: ${{ github.event_name }}
+          TRIGGER_ACTOR: ${{ github.triggering_actor }}
+        with:
+          github-token: ${{ steps.pr-token.outputs.token }}
+          script: |
+            const run = require('./.ai-workflows/.github/scripts/shared/pr-from-file.js');
+            await run({ github, context, core });

--- a/.github/workflows/cc-post-merge-tests.yml
+++ b/.github/workflows/cc-post-merge-tests.yml
@@ -161,12 +161,34 @@ jobs:
           TRIGGER_ACTOR: ${{ github.triggering_actor }}
         run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/post-merge-tests.md MERGE_SHA REPO_FULL_NAME WORKFLOW_NAME RUN_ID RUN_URL EVENT_NAME TRIGGER_ACTOR
 
-      - name: Run Claude Code with bot attribution
+      # Verified Commit & PR Pattern (docs/PATTERNS.md): Claude only edits + writes its
+      # PR description to .claude-pr.md; the steps below open a VERIFIED PR from it.
+      - name: Run Claude Code
         uses: dryvist/ai-workflows/.github/actions/run-claude-code@main
         with:
           prompt: ${{ steps.prompt.outputs.content }}
           model: ${{ vars.GH_ACTION_AI_MODEL_CODE || vars.GH_ACTION_AI_MODEL }}
-          allowed_tools: "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),Bash(git branch:*),Bash(gh pr:*),Bash(gh api:*),Bash(gh search:*)"
+          allowed_tools: "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),Bash(git branch:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh search:*)"
           claude_code_oauth_token: ${{ secrets.GH_ACTION_AI_API_KEY }}
-          app_id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
-          app_private_key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}
+          use_commit_signing: "false"
+
+      - name: Mint PR token
+        id: pr-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
+          private-key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}
+
+      - name: Open PR
+        uses: actions/github-script@v9
+        env:
+          PR_BRANCH: claude/post-merge-tests-${{ github.run_id }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          EVENT_NAME: ${{ github.event_name }}
+          TRIGGER_ACTOR: ${{ github.triggering_actor }}
+        with:
+          github-token: ${{ steps.pr-token.outputs.token }}
+          script: |
+            const run = require('./.ai-workflows/.github/scripts/shared/pr-from-file.js');
+            await run({ github, context, core });

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,8 +40,12 @@ repos invoke via `uses: dryvist/ai-workflows/.github/workflows/<name>.yml@v0.1.0
 - Static prompts: most workflows
 - Dynamic prompts (ci-fix, post-merge-tests, post-merge-docs-review): `render-prompt.sh` with named env vars
 - Write workflows (code-simplifier, next-steps, post-merge-*, ci-fix,
-  issue-resolver): add `use_commit_signing: "true"` and restrict git to
-  read-only subcommands (see docs/PATTERNS.md Commit Signing Pattern)
+  issue-resolver): Claude only EDITS files (`use_commit_signing: "false"`, no
+  git-write/`gh pr`/`gh api` write tools); a workflow step lands a GitHub-VERIFIED
+  commit/PR via `createCommitOnBranch` (shared `scripts/shared/verified-commit.js`).
+  This is mandatory — native `use_commit_signing` cannot target a branch on our
+  workflow_run/issues/schedule/dispatch triggers. See docs/PATTERNS.md
+  "Verified Commit & PR Pattern".
 
 **Supported event types**: `issues`, `issue_comment`, `pull_request`,
 `pull_request_review`, `pull_request_review_comment`, `workflow_dispatch`,

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -38,37 +38,99 @@ Used by most workflows. Static prompt, read-only tools.
 
 ---
 
-## Commit Signing Pattern
+## Verified Commit & PR Pattern
 
-Used by workflows that create commits or PRs. Adds `use_commit_signing: "true"` for commits verified as the Claude GitHub App.
+**This is the ONE way every write-workflow lands commits and PRs. Do not invent another.**
 
-**Workflows**: code-simplifier, next-steps (creates PRs), post-merge-docs-review, post-merge-tests, ci-fix, issue-resolver
+### The problem (read this before adding a write-workflow)
 
-**Additional permissions**: `contents: write`, `pull-requests: write`
+A write-workflow must land a **GitHub-verified** commit, because the dryvist org enforces a
+`required_signatures` ruleset that rejects unsigned pushes (`GH013`). There are two tempting
+ways to do this that **do not work** in our workflows:
 
-**Additional input**:
+1. **`use_commit_signing: "true"`** (claude-code-action's native web-flow). The action derives
+   the commit's target branch from the **trigger event's PR context**. Per its own docs: *open
+   PR → pushes to the PR branch; issue → new branch; otherwise → it cannot resolve a branch.*
+   Our write-workflows fire on **`workflow_run`, `issues`, `schedule`, and `workflow_dispatch`**
+   — none give it a usable branch, so it commits **nothing** (observed: `base_branch: ""`, no
+   commit, no branch). Proven dead under `workflow_run` (ai-workflows #267, reverted by #268)
+   and under `issues` (nix-ai #998: Claude produced the fix but every write channel was denied).
+2. **Claude running `git commit && git push` or `gh pr create` itself.** A CLI push is
+   **unsigned** → rejected by `required_signatures` (`GH013`). This is what #261 hit.
+
+### The solution
+
+Claude **only edits files** (`use_commit_signing: "false"`, and NO git-write / `gh pr` /
+`gh api` write tools in `--allowedTools`). A workflow step then commits the working-tree diff
+through the GitHub **`createCommitOnBranch` GraphQL mutation** using a freshly minted
+**JacobPEvans-claude App installation token**. Those commits are **GitHub-VERIFIED** (satisfy
+`required_signatures`), attributed to the bot, and re-trigger CI.
+
+All of this lives in one shared helper — **`.github/scripts/shared/verified-commit.js`** — with
+two shapes:
+
+| Shape | Helper fn | When | Used by |
+| --- | --- | --- | --- |
+| Commit to an **existing** branch | `commitToBranch` | fixing a PR in place | `cc-ci-fix` (via `ci-fix/commit-fix.js`) |
+| Create a **new** branch + open a PR | `openPr` | turning work into a new PR | `cc-issue-resolver` (`issue-resolver/open-pr.js`), `code-simplifier`, `next-steps`, `post-merge-*` (via `shared/pr-from-file.js`) |
+
+**Workflows**: ci-fix, issue-resolver, code-simplifier, next-steps, post-merge-docs-review, post-merge-tests.
+
+### Workflow shape (new-branch + PR)
 
 ```yaml
-- name: Run Claude
-  uses: anthropics/claude-code-action@v1
-  env:
-    ANTHROPIC_BASE_URL: ${{ vars.GH_ACTION_AI_BASE_URL }}
-  with:
-    anthropic_api_key: ${{ secrets.GH_ACTION_AI_API_KEY }}
-    allowed_bots: "github-actions"
-    use_commit_signing: "true"
-    prompt: ${{ steps.prompt.outputs.content }}
-    claude_args: >-
-      --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git log:*),Bash(git diff:*),
-      Bash(git show:*),Bash(git status:*),Bash(git branch:*),Bash(gh pr:*)"
-      --model ${{ vars.GH_ACTION_AI_MODEL_EXAMPLE || vars.GH_ACTION_AI_MODEL }}
+permissions:               # job-level
+  contents: write
+  id-token: write
+  pull-requests: write
+
+steps:
+  # 1. Claude EDITS ONLY — no git-write, no gh pr/gh api writes. For non-issue
+  #    workflows it also writes its PR title (first line) + body to `.claude-pr.md`.
+  - name: Run Claude Code
+    uses: dryvist/ai-workflows/.github/actions/run-claude-code@main
+    with:
+      prompt: ${{ steps.prompt.outputs.content }}
+      model: ${{ vars.GH_ACTION_AI_MODEL_PLAN || vars.GH_ACTION_AI_MODEL }}
+      allowed_tools: "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),Bash(git branch:*)"
+      claude_code_oauth_token: ${{ secrets.GH_ACTION_AI_API_KEY }}
+      use_commit_signing: "false"
+
+  # 2. Mint the App token so the commit is VERIFIED + bot-attributed.
+  - name: Mint PR token
+    id: pr-token
+    uses: actions/create-github-app-token@v3
+    with:
+      app-id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
+      private-key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}
+
+  # 3. Open the PR from Claude's edits via the shared helper.
+  - name: Open PR
+    uses: actions/github-script@v9
+    env:
+      PR_BRANCH: claude/<workflow>-${{ github.run_id }}
+      WORKFLOW_NAME: ${{ github.workflow }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      EVENT_NAME: ${{ github.event_name }}
+      TRIGGER_ACTOR: ${{ github.triggering_actor }}
+    with:
+      github-token: ${{ steps.pr-token.outputs.token }}
+      script: |
+        const run = require('./.ai-workflows/.github/scripts/shared/pr-from-file.js');
+        await run({ github, context, core });
 ```
 
-The `--allowedTools` value above spans two lines for readability; in production workflow files, keep it on
-a single line within the `>-` block (or consult `.github/workflows/*.yml` for the canonical form).
+`pr-from-file.js` reads `.claude-pr.md` (title = first line, body = rest), appends the AI
+Provenance footer, and excludes that file from the commit. **No `.claude-pr.md` written →
+Claude declined → no PR** (clean no-op). Issue-driven resolution (`open-pr.js`) composes the
+title/branch from the issue instead of a file; CI-fix (`commit-fix.js`) calls `commitToBranch`.
 
-Uses GitHub API commit signing. Commits are automatically verified as the Claude GitHub App.
-`Bash(git:*)` is restricted to read-only subcommands to prevent unsigned CLI commits.
+### Prompt rules for a write-workflow
+
+- Tell Claude to make the change with `Edit`/`Write`/`MultiEdit` only.
+- Tell Claude **NOT** to run git, NOT to `gh pr create`, NOT to push — the workflow commits.
+- For non-issue workflows: tell Claude to write the PR title (first line) + body to
+  `.claude-pr.md`, or to write nothing if it has no change to propose.
 
 ---
 

--- a/tests/shared-pr-from-file.test.js
+++ b/tests/shared-pr-from-file.test.js
@@ -1,0 +1,78 @@
+const { mock, describe, it, expect, beforeEach, afterEach } = require('bun:test');
+const { createMockCore, createMockContext } = require('./helpers.js');
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const run = require('../.github/scripts/shared/pr-from-file.js');
+
+const git = (cwd, args) => execFileSync('git', args, { cwd, encoding: 'utf8' });
+
+function initRepo() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'prfile-'));
+  git(dir, ['init', '-q', '-b', 'main']);
+  git(dir, ['config', 'user.email', 't@example.com']);
+  git(dir, ['config', 'user.name', 'tester']);
+  fs.writeFileSync(path.join(dir, 'a.txt'), 'one\n');
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-qm', 'init']);
+  return dir;
+}
+
+function makeGithub() {
+  return {
+    graphql: mock(async () => ({ createCommitOnBranch: { commit: { oid: 'oid' } } })),
+    rest: {
+      git: { createRef: mock(async () => ({})) },
+      pulls: { create: mock(async () => ({ data: { number: 55, html_url: 'https://x/pull/55' } })) },
+    },
+  };
+}
+
+async function runIn(dir, deps) {
+  const prev = process.cwd();
+  process.chdir(dir);
+  try { await run(deps); } finally { process.chdir(prev); }
+}
+
+describe('pr-from-file', () => {
+  let core, context, dir, github;
+
+  beforeEach(() => {
+    core = createMockCore();
+    context = createMockContext();
+    dir = initRepo();
+    github = makeGithub();
+    process.env.PR_BRANCH = 'claude/code-simplifier-123';
+    process.env.BASE_BRANCH = 'main';
+    delete process.env.PR_FILE;
+  });
+
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  it('opens a PR using the title/body Claude wrote, excluding the PR file', async () => {
+    fs.writeFileSync(path.join(dir, 'a.txt'), 'one\ntwo\n'); // Claude's edit
+    fs.writeFileSync(path.join(dir, '.claude-pr.md'), 'refactor: simplify a.txt\n\nCollapsed duplicate lines.');
+
+    await runIn(dir, { github, context, core });
+
+    const pr = github.rest.pulls.create.mock.calls[0][0];
+    expect(pr.title).toBe('refactor: simplify a.txt');
+    expect(pr.head).toBe('claude/code-simplifier-123');
+    expect(pr.body).toContain('Collapsed duplicate lines.');
+    expect(pr.body).toContain('AI Provenance');
+    // the PR-description file must NOT be committed
+    const committedPaths = github.graphql.mock.calls[0][1].input.fileChanges.additions.map((a) => a.path);
+    expect(committedPaths).toContain('a.txt');
+    expect(committedPaths).not.toContain('.claude-pr.md');
+    expect(core.getOutput('opened')).toBe('true');
+  });
+
+  it('opens no PR when Claude wrote no description file (declined)', async () => {
+    fs.writeFileSync(path.join(dir, 'a.txt'), 'one\ntwo\n');
+    await runIn(dir, { github, context, core });
+    expect(github.rest.pulls.create).not.toHaveBeenCalled();
+    expect(core.getOutput('opened')).toBe('false');
+  });
+});


### PR DESCRIPTION
Addresses "ensure all relevant flows work similarly so we don't keep seeing this issue, and document the format."

### The recurring bug
Write-workflows kept failing to land a verified PR: native `use_commit_signing` can't resolve a branch on our `workflow_run`/`issues`/`schedule`/`dispatch` triggers, and a CLI `git push`/`gh pr create` is unsigned → rejected by dryvist's `required_signatures`. We'd solved it twice by copy-paste (cc-ci-fix, issue-resolver).

### Now: one shared, documented mechanism
- **`shared/verified-commit.js`** — `commitToBranch` (existing branch) + `openPr` (new branch + PR) via App-token **`createCommitOnBranch`** (GitHub-Verified). **`shared/pr-from-file.js`** opens a PR from a Claude-authored `.claude-pr.md`.
- **ci-fix** + **issue-resolver** refactored to thin wrappers (no behavior change; already validated E2E).
- **code-simplifier, next-steps, post-merge-docs-review, post-merge-tests** converted: Claude edits only (`use_commit_signing: false`, no git-write/`gh` write tools) and writes `.claude-pr.md`; the workflow opens the verified PR. next-steps keeps `gh issue:*` for its issue path.
- **Docs**: PATTERNS.md "Commit Signing Pattern" (which recommended the broken native path) replaced with **"Verified Commit & PR Pattern"** — problem, why native fails, the helper, the two shapes, prompt rules. AGENTS.md updated.

`bun test` green (158; new `shared-pr-from-file.test.js`).

### Validation note
ci-fix + issue-resolver are proven E2E. The 4 converted schedule/dispatch workflows share the same proven helper + unit-tested `pr-from-file`; their live runs are scheduled/dispatch-driven and will exercise on their next trigger. CI here runs `bun test` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)