### PR TITLE
fix: remove inputs-in-with from backlog example (schedule startup failure)

### DIFF
--- a/examples/issue-backlog-sweep-caller.yml
+++ b/examples/issue-backlog-sweep-caller.yml
@@ -17,18 +17,18 @@
 # triggers. Keep the cadence slow — the sweep only needs to top up the ai:ready
 # queue as the resolver drains it.
 #
-# Throttling: max_issues caps labels per run; the resolver's own PR ceiling
-# (5 bot PRs / 24h) is the hard backstop on PRs actually opened.
+# Throttling: the reusable's max_issues (default 5) caps labels per run; the
+# resolver's own PR ceiling (5 bot PRs / 24h) is the hard backstop on PRs opened.
+#
+# Do NOT add `with: max_issues: ${{ inputs.max_issues ... }}` here. Referencing
+# the `inputs` context in a reusable-call `with:` while a `schedule` trigger is
+# present makes GitHub startup-fail every run (`inputs` is undefined for
+# scheduled events). The reusable's default (5) covers weekly and manual runs.
 
 name: Issue Backlog Sweep
 
 on:
   workflow_dispatch:
-    inputs:
-      max_issues:
-        description: "Max backlog issues to label this run"
-        type: string
-        default: "5"
   schedule:
     - cron: "0 9 * * 1" # Mondays 09:00 UTC — top up the ai:ready queue weekly
 
@@ -50,5 +50,3 @@ jobs:
     # org secrets fails reusable instantiation. zizmor's secrets-inherit audit is a
     # false positive here (this is a first-party reusable), hence the ignore.
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    with:
-      max_issues: ${{ inputs.max_issues || '5' }}


### PR DESCRIPTION
The `examples/issue-backlog-sweep-caller.yml` template referenced the `inputs`
context in the reusable-call `with:` while declaring a `schedule` trigger.
`inputs` is undefined for scheduled events, so any repo copying this template
**startup-failed every run** (0 jobs).

This is the second of **two independent** startup-failure causes for backlog
callers, both now fixed here and in the live dryvist/nix-ai caller:
1. Caller concurrency group colliding with the reusable's identical group
   (already dropped + documented in this example).
2. `inputs`-in-`with` under a `schedule` trigger (this PR).

Verified on dryvist/nix-ai: after both fixes the sweep instantiates and **runs
to success (jobs=2)**. This aligns the template with that working config — drop
the `with: max_issues` block and the now-unused `workflow_dispatch` input; the
reusable defaults `max_issues` to 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)