### PR TITLE
fix(write-workflows): clear stale index.lock + surface git stderr in verified-commit

### DIFF
--- a/.github/scripts/shared/verified-commit.js
+++ b/.github/scripts/shared/verified-commit.js
@@ -26,10 +26,12 @@ const git = (args) => {
   try {
     return execFileSync('git', args, { encoding: 'utf8' });
   } catch (e) {
-    const stderr = (e.stderr || '').toString().trim();
-    const stdout = (e.stdout || '').toString().trim();
-    const detail = stderr || stdout || e.message;
-    throw new Error(`git ${args.join(' ')} failed (exit ${e.status ?? '?'}): ${detail}`);
+    // Defensive optional-chaining: execFileSync always throws an Error here, but
+    // guard anyway so a non-Error throw can't mask the failure with a TypeError.
+    const stderr = (e?.stderr || '').toString().trim();
+    const stdout = (e?.stdout || '').toString().trim();
+    const detail = stderr || stdout || e?.message || String(e);
+    throw new Error(`git ${args.join(' ')} failed (exit ${e?.status ?? '?'}): ${detail}`);
   }
 };
 

--- a/.github/scripts/shared/verified-commit.js
+++ b/.github/scripts/shared/verified-commit.js
@@ -17,7 +17,21 @@
 const { execFileSync } = require('child_process');
 const fs = require('fs');
 
-const git = (args) => execFileSync('git', args, { encoding: 'utf8' });
+// execFileSync's default thrown Error carries git's real diagnostics on `.stderr`
+// but hides them from `.message` — so a failed commit surfaced only
+// "Command failed: git add ..." with no cause. Re-throw with stderr + exit code
+// folded into the message so CI logs show WHY git failed (e.g. index.lock,
+// embedded-repo refusal, pathspec error) instead of an opaque command string.
+const git = (args) => {
+  try {
+    return execFileSync('git', args, { encoding: 'utf8' });
+  } catch (e) {
+    const stderr = (e.stderr || '').toString().trim();
+    const stdout = (e.stdout || '').toString().trim();
+    const detail = stderr || stdout || e.message;
+    throw new Error(`git ${args.join(' ')} failed (exit ${e.status ?? '?'}): ${detail}`);
+  }
+};
 
 // Stage all working-tree changes except the ai-workflows checkout (and any extra
 // excludes, e.g. a Claude-authored PR-body file) and return GraphQL fileChanges,

--- a/.github/scripts/shared/verified-commit.js
+++ b/.github/scripts/shared/verified-commit.js
@@ -39,6 +39,16 @@ const git = (args) => {
 // ponytail: --name-status quotes paths with spaces; tab-split assumes plain paths.
 function stageChanges(extraExcludes = []) {
   const excludes = ['.ai-workflows', ...extraExcludes].map((p) => `:(exclude)${p}`);
+  // claude-code-action runs git under the hood and can leave a stale
+  // `.git/index.lock` behind. Steps run sequentially, so by the time we stage
+  // there is never a legitimate concurrent git process — any leftover lock is
+  // stale and makes `git add` die with exit 128 ("Another git process seems to
+  // be running"). Clear it best-effort; if the real failure is something else
+  // (dubious ownership, corrupt index), the surfaced git() stderr still shows it.
+  try {
+    const gitDir = git(['rev-parse', '--git-dir']).trim();
+    fs.rmSync(`${gitDir}/index.lock`, { force: true });
+  } catch { /* best-effort — never let lock cleanup mask the real git error below */ }
   git(['add', '-A', '--', ...excludes]);
   const status = git(['diff', '--cached', '--name-status']).trim();
   if (!status) return null;

--- a/tests/commit-fix.test.js
+++ b/tests/commit-fix.test.js
@@ -103,6 +103,22 @@ describe('commit-fix', () => {
     expect(core.getOutput('committed')).toBe('false');
   });
 
+  it('surfaces git stderr (not just "Command failed") when a git call fails', async () => {
+    fs.writeFileSync(path.join(dir, 'main.tf'), 'fixed\n');
+    // Corrupt the index so `git add` exits non-zero with a real diagnostic.
+    fs.writeFileSync(path.join(dir, '.git', 'index'), 'not a valid index\n');
+    const github = makeGithub();
+
+    let err;
+    await runIn(dir, { github, context, core }).catch((e) => { err = e; });
+
+    expect(err).toBeDefined();
+    expect(github.graphql).not.toHaveBeenCalled();
+    // The thrown message must carry git's own diagnostics, not an opaque command echo.
+    expect(err.message).toMatch(/git add .* failed \(exit/);
+    expect(err.message).not.toBe('Command failed: git add -A -- :(exclude).ai-workflows');
+  });
+
   it('fails when HEAD_BRANCH is missing', async () => {
     delete process.env.HEAD_BRANCH;
     const github = makeGithub();

--- a/tests/commit-fix.test.js
+++ b/tests/commit-fix.test.js
@@ -103,6 +103,19 @@ describe('commit-fix', () => {
     expect(core.getOutput('committed')).toBe('false');
   });
 
+  it('clears a stale .git/index.lock so staging succeeds', async () => {
+    fs.writeFileSync(path.join(dir, 'main.tf'), 'fixed\n');
+    fs.writeFileSync(path.join(dir, '.git', 'index.lock'), ''); // leftover from claude-code-action
+    const github = makeGithub();
+
+    await runIn(dir, { github, context, core });
+
+    expect(github.graphql).toHaveBeenCalledTimes(1);
+    const paths = github.graphql.mock.calls[0][1].input.fileChanges.additions.map((a) => a.path);
+    expect(paths).toEqual(['main.tf']);
+    expect(fs.existsSync(path.join(dir, '.git', 'index.lock'))).toBe(false);
+  });
+
   it('surfaces git stderr (not just "Command failed") when a git call fails', async () => {
     fs.writeFileSync(path.join(dir, 'main.tf'), 'fixed\n');
     // Corrupt the index so `git add` exits non-zero with a real diagnostic.


### PR DESCRIPTION
cc-ci-fix failed to land a fix on dryvist/terraform-proxmox#516: the `Commit fix to PR branch` step failed on BOTH auto-fix attempts with only:

```
Error: Command failed: git add -A -- :(exclude).ai-workflows
```

Claude edited the file fine; staging died with exit 128. Reproduced under the runner's exact git 2.54.0 only when a stale `.git/index.lock` is present — `claude-code-action` runs git internally and can leave one behind. Because workflow steps run sequentially, no legitimate git process is live when the shared helper stages, so any leftover lock is stale.

## Changes (shared `verified-commit.js` → all write-workflows)

1. **Clear a stale `.git/index.lock` before `git add`** — the fix. Best-effort, wrapped so it can never mask a real error.
2. **`git()` re-throws with git's real stderr + exit code** — the original failure surfaced only an opaque "Command failed" with no cause. Now every write-workflow (ci-fix, code-simplifier, next-steps, post-merge-*, issue-resolver) reports WHY git failed, so a different future exit-128 (dubious ownership, corrupt index) stays diagnosable.

Tests: added stale-lock + stderr-surfacing cases to `commit-fix.test.js`. Full suite 143 pass under git 2.54.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)