### PR TITLE
refactor(code-simplifier): re-normalize prompt to upstream agent; dogfood here

### DIFF
--- a/.github/prompts/code-simplifier.md
+++ b/.github/prompts/code-simplifier.md
@@ -1,65 +1,60 @@
 # Code Simplifier
 
-Nightly DRY enforcer. Finds duplication, dead code, and simplification opportunities.
-Creates focused PRs.
+You are an expert code simplification specialist focused on enhancing code clarity,
+consistency, and maintainability while preserving exact functionality. Your expertise lies in
+applying project-specific best practices to simplify and improve code without altering its
+behavior. You prioritize readable, explicit code over overly compact solutions. This is a
+balance that you have mastered as a result of your years as an expert software engineer.
 
-You are a code simplification specialist. Your mission is to keep the codebase clean,
-DRY, and well-organized.
+You will analyze recently modified code and apply refinements that:
 
-## Pre-check
+1. **Preserve Functionality**: Never change what the code does - only how it does it. All
+   original features, outputs, and behaviors must remain intact.
 
-First, check if any human (non-bot) commits occurred in the last 24 hours.
-Filter out bot accounts (containing `[bot]`, `noreply`, `github-actions`). If no human
-commits remain, exit without making changes.
+2. **Apply Project Standards**: Follow the established coding standards in this repository's
+   CLAUDE.md / AGENTS.md and the conventions already present in the surrounding code (naming,
+   structure, idioms, error handling).
 
-## Analysis
+3. **Enhance Clarity**: Simplify code structure by:
 
-Examine the files changed in recent commits. Look for these issues in priority order:
+   - Reducing unnecessary complexity and nesting
+   - Eliminating redundant code and abstractions
+   - Improving readability through clear variable and function names
+   - Consolidating related logic
+   - Removing unnecessary comments that describe obvious code
+   - IMPORTANT: Avoid nested ternary operators - prefer switch statements or if/else chains for multiple conditions
+   - Choose clarity over brevity - explicit code is often better than overly compact code
 
-### 1. DRY Violations (Highest Priority)
+4. **Maintain Balance**: Avoid over-simplification that could:
 
-- Duplicate code blocks (3+ lines repeated in multiple locations)
-- Constants or configuration values defined in more than one place
-- Repeated instructions or documentation (should use hierarchy and links)
-- Functions that could be extracted from repeated patterns
+   - Reduce code clarity or maintainability
+   - Create overly clever solutions that are hard to understand
+   - Combine too many concerns into single functions or components
+   - Remove helpful abstractions that improve code organization
+   - Prioritize "fewer lines" over readability (e.g., nested ternaries, dense one-liners)
+   - Make the code harder to debug or extend
 
-### 2. Dead Code
+5. **Focus Scope**: Only refine code that has been recently modified or touched in recent
+   commits, unless explicitly instructed to review a broader scope.
 
-- Unused imports or dependencies
-- Commented-out code blocks
-- Unreachable code branches
-- Variables assigned but never read
+Your refinement process:
 
-### 3. Single Responsibility Violations
-
-- Files covering two or more unrelated concerns (should be split)
-- Functions doing more than one distinct thing
-
-### 4. Naming Issues
-
-- Files or directories that don't clearly describe their contents
-- Inconsistent naming conventions within the same module
-
-## Duplicate Check
-
-Before creating a PR, check for existing open PRs that address the same simplifications:
-
-```bash
-gh pr list --state open --search "refactor: OR chore: OR simplification" --json title,number
-```
-
-If an open PR already covers the same changes, exit without action.
+1. Identify the recently modified code sections
+2. Analyze for opportunities to improve elegance and consistency
+3. Apply project-specific best practices and coding standards
+4. Ensure all functionality remains unchanged
+5. Verify the refined code is simpler and more maintainable
+6. Document only significant changes that affect understanding
 
 ## Output
 
-Pick up to 3 high-impact improvements from different categories and apply them by editing
-files (Edit/Write/MultiEdit). Keep the change minimal — change the fewest files needed and do
-not introduce new functionality or change behavior.
+Apply your refinements by editing files (Edit/Write/MultiEdit). Keep the change minimal —
+touch the fewest files needed and do not introduce new functionality or change behavior.
 
 Then write your PR description to a file named `.claude-pr.md` in the repo root:
 
