### PR TITLE
fix: remove colliding concurrency from backlog example caller

### DIFF
--- a/examples/issue-backlog-sweep-caller.yml
+++ b/examples/issue-backlog-sweep-caller.yml
@@ -38,9 +38,10 @@ permissions:
   issues: write
   pull-requests: read
 
-concurrency:
-  group: issue-backlog-sweep-${{ github.repository }}
-  cancel-in-progress: false # Never cancel — queue instead to avoid wasting AI tokens
+# Do NOT add a caller-level `concurrency:` here. The reusable already sets the
+# group `issue-backlog-sweep-${{ github.repository }}`. A caller that reuses the
+# reusable's EXACT group holds that slot, so the reusable's jobs can never
+# acquire it — the run startup-fails with 0 jobs. The reusable queues runs.
 
 jobs:
   sweep:


### PR DESCRIPTION
The example caller set `concurrency.group` byte-identical to the reusable's own group. A caller sharing the reusable's exact concurrency group holds the slot, so the reusable's jobs can never acquire it — every dispatch startup-fails with 0 jobs. Root-caused on a live nix-ai consumer (dryvist/nix-ai#1078): a minimal caller without concurrency instantiated jobs=2 against the same reusable; removing the caller concurrency made the real caller instantiate. The reusable already queues runs per-repo, so behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)