### PR TITLE
fix: declare explicit secrets on issue-backlog-sweep reusable

### DIFF
--- a/.github/workflows/issue-backlog-sweep.yml
+++ b/.github/workflows/issue-backlog-sweep.yml
@@ -48,6 +48,17 @@ on:
         description: "Max sweep runs per 24h (0 to disable)"
         type: string
         default: "3"
+    secrets:
+      # Declared explicitly so callers pass exactly these two rather than
+      # `secrets: inherit` (which hands the reusable every parent secret and
+      # trips zizmor's secrets-inherit audit). required: false keeps existing
+      # inherit-based callers working unchanged.
+      GH_ACTION_AI_API_KEY:
+        description: "AI provider API key for the claude-code-action step."
+        required: false
+      GH_APP_CLAUDE_BOT_PRIVATE_KEY:
+        description: "Private key for the JacobPEvans-claude App, used to mint the token that applies triage labels."
+        required: false
   workflow_dispatch:
     inputs:
       max_issues:

--- a/examples/issue-backlog-sweep-caller.yml
+++ b/examples/issue-backlog-sweep-caller.yml
@@ -46,6 +46,10 @@ concurrency:
 jobs:
   sweep:
     uses: dryvist/ai-workflows/.github/workflows/issue-backlog-sweep.yml@main
-    secrets: inherit
+    # Pass exactly the two secrets the reusable needs — not `secrets: inherit`,
+    # which hands over every parent secret and trips zizmor's secrets-inherit audit.
+    secrets:
+      GH_ACTION_AI_API_KEY: ${{ secrets.GH_ACTION_AI_API_KEY }}
+      GH_APP_CLAUDE_BOT_PRIVATE_KEY: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}
     with:
       max_issues: ${{ inputs.max_issues || '5' }}


### PR DESCRIPTION
## Problem
`issue-backlog-sweep.yml` references `secrets.GH_ACTION_AI_API_KEY` and
`secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY` but declares no `workflow_call: secrets:`
block. That forces every consumer caller to use `secrets: inherit`, which:
- trips zizmor's `secrets-inherit` audit (medium) in consumer repos, and
- hands the reusable **all** parent secrets instead of just the two it needs.

Consumers were papering over this with `# zizmor: ignore[secrets-inherit]` — a
suppression, not a fix.

## Fix
Declare both secrets explicitly (`required: false`, so existing
`secrets: inherit` callers are unaffected) so callers can pass exactly the two.
Update `examples/issue-backlog-sweep-caller.yml` to demonstrate explicit passing.

Scope: this reusable only. The other reusables still rely on bare inherit; a
broader migration is a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)