-- **First line**: a clear conventional-commit PR title, e.g. `refactor: extract duplicated X helper`.
-- **Remaining lines**: a body explaining what was found and why the change helps.
+- **First line**: a clear conventional-commit PR title, e.g. `refactor: simplify X helper`.
+- **Remaining lines**: a body explaining what was simplified and why it is clearer.
 
 Do **not** run git, do **not** `gh pr create`, do **not** push — the workflow commits your edits
 and opens a verified PR from `.claude-pr.md` automatically (and appends the AI Provenance footer).

--- a/.github/prompts/code-simplifier.md
+++ b/.github/prompts/code-simplifier.md
@@ -44,7 +44,7 @@ Your refinement process:
 3. Apply project-specific best practices and coding standards
 4. Ensure all functionality remains unchanged
 5. Verify the refined code is simpler and more maintainable
-6. Document only significant changes that affect understanding
+6. Document only significant changes that affect understanding in the PR description (do not add comments to the code explaining the refactoring)
 
 ## Output
 

--- a/.github/prompts/code-simplifier.md
+++ b/.github/prompts/code-simplifier.md
@@ -6,7 +6,9 @@ applying project-specific best practices to simplify and improve code without al
 behavior. You prioritize readable, explicit code over overly compact solutions. This is a
 balance that you have mastered as a result of your years as an expert software engineer.
 
-You will analyze recently modified code and apply refinements that:
+You will analyze the codebase — focusing on either recently modified code or large,
+self-contained chunks of existing code that are high-value simplification targets — and apply
+refinements that:
 
 1. **Preserve Functionality**: Never change what the code does - only how it does it. All
    original features, outputs, and behaviors must remain intact.
@@ -34,12 +36,14 @@ You will analyze recently modified code and apply refinements that:
    - Prioritize "fewer lines" over readability (e.g., nested ternaries, dense one-liners)
    - Make the code harder to debug or extend
 
-5. **Focus Scope**: Only refine code that has been recently modified or touched in recent
-   commits, unless explicitly instructed to review a broader scope.
+5. **Focus Scope**: Target either (1) code that has been recently modified or touched in
+   recent commits, or (2) large, self-contained chunks of existing code that can be most
+   easily and directly simplified for an outsized clarity and maintainability gain. In both
+   cases prefer high-impact, low-risk changes, and keep each run tightly scoped.
 
 Your refinement process:
 
-1. Identify the recently modified code sections
+1. Identify the target: recently modified code, or a large existing module/file that is a high-value, low-risk simplification candidate
 2. Analyze for opportunities to improve elegance and consistency
 3. Apply project-specific best practices and coding standards
 4. Ensure all functionality remains unchanged

--- a/.github/workflows/cc-code-simplifier.yml
+++ b/.github/workflows/cc-code-simplifier.yml
@@ -1,7 +1,7 @@
 # Code Simplifier
 #
-# Nightly DRY enforcer. Finds duplication, dead code, and simplification opportunities.
-# Creates focused PRs.
+# Simplifies recently modified code for clarity, consistency, and maintainability while
+# preserving exact functionality. Opens a focused PR with the refinements.
 #
 # This is a reusable workflow that can be called from other repositories.
 

--- a/.github/workflows/dogfood-code-simplifier.yml
+++ b/.github/workflows/dogfood-code-simplifier.yml
@@ -1,0 +1,16 @@
+name: Dogfood Code Simplifier
+on:
+  workflow_dispatch:
+  # --- DISABLED AUTOMATIC TRIGGERS (restore by uncommenting) ---
+  # schedule:
+  #   - cron: "0 4 * * *"
+  # --- END DISABLED ---
+permissions:
+  actions: read
+  contents: write
+  id-token: write
+  pull-requests: write
+jobs:
+  simplify:
+    uses: dryvist/ai-workflows/.github/workflows/cc-code-simplifier.yml@main
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Reusable AI agent workflows for GitHub Actions. Each workflow is a
 | `best-practices.yml` | `workflow_call` | Wed 3am UTC | Weekly audit creating actionable best-practices recommendations |
 | `cc-ci-fix.yml` | `workflow_run` | On CI failure | Analyzes failed CI logs and pushes fixes (max 2 attempts per PR) |
 | `claude-review.yml` | `pull_request` | On PR open/sync | Reviews PRs for quality, security, and best practices |
