### PR TITLE
chore: pin ai-workflows self-references at @main

### DIFF
--- a/.github/workflows/dogfood-best-practices.yml
+++ b/.github/workflows/dogfood-best-practices.yml
@@ -12,5 +12,5 @@ permissions:
   pull-requests: read
 jobs:
   best-practices:
-    uses: dryvist/ai-workflows/.github/workflows/best-practices.yml@v0.16.0
+    uses: dryvist/ai-workflows/.github/workflows/best-practices.yml@main
     secrets: inherit

--- a/.github/workflows/dogfood-issue-hygiene.yml
+++ b/.github/workflows/dogfood-issue-hygiene.yml
@@ -12,5 +12,5 @@ permissions:
   pull-requests: read
 jobs:
   hygiene:
-    uses: dryvist/ai-workflows/.github/workflows/issue-hygiene.yml@v0.16.0
+    uses: dryvist/ai-workflows/.github/workflows/issue-hygiene.yml@main
     secrets: inherit

--- a/.github/workflows/dogfood-issue-sweeper.yml
+++ b/.github/workflows/dogfood-issue-sweeper.yml
@@ -12,5 +12,5 @@ permissions:
   pull-requests: read
 jobs:
   sweep:
-    uses: dryvist/ai-workflows/.github/workflows/issue-sweeper.yml@v0.16.0
+    uses: dryvist/ai-workflows/.github/workflows/issue-sweeper.yml@main
     secrets: inherit

--- a/.github/workflows/suite-all.yml
+++ b/.github/workflows/suite-all.yml
@@ -9,10 +9,10 @@
 # = 3 levels (well within the 4-level GitHub Actions limit).
 #
 # Internal uses: paths are relative — they resolve to the same ref as this
-# suite when called by a child repo (e.g., @v0.8.0 pins the whole chain).
+# suite when called by a child repo (e.g., @main rides the whole chain).
 #
 # Usage:
-#   uses: dryvist/ai-workflows/.github/workflows/suite-all.yml@v0.8.0
+#   uses: dryvist/ai-workflows/.github/workflows/suite-all.yml@main
 #   with:
 #     caller_event: ${{ github.event_name }}
 #     commit_sha: ${{ inputs.commit_sha || github.sha }}

--- a/.github/workflows/suite-ci.yml
+++ b/.github/workflows/suite-ci.yml
@@ -6,10 +6,10 @@
 # Caller keeps repo-specific workflow_run trigger (workflows: ["<CI-GATE-NAME>"]).
 #
 # Internal uses: paths are relative — they resolve to the same ref as this
-# suite when called by a child repo (e.g., @v0.8.0 pins the whole chain).
+# suite when called by a child repo (e.g., @main rides the whole chain).
 #
 # Usage:
-#   uses: dryvist/ai-workflows/.github/workflows/suite-ci.yml@v0.8.0
+#   uses: dryvist/ai-workflows/.github/workflows/suite-ci.yml@main
 #   with:
 #     repo_context: "Brief description of the repository"
 #     ci_structure: "Description of CI workflows and what they check"

--- a/.github/workflows/suite-post-merge.yml
+++ b/.github/workflows/suite-post-merge.yml
@@ -4,10 +4,10 @@
 # Both run in parallel after a merge to main (triggered via workflow_dispatch re-dispatch).
 #
 # Internal uses: paths are relative — they resolve to the same ref as this
-# suite when called by a child repo (e.g., @v0.8.0 pins the whole chain).
+# suite when called by a child repo (e.g., @main rides the whole chain).
 #
 # Usage:
-#   uses: dryvist/ai-workflows/.github/workflows/suite-post-merge.yml@v0.8.0
+#   uses: dryvist/ai-workflows/.github/workflows/suite-post-merge.yml@main
 #   with:
 #     commit_sha: ${{ inputs.commit_sha || github.sha }}
 

