### PR TITLE
fix(write-workflows): stage via add+reset so gitignored .ai-workflows doesn't break commits

### DIFF
--- a/.github/scripts/shared/verified-commit.js
+++ b/.github/scripts/shared/verified-commit.js
@@ -40,18 +40,16 @@ const git = (args) => {
 // or null when there is nothing to commit.
 // ponytail: --name-status quotes paths with spaces; tab-split assumes plain paths.
 function stageChanges(extraExcludes = []) {
-  const excludes = ['.ai-workflows', ...extraExcludes].map((p) => `:(exclude)${p}`);
-  // claude-code-action runs git under the hood and can leave a stale
-  // `.git/index.lock` behind. Steps run sequentially, so by the time we stage
-  // there is never a legitimate concurrent git process — any leftover lock is
-  // stale and makes `git add` die with exit 128 ("Another git process seems to
-  // be running"). Clear it best-effort; if the real failure is something else
-  // (dubious ownership, corrupt index), the surfaced git() stderr still shows it.
-  try {
-    const gitDir = git(['rev-parse', '--git-dir']).trim();
-    fs.rmSync(`${gitDir}/index.lock`, { force: true });
-  } catch { /* best-effort — never let lock cleanup mask the real git error below */ }
-  git(['add', '-A', '--', ...excludes]);
+  const excludes = ['.ai-workflows', ...extraExcludes];
+  // Stage everything, then unstage the tool checkouts. Do NOT use
+  // `git add -A -- :(exclude).ai-workflows`: when a consumer repo .gitignores
+  // the .ai-workflows checkout, git flags the explicitly-named ignored path and
+  // exits 1 ("The following paths are ignored") instead of skipping it — this
+  // broke every cc-ci-fix commit on such repos. `git add -A` skips ignored paths
+  // silently; the reset drops the checkouts whether they were staged (embedded
+  // -repo gitlink when not ignored) or not (nothing staged when ignored).
+  git(['add', '-A']);
+  git(['reset', '-q', '--', ...excludes]);
   const status = git(['diff', '--cached', '--name-status']).trim();
   if (!status) return null;
 

--- a/tests/commit-fix.test.js
+++ b/tests/commit-fix.test.js
@@ -103,17 +103,20 @@ describe('commit-fix', () => {
     expect(core.getOutput('committed')).toBe('false');
   });
 
-  it('clears a stale .git/index.lock so staging succeeds', async () => {
+  it('stages the fix when the repo .gitignores the .ai-workflows checkout', async () => {
+    // Regression: `git add -A -- :(exclude).ai-workflows` exits 1 ("paths are
+    // ignored") when .ai-workflows is gitignored, breaking the commit entirely.
+    fs.writeFileSync(path.join(dir, '.gitignore'), '.ai-workflows\n');
     fs.writeFileSync(path.join(dir, 'main.tf'), 'fixed\n');
-    fs.writeFileSync(path.join(dir, '.git', 'index.lock'), ''); // leftover from claude-code-action
+    fs.mkdirSync(path.join(dir, '.ai-workflows'), { recursive: true });
+    fs.writeFileSync(path.join(dir, '.ai-workflows', 'x.js'), 'leak\n');
     const github = makeGithub();
 
     await runIn(dir, { github, context, core });
 
     expect(github.graphql).toHaveBeenCalledTimes(1);
-    const paths = github.graphql.mock.calls[0][1].input.fileChanges.additions.map((a) => a.path);
-    expect(paths).toEqual(['main.tf']);
-    expect(fs.existsSync(path.join(dir, '.git', 'index.lock'))).toBe(false);
+    const paths = github.graphql.mock.calls[0][1].input.fileChanges.additions.map((a) => a.path).sort();
+    expect(paths).toEqual(['.gitignore', 'main.tf']); // .ai-workflows never staged
   });
 
   it('surfaces git stderr (not just "Command failed") when a git call fails', async () => {


### PR DESCRIPTION
The `git() stderr surfacing from #292 revealed the real cause of cc-ci-fix failing to commit fixes (e.g. dryvist/terraform-proxmox#516):

```
git add -A -- :(exclude).ai-workflows failed (exit 1): The following paths are ignored by one of your .gitignore files:
.ai-workflows
```

terraform-proxmox `.gitignore`s the `.ai-workflows` sparse checkout. When an `:(exclude)` pathspec explicitly names a gitignored path, git 2.54 errors (exit 1) instead of skipping it — so the commit step died and **no auto-fix ever landed**, on every repo that ignores `.ai-workflows`.

## Fix

Replace the exclude-pathspec with `git add -A` (which skips ignored paths silently) followed by `git reset -- .ai-workflows <extraExcludes>` to unstage the tool checkouts. Verified under the runner’s exact git 2.54.0 both when `.ai-workflows` is gitignored (terraform-proxmox) and when it is not (embedded-repo gitlink, unstaged by the reset).

Also drops the speculative `index.lock` cleanup added in #292 — that was a wrong hypothesis; the surfaced stderr proved the cause was ignored-path handling. The stderr surfacing (which found this) stays.

Regression test added for the gitignored-`.ai-workflows` case. Full suite 143 pass under git 2.54.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)