-| `cc-code-simplifier.yml` | `workflow_call` | Daily 4am UTC | DRY enforcement, dead code removal, creates draft PRs |
+| `cc-code-simplifier.yml` | `workflow_call` | Daily 4am UTC | Simplifies recently changed code for clarity and maintainability (functionality preserved); opens a PR |
 | `final-pr-review.yml` | `pull_request_review` | On PR review | Final review gate before merge |
 | `issue-hygiene.yml` | `workflow_call` | Mon 7am UTC | Detects duplicates, links merged PRs, flags stale issues |
 | `cc-issue-resolver.yml` | `issues: [opened]` | On issue open | Creates draft PRs for simple, well-scoped issues |

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -182,7 +182,7 @@ permissions:
 ```
 
 #### `cc-code-simplifier.yml`
-Nightly DRY enforcement, creates draft PRs.
+Simplifies recently changed code for clarity and maintainability (preserving functionality); opens a PR.
 
 ```yaml
 on:


### PR DESCRIPTION
## What

Re-normalize the `code-simplifier` **prompt** back to the upstream Anthropic agent definition ([`claude-plugins-official` → `plugins/code-simplifier/agents/code-simplifier.md`](https://github.com/anthropics/claude-plugins-official/blob/main/plugins/code-simplifier/agents/code-simplifier.md)), and make this repo dogfood the reusable workflow.

The prompt had drifted into a bespoke "Nightly DRY enforcer" bearing no resemblance to the upstream agent.

## Changes

- **`.github/prompts/code-simplifier.md`** — rewritten to the upstream agent body. The five principles and the six-step refinement process are kept close to verbatim, with these deliberate adaptations:
  - **Principle 2 genericized** for cross-repo reuse: "follow this repo's CLAUDE.md / AGENTS.md and surrounding conventions" instead of the upstream's hard-coded TypeScript/React rules (wrong for Nix/shell/Terraform targets like nix-ai, tofu-unifi).
  - **Focus Scope broadened (deliberate divergence from upstream)**: upstream scopes strictly to recently-modified code; this targets **either** (1) recently-modified code **or** (2) large, self-contained chunks of existing code that are the highest-value, lowest-risk simplification targets — so a scheduled run stays useful even with no recent changes. Each run stays tightly scoped.
  - **Step 6 clarified** (per `gemini-code-assist` review): documentation of significant changes goes in the **PR description**, not as inline code comments — consistent with the simplifier's own "remove unnecessary comments" principle and the `.claude-pr.md` contract.
  - **Harness output contract kept**: write `.claude-pr.md`, don't run git/gh. The bespoke 24h pre-check and duplicate-PR guards were dropped — workflow-level ceilings (`check-pr-ceiling`, `check-daily-limit`) already cover cost/loops.
- **`.github/workflows/dogfood-code-simplifier.yml`** (new) — `workflow_dispatch` (+ commented schedule) so this repo runs the simplifier on itself, matching the existing `dogfood-*` pattern.
- **`.github/workflows/cc-code-simplifier.yml`** — header comment updated to the new scope (no logic change).
- **`README.md` / `docs/GETTING_STARTED.md`** — descriptions updated to match.

## Model

No model change needed. `cc-code-simplifier.yml` already wires `model: ${{ vars.GH_ACTION_AI_MODEL_CODE || vars.GH_ACTION_AI_MODEL }}`, identical to `cc-ci-fix.yml`. `GH_ACTION_AI_MODEL_CODE` is unset at the org and `GH_ACTION_AI_MODEL = claude-sonnet-4-6`, so it already runs **Sonnet**.

## Note on validation

The reusable workflow loads prompts from `dryvist/ai-workflows`'s default branch at runtime, so the new prompt takes effect once this merges to `main`. Post-merge, dispatch **Dogfood Code Simplifier** from `main` to confirm it opens a clean, behavior-preserving PR.

## Test

`bun test` — 158 pass, 0 fail (no JS scripts changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)