--- a/.github/workflows/suite-pr.yml
+++ b/.github/workflows/suite-pr.yml
@@ -4,10 +4,10 @@
 # Callers pass caller_event to route to the correct individual workflow.
 #
 # Internal uses: paths are relative — they resolve to the same ref as this
-# suite when called by a child repo (e.g., @v0.8.0 pins the whole chain).
+# suite when called by a child repo (e.g., @main rides the whole chain).
 #
 # Usage:
-#   uses: dryvist/ai-workflows/.github/workflows/suite-pr.yml@v0.8.0
+#   uses: dryvist/ai-workflows/.github/workflows/suite-pr.yml@main
 #   with:
 #     caller_event: ${{ github.event_name }}
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Reusable AI agent workflows for GitHub Actions. Consumer repos call these with t
 
 This repo is the single source of truth for CI/CD automation workflows.
 Each workflow is a GitHub reusable workflow (`on: workflow_call`) that consumer
-repos invoke via `uses: dryvist/ai-workflows/.github/workflows/<name>.yml@v0.1.0`.
+repos invoke via `uses: dryvist/ai-workflows/.github/workflows/<name>.yml@main`.
 
 ### Directory Structure
 
@@ -84,7 +84,7 @@ permissions:
   pull-requests: read
 jobs:
   sweep:
-    uses: dryvist/ai-workflows/.github/workflows/issue-sweeper.yml@v0.3.3
+    uses: dryvist/ai-workflows/.github/workflows/issue-sweeper.yml@main
     secrets: inherit
 ```
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ permissions:
   issues: write
 jobs:
   triage:
-    uses: dryvist/ai-workflows/.github/workflows/issue-triage.yml@v0.3.0
+    uses: dryvist/ai-workflows/.github/workflows/issue-triage.yml@main
     secrets: inherit
 ```
 
@@ -104,7 +104,7 @@ permissions:
   pull-requests: read
 jobs:
   sweep:
-    uses: dryvist/ai-workflows/.github/workflows/issue-sweeper.yml@v0.3.0
+    uses: dryvist/ai-workflows/.github/workflows/issue-sweeper.yml@main
     secrets: inherit
 ```
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -27,11 +27,13 @@ permissions:
   issues: write            # add what this workflow needs
 jobs:
   run:
-    uses: dryvist/ai-workflows/.github/workflows/<name>.yml@v0.3.0
+    uses: dryvist/ai-workflows/.github/workflows/<name>.yml@main
     secrets: inherit
 ```
 
 **Important**: Consumer callers must declare `permissions:` explicitly. CodeQL and branch protection rules may block merges if permissions are missing.
