### PR TITLE
refactor(workflows): drop dead render-prompt args from static prompts

### DIFF
--- a/.github/workflows/cc-code-simplifier.yml
+++ b/.github/workflows/cc-code-simplifier.yml
@@ -112,13 +112,7 @@ jobs:
 
       - name: Render prompt
         id: prompt
-        env:
-          WORKFLOW_NAME: ${{ github.workflow }}
-          RUN_ID: ${{ github.run_id }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          EVENT_NAME: ${{ github.event_name }}
-          TRIGGER_ACTOR: ${{ github.triggering_actor }}
-        run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/code-simplifier.md WORKFLOW_NAME RUN_ID RUN_URL EVENT_NAME TRIGGER_ACTOR
+        run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/code-simplifier.md
 
       # Verified Commit & PR Pattern (docs/PATTERNS.md): Claude only edits + writes its
       # PR description to .claude-pr.md; the steps below open a VERIFIED PR from it.

--- a/.github/workflows/cc-next-steps.yml
+++ b/.github/workflows/cc-next-steps.yml
@@ -114,13 +114,7 @@ jobs:
 
       - name: Render prompt
         id: prompt
-        env:
-          WORKFLOW_NAME: ${{ github.workflow }}
-          RUN_ID: ${{ github.run_id }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          EVENT_NAME: ${{ github.event_name }}
-          TRIGGER_ACTOR: ${{ github.triggering_actor }}
-        run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/next-steps.md WORKFLOW_NAME RUN_ID RUN_URL EVENT_NAME TRIGGER_ACTOR
+        run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/next-steps.md
 
       # Verified Commit & PR Pattern (docs/PATTERNS.md): Claude only edits (and may create an
       # issue for Option B). For Option A it writes .claude-pr.md; the steps below open a


### PR DESCRIPTION
## What

`cc-code-simplifier.yml` and `cc-next-steps.yml` passed `WORKFLOW_NAME RUN_ID RUN_URL EVENT_NAME TRIGGER_ACTOR` to `render-prompt.sh` and set a matching step-scoped `env:` block — but `prompts/code-simplifier.md` and `prompts/next-steps.md` contain **no `${VAR}` placeholders** (and no `$` at all), so the substitution was a no-op and the env block was dead config.

Reduce both render steps to the no-arg static form already used by `best-practices.yml`, `final-pr-review.yml`, `issue-sweeper.yml`, etc.:

```yaml
- name: Render prompt
  id: prompt
  run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/<file>.md
```

## Why it's safe

- `render-prompt.sh` with named args substitutes only those vars; with no args it substitutes all env vars. Since both prompts have zero placeholders, **the rendered output is byte-identical** either way.
- The **AI Provenance footer is unaffected** — it is built in the separate "Open PR" step by `pr-from-file.js`, which sets its own `env:` (`WORKFLOW_NAME`/`RUN_URL`/`EVENT_NAME`/`TRIGGER_ACTOR`) and uses `[Run](${RUN_URL})`. The footer never referenced `RUN_ID`, and step env does not cross steps, so the removed render-step vars were never visible to it.

## Test

`bun test` — 158 pass, 0 fail (no script behavior changed).

## Context

Follow-up cleanup surfaced during `/simplify` review of dryvist/ai-workflows#275. Independent of #275 (different region of `cc-code-simplifier.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)