### PR TITLE
fix: remove actions:read from issue-backlog-sweep (broke workflow_call)

### DIFF
--- a/.github/workflows/issue-backlog-sweep.yml
+++ b/.github/workflows/issue-backlog-sweep.yml
@@ -21,7 +21,6 @@
 #
 # Throttling (never runs away):
 #   - max_issues caps how many issues are labeled per run (default 5).
-#   - daily_run_limit caps sweep runs per 24h (default 3).
 #   - the downstream resolver's own PR ceiling (5 bot PRs / 24h) is the hard
 #     backstop on PRs opened — this sweep cannot exceed it.
 #
@@ -44,10 +43,6 @@ on:
         description: "Max backlog issues to label per run"
         type: string
         default: "5"
-      daily_run_limit:
-        description: "Max sweep runs per 24h (0 to disable)"
-        type: string
-        default: "3"
     # No `secrets:` block: callers forward org-level secrets via `secrets: inherit`.
     # Declaring them here (even required: false) broke workflow_call instantiation
     # for consumers passing org secrets — GitHub startup-failed the caller. The
@@ -62,8 +57,10 @@ on:
 
 # Workflow-level permissions set the maximum for all jobs.
 # permissions: {} silently skips all jobs in cross-repo calls.
+# NOTE: no `actions: read` here — granting it made cross-repo workflow_call
+# consumers fail at startup ("workflow file issue"). The daily-run-limit check
+# that needed it was removed; the resolver's 5-PR/24h ceiling is the hard cap.
 permissions:
-  actions: read
   contents: read
   id-token: write
   issues: write
@@ -97,35 +94,9 @@ jobs:
             const run = require('./.ai-workflows/.github/scripts/shared/check-pr-ceiling.js');
             await run({ github, context, core });
 
-  check-daily-limit:
-    name: Check daily run limit
-    runs-on: ${{ inputs.runner_label || 'ubuntu-latest' }}
-    permissions:
-      actions: read
-    outputs:
-      should_run: ${{ steps.check.outputs.should_run }}
-    steps:
-      - name: Checkout ai-workflows scripts
-        uses: actions/checkout@v6
-        with:
-          repository: dryvist/ai-workflows
-          sparse-checkout: .github/scripts
-          path: .ai-workflows
-
-      - name: Check daily run limit
-        id: check
-        uses: actions/github-script@v9
-        env:
-          DAILY_RUN_LIMIT: ${{ inputs.daily_run_limit }}
-          WORKFLOW_FILE: ${{ github.workflow_ref }}
-        with:
-          script: |
-            const run = require('./.ai-workflows/.github/scripts/shared/check-daily-limit.js');
-            await run({ github, context, core });
-
   sweep:
-    needs: [check-pr-ceiling, check-daily-limit]
-    if: needs.check-pr-ceiling.outputs.allowed == 'true' && needs.check-daily-limit.outputs.should_run == 'true'
+    needs: [check-pr-ceiling]
+    if: needs.check-pr-ceiling.outputs.allowed == 'true'
     runs-on: ${{ inputs.runner_label || 'ubuntu-latest' }}
     permissions:
       contents: read

--- a/examples/issue-backlog-sweep-caller.yml
+++ b/examples/issue-backlog-sweep-caller.yml
@@ -33,7 +33,6 @@ on:
     - cron: "0 9 * * 1" # Mondays 09:00 UTC — top up the ai:ready queue weekly
 
 permissions:
-  actions: read
   contents: read
   id-token: write
   issues: write


### PR DESCRIPTION
## Problem
Consumer callers of `issue-backlog-sweep.yml` failed at **startup** ("workflow
file issue", 0 jobs) on every cross-repo `workflow_call` — while the reusable
runs fine when **dispatched directly**, and every other reusable (issue-triage,
cc-issue-resolver, issue-sweeper) instantiates fine when called.

Isolation via a feature matrix across all reusables: the **only** feature unique
to issue-backlog-sweep is workflow-level **`actions: read`** (needed solely by
the `check-daily-limit` job). cc-issue-resolver has the identical multi-job
`needs`/`outputs`/`if` structure and works — ruling out job structure. Granting
`actions: read` is what breaks cross-repo instantiation.

## Fix
Drop the `check-daily-limit` job and the `daily_run_limit` input — the only thing
that needed `actions: read`. The resolver's hard **5-bot-PR/24h ceiling** remains
the real runaway backstop and the sweep cron is weekly, so throttling is intact.
Remove `actions: read` from the reusable's and the example caller's permissions.

## Follow-up (flagged, not done here)
Six other reusables (cc-ci-fix, cc-code-simplifier, cc-post-merge-*, cc-next-steps,
best-practices) also declare workflow-level `actions: read` via check-daily-limit.
If this is the cross-repo cause, they may have the same latent startup failure —
worth verifying once this fix is confirmed on nix-ai.

🤖 Generated with [Claude Code](https://claude.com/claude-code)