+
+**Versioning**: Always pin `@main`, never a SemVer tag or SHA. `ai-workflows` is a first-party `dryvist/*` reusable workflow, so consumers ride `@main` and pick up fixes the moment they land — no per-repo Renovate PR. SemVer tags still exist (release-please keeps bumping them for the changelog and the per-run resolved-SHA audit trail), but callers do not pin them. The org scanners are configured to allow `@main`; see [CI/CD policy → scanner posture](https://docs.jacobpevans.com/infrastructure/cicd/policy#scanner-posture-for-self-references).
 
 ---
 

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -267,7 +267,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
   review:
     if: github.event_name == 'workflow_dispatch'
-    uses: dryvist/ai-workflows/.github/workflows/cc-post-merge-tests.yml@v0.3.3
+    uses: dryvist/ai-workflows/.github/workflows/cc-post-merge-tests.yml@main
     with:
       commit_sha: ${{ inputs.commit_sha || github.sha }}
     secrets: inherit
@@ -324,7 +324,7 @@ When a bot creates the PR and isn't in `allowed_bots`, the step shows as **skipp
 ```yaml
 jobs:
   sweep:
-    uses: dryvist/ai-workflows/.github/workflows/suite-all.yml@v0.9.0
+    uses: dryvist/ai-workflows/.github/workflows/suite-all.yml@main
     with:
       caller_event: ${{ github.event_name }}
       allowed_bots: "claude"  # Allow Claude App PRs to be reviewed
@@ -506,7 +506,7 @@ jobs:
         (github.event.action == 'opened' && !github.event.pull_request.draft) ||
         (github.event.action == 'closed' && github.event.pull_request.merged == true)
       )
-    uses: dryvist/ai-workflows/.github/workflows/issue-linker.yml@v0.4.0
+    uses: dryvist/ai-workflows/.github/workflows/issue-linker.yml@main
     secrets: inherit
 ```
 
@@ -631,7 +631,7 @@ permissions:
   pull-requests: read
 jobs:
   notify:
-    uses: dryvist/ai-workflows/.github/workflows/notify-ai-pr.yml@v0.4.0
+    uses: dryvist/ai-workflows/.github/workflows/notify-ai-pr.yml@main
     secrets: inherit
 ```
 

--- a/examples/ci-fix-caller.yml
+++ b/examples/ci-fix-caller.yml
@@ -32,7 +32,7 @@ permissions:
 
 jobs:
   ci-fix:
-    uses: dryvist/ai-workflows/.github/workflows/cc-ci-fix.yml@v0
+    uses: dryvist/ai-workflows/.github/workflows/cc-ci-fix.yml@main
     secrets: inherit
     with:
       repo_context: "Describe your repo: language, frameworks, how it builds."

--- a/examples/issue-auto-resolve-caller.yml
+++ b/examples/issue-auto-resolve-caller.yml
@@ -50,7 +50,7 @@ jobs:
     if: >-
       github.event_name == 'issues' &&
       (github.event.action == 'opened' || github.event.action == 'reopened')
-    uses: dryvist/ai-workflows/.github/workflows/issue-triage.yml@v0
+    uses: dryvist/ai-workflows/.github/workflows/issue-triage.yml@main
     secrets: inherit
 
   resolve:
@@ -63,7 +63,7 @@ jobs:
       !(github.event_name == 'issues' &&
         github.event.action == 'labeled' &&
         github.event.label.name != 'ai:ready')
-    uses: dryvist/ai-workflows/.github/workflows/cc-issue-resolver.yml@v0
+    uses: dryvist/ai-workflows/.github/workflows/cc-issue-resolver.yml@main
     secrets: inherit
     with:
       # Describe your repo so Claude has context (language, frameworks, how it builds).


### PR DESCRIPTION
## What

Aligns this repo with the org self-reference convention: every
`dryvist/ai-workflows/…` reference rides **`@main`**, never a SemVer tag —
matching the now-fixed terraform-proxmox wrapper
([terraform-proxmox#502](https://github.com/dryvist/terraform-proxmox/pull/502))
and documented in [docs#89](https://github.com/dryvist/docs/pull/89) /
[dryvist/.github#52](https://github.com/dryvist/.github/pull/52).

## Changes

- **`examples/*-caller.yml`** — `@v0` → `@main` (the canonical copy-paste
  templates).
- **`dogfood-*.yml`** — `@v0.16.0` → `@main` (live self-references that dogfood
  this repo's own workflows).
- **`suite-*.yml`** — usage comments + the transitivity note → `@main`.
- **README / AGENTS / GETTING_STARTED / PATTERNS** — caller examples → `@main`.
- **GETTING_STARTED** — new authoritative **Versioning** note explaining the
  `@main` convention and linking to the docs CI/CD policy scanner posture.

`release-please` and the moving major/minor tags are untouched — SemVer tags
keep existing for the changelog and per-run resolved-SHA audit trail, but
consumers ride `@main` so upstream fixes land with no per-repo Renovate PR.

## Verification

- `bun test` → **158 pass, 0 fail** (no script logic changed).
- `grep` confirms zero remaining `ai-workflows/…@vX` references in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
