### PR TITLE
feat: add _iac-drift reusable workflow

### DIFF
--- a/.github/scripts/iac-drift/upsert-drift-issue.js
+++ b/.github/scripts/iac-drift/upsert-drift-issue.js
@@ -1,0 +1,113 @@
+// Upsert (or close) the drift issue for one IaC working directory.
+//
+// Deterministic drift reporting for the _iac-drift reusable workflow. The plan
+// step captured `tofu`/`terragrunt plan -detailed-exitcode`:
+//   exit 0 -> in sync   (close any open drift issue for this workdir)
+//   exit 2 -> drift      (open, or refresh, the drift issue)
+//   exit 1 -> plan error (open, or refresh, a PLAN FAILURE issue)
+//
+// Dedupe key is a hidden marker `<!-- iac-drift:<workdir> -->` carried in the
+// issue body, so exactly one open issue tracks each working directory. Issues
+// carry the `iac-drift` label (auto-created on first use) so the lookup is a
+// cheap labeled list, not a full-repo scan.
+//
+// Env: PLAN_EXIT_CODE, WORKDIR, PLAN_FILE, POST_PLAN_EXCERPT.
+const fs = require('fs');
+
+const LABEL = 'iac-drift';
+const HEARTBEAT = '<!-- iac-drift-heartbeat -->';
+
+module.exports = async ({ github, context, core }) => {
+  const exitCode = String(process.env.PLAN_EXIT_CODE || '').trim();
+  const workdir = process.env.WORKDIR || '.';
+  const planFile = process.env.PLAN_FILE || '';
+  const postExcerpt = String(process.env.POST_PLAN_EXCERPT || 'false').toLowerCase() === 'true';
+  const { owner, repo } = context.repo;
+  const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+  const now = new Date().toISOString();
+  const marker = `<!-- iac-drift:${workdir} -->`;
+
+  // One open drift issue per workdir, found via the hidden body marker.
+  const openIssues = await github.paginate(github.rest.issues.listForRepo, {
+    owner, repo, state: 'open', labels: LABEL, per_page: 100,
+  });
+  const existing = openIssues.find(
+    (i) => !i.pull_request && (i.body || '').includes(marker),
+  );
+
+  // exit 0 = clean. Close the open drift issue (if any) and stop.
+  if (exitCode === '0') {
+    if (!existing) {
+      core.info(`No drift in ${workdir}; no open issue to close.`);
+      return;
+    }
+    await github.rest.issues.createComment({
+      owner, repo, issue_number: existing.number,
+      body: `Drift cleared as of ${now}. Plan is back in sync ([run](${runUrl})). Closing.`,
+    });
+    await github.rest.issues.update({
+      owner, repo, issue_number: existing.number, state: 'closed',
+    });
+    core.info(`Closed drift issue #${existing.number} for ${workdir}.`);
+    return;
+  }
+
+  // Non-zero: exit 2 = drift, anything else (1, etc.) = plan failure.
+  const isDrift = exitCode === '2';
+  const kind = isDrift ? 'drift detected' : 'PLAN FAILURE';
+  const title = isDrift
+    ? `IaC drift detected: ${repo} ${workdir}`
+    : `IaC PLAN FAILURE: ${repo} ${workdir}`;
+
+  let excerpt = '';
+  if (postExcerpt && planFile) {
+    try {
+      const tail = fs.readFileSync(planFile, 'utf8').split('\n').slice(-60).join('\n');
+      excerpt = `\n\n<details><summary>Plan excerpt (last 60 lines)</summary>\n\n\`\`\`\n${tail}\n\`\`\`\n\n</details>`;
+    } catch (e) {
+      core.info(`Could not read plan file ${planFile}: ${e.message}`);
+    }
+  }
+
+  const body = [
+    marker,
+    `**Status:** ${kind}`,
+    `**Working directory:** \`${workdir}\``,
+    `**Last seen:** ${now}`,
+    `**Run:** ${runUrl}`,
+    '',
+    isDrift
+      ? 'The live infrastructure has drifted from the committed IaC. Reconcile by codifying the change into IaC, or revert it with an apply.'
+      : 'The scheduled plan failed to run (exit 1). Investigate the workflow logs before trusting the drift signal.',
+    excerpt,
+  ].join('\n');
+
+  if (!existing) {
+    const { data } = await github.rest.issues.create({
+      owner, repo, title, body, labels: [LABEL],
+    });
+    core.info(`Opened ${kind} issue #${data.number} for ${workdir}.`);
+    return;
+  }
+
+  // Refresh in place — prefer editing the body's "Last seen" over stacking
+  // comments; post at most one heartbeat comment per calendar day.
+  await github.rest.issues.update({
+    owner, repo, issue_number: existing.number, title, body,
+  });
+
+  const today = now.slice(0, 10);
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    owner, repo, issue_number: existing.number, per_page: 100,
+  });
+  const beatToday = comments.some(
+    (c) => (c.body || '').includes(HEARTBEAT) && (c.created_at || '').slice(0, 10) === today,
+  );
+  if (!beatToday) {
+    await github.rest.issues.createComment({
+      owner, repo, issue_number: existing.number,
+      body: `${HEARTBEAT}\nStill ${kind} as of ${now} ([run](${runUrl})).`,
+    });
+  }
+  core.info(`Refreshed ${kind} issue #${existing.number} for ${workdir}.`);
+};

--- a/.github/workflows/_iac-drift.yml
+++ b/.github/workflows/_iac-drift.yml
@@ -1,0 +1,206 @@
+# Reusable: IaC Drift Detection (deterministic — NO AI)
+#
+# Scheduled config-as-code drift detection for any OpenTofu / Terragrunt stack.
+# `plan -detailed-exitcode` is the purpose-built drift detector: exit 0 = in
+# sync, exit 2 = the live infrastructure has drifted from committed code, exit 1
+# = the plan itself failed. Any non-zero exit fails the job so drift is LOUD,
+# never a silent green. Out-of-band changes surface as a deduped GitHub issue
+# (one per working directory) for triage — codify into IaC, or revert by apply.
+#
+# There is intentionally NO Claude / AI step here. Drift detection must be
+# deterministic and cheap to run on every schedule tick; a plan exit code is a
+# precise signal that needs no model.
+#
+# Secrets come from Doppler (dopplerhq/secrets-fetch-action) with
+# inject-env-vars: true, so the consumer's own project supplies whatever the
+# stack needs (AWS_*, TF_VAR_*, backend creds, NTFY_BASE_URL) as env vars with
+# no per-secret mapping in this reusable. Tradeoff: every Doppler secret in the
+# consumer's config is visible to later steps in this job — acceptable because
+# this job runs only first-party plan/init and the notify curl.
+#
+# Generalizes terraform-proxmox/.github/workflows/servarr-config-drift.yml.
+#
+# Usage:
+#   uses: dryvist/ai-workflows/.github/workflows/_iac-drift.yml@main
+name: _iac-drift
+
+on:
+  workflow_call:
+    inputs:
+      runner_label:
+        description: >-
+          Runner label(s). A plain string (default ubuntu-latest) runs on a
+          single label. Pass a JSON array string (e.g.
+          '["self-hosted","Linux","terraform"]') to target a self-hosted
+          multi-label runner — it is fromJSON-decoded when it starts with '['.
+        type: string
+        required: false
+        default: ubuntu-latest
+      working_directory:
+        description: "Stack directory to plan (relative to the consumer repo root)."
+        type: string
+        required: true
+      tool:
+        description: "IaC tool: 'tofu' or 'terragrunt'. Default tofu."
+        type: string
+        required: false
+        default: tofu
+      backend_config:
+        description: "Optional value passed as `-backend-config=<value>` to init."
+        type: string
+        required: false
+        default: ""
+      plan_args:
+        description: "Optional extra args appended to the plan command (word-split)."
+        type: string
+        required: false
+        default: ""
+      post_plan_excerpt:
+        description: >-
+          When true, include the last ~60 lines of plan output in the drift
+          issue body. Default false — public-repo leak safety (plan output can
+          echo resource names / values).
+        type: boolean
+        required: false
+        default: false
+      ntfy_topic:
+        description: >-
+          Optional ntfy topic. When set and the job fails, POSTs an alert to
+          $NTFY_BASE_URL/<topic> (NTFY_BASE_URL is Doppler-injected).
+        type: string
+        required: false
+        default: ""
+      timeout_minutes:
+        description: "Job timeout in minutes. Default 15."
+        type: number
+        required: false
+        default: 15
+    # No `secrets:` block: callers forward org/repo secrets via `secrets: inherit`.
+    # Declaring secrets here (even required: false) breaks workflow_call
+    # instantiation for consumers passing inherited secrets.
+  workflow_dispatch:
+    inputs:
+      working_directory:
+        description: "Stack directory to plan (relative to the consumer repo root)."
+        type: string
+        required: true
+      tool:
+        description: "IaC tool: 'tofu' or 'terragrunt'."
+        type: string
+        required: false
+        default: tofu
+
+# Workflow-level permissions set the maximum for all jobs.
+# permissions: {} silently skips all jobs in cross-repo calls; declare the full
+# set explicitly. No `actions: read` — granting it has historically startup-
+# failed cross-repo workflow_call consumers.
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: iac-drift-${{ github.repository }}-${{ inputs.working_directory }}
+  cancel-in-progress: false
+
+jobs:
+  drift:
+    name: Detect IaC drift
+    runs-on: ${{ startsWith(inputs.runner_label, '[') && fromJSON(inputs.runner_label) || inputs.runner_label || 'ubuntu-latest' }}
+    timeout-minutes: ${{ inputs.timeout_minutes || 15 }}
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout consumer repository
+        uses: actions/checkout@v6
+
+      - name: Checkout ai-workflows scripts
+        uses: actions/checkout@v6
+        with:
+          repository: dryvist/ai-workflows
+          sparse-checkout: .github/scripts
+          path: .ai-workflows
+
+      - name: Setup OpenTofu
+        uses: opentofu/setup-opentofu@v2
+        with:
+          # Pass the real plan exit code through (needed for -detailed-exitcode).
+          tofu_wrapper: false
+
+      - name: Setup Terragrunt
+        if: inputs.tool == 'terragrunt'
+        uses: autero1/action-terragrunt@v3
+        with:
+          terragrunt-version: latest
+          token: ${{ github.token }}
+
+      - name: Fetch secrets from Doppler
+        uses: dopplerhq/secrets-fetch-action@v2
+        with:
+          doppler-token: ${{ secrets.DOPPLER_TOKEN }}
+          # Inject every project secret as an env var for the init/plan/notify
+          # steps below — the reusable can't enumerate a consumer's secret names.
+          inject-env-vars: true
+
+      - name: Init
+        working-directory: ${{ inputs.working_directory }}
+        env:
+          TOOL: ${{ inputs.tool }}
+          BACKEND_CONFIG: ${{ inputs.backend_config }}
+          # Terragrunt drives the OpenTofu binary (no-op when tool == tofu).
+          TERRAGRUNT_TFPATH: tofu
+          TG_TF_PATH: tofu
+        run: |
+          ARGS=(-input=false)
+          [ -n "$BACKEND_CONFIG" ] && ARGS+=("-backend-config=$BACKEND_CONFIG")
+          "$TOOL" init "${ARGS[@]}"
+
+      - name: Plan (detailed-exitcode; non-zero = drift/error, captured not fatal)
+        id: plan
+        working-directory: ${{ inputs.working_directory }}
+        env:
+          TOOL: ${{ inputs.tool }}
+          PLAN_ARGS: ${{ inputs.plan_args }}
+          TERRAGRUNT_TFPATH: tofu
+          TG_TF_PATH: tofu
+        # -lock=false: a read-only drift plan must never block a real apply.
+        run: |
+          set +e
+          read -ra EXTRA <<< "$PLAN_ARGS"
+          "$TOOL" plan -input=false -lock=false -detailed-exitcode "${EXTRA[@]}" 2>&1 | tee plan.txt
+          echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
+      - name: Upsert drift issue
+        if: always()
+        uses: actions/github-script@v9
+        env:
+          PLAN_EXIT_CODE: ${{ steps.plan.outputs.exit_code }}
+          WORKDIR: ${{ inputs.working_directory }}
+          PLAN_FILE: ${{ inputs.working_directory }}/plan.txt
+          POST_PLAN_EXCERPT: ${{ inputs.post_plan_excerpt }}
+        with:
+          script: |
+            const run = require('./.ai-workflows/.github/scripts/iac-drift/upsert-drift-issue.js');
+            await run({ github, context, core });
+
+      - name: Fail on drift or plan error
+        if: steps.plan.outputs.exit_code != '0'
+        env:
+          TOOL: ${{ inputs.tool }}
+          EXIT_CODE: ${{ steps.plan.outputs.exit_code }}
+          WORKDIR: ${{ inputs.working_directory }}
+        run: |
+          echo "::error::${TOOL} plan exit ${EXIT_CODE} (1=plan error, 2=drift) in ${WORKDIR}"
+          exit 1
+
+      - name: Alert ntfy on drift/failure
+        if: failure() && inputs.ntfy_topic != ''
+        env:
+          NTFY_TOPIC: ${{ inputs.ntfy_topic }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: >-
+          test -n "${NTFY_BASE_URL:-}" && curl -fsS --connect-timeout 5 --max-time 15 --retry 2
+          -H "Title: IaC drift ${{ github.repository }}" -H "Priority: high" -H "Tags: warning,drift"
+          -d "IaC drift or plan failure in ${WORKDIR:-stack}. Review: ${RUN_URL}"
+          "${NTFY_BASE_URL%/}/${NTFY_TOPIC}"
+          || echo "ntfy unset/failed; the job failure is the signal."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,14 @@ repos invoke via `uses: dryvist/ai-workflows/.github/workflows/<name>.yml@main`.
 
 ### Workflow Types
 
-**All workflows use `claude-code-action@v1`** with OIDC auth (`id-token: write`).
+**Most workflows use `claude-code-action@v1`** with OIDC auth (`id-token: write`).
+
+**Exception — deterministic workflows (no AI):** `_iac-drift.yml` is a reusable
+scheduled IaC drift detector that runs `tofu`/`terragrunt plan -detailed-exitcode`
+and opens a deduped GitHub issue per working directory. It contains no Claude
+step — drift is a precise plan exit code, so it needs no model. See
+`docs/PATTERNS.md` "Drift Issue Pattern". It has no dogfood caller (this repo has
+no IaC to plan); consumers wire it via `examples/iac-drift-caller.yml`.
 
 - Prompts rendered via `render-prompt.sh` + step output (envsubst)
 - Static prompts: most workflows

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -212,6 +212,51 @@ jobs:
 
 ---
 
+## Drift Issue Pattern
+
+Used by the deterministic (no-AI) `_iac-drift.yml` reusable workflow to report
+IaC drift as a single, self-healing GitHub issue per stack.
+
+**Workflows**: iac-drift
+
+**Why no AI**: drift is `tofu`/`terragrunt plan -detailed-exitcode` — exit 0 = in
+sync, exit 2 = drift, exit 1 = plan error. That exit code is a precise, cheap
+signal; a model would add cost and nondeterminism for zero gain. The plan step
+captures the code with `set +e` and writes it to `GITHUB_OUTPUT`; a later step
+fails the job on any non-zero code so drift is **loud, never a silent green**
+(same principle as the Gate Pattern's fail-loud posture).
+
+**Dedupe via a hidden body marker**: the reporting script
+(`.github/scripts/iac-drift/upsert-drift-issue.js`) keys off a
+`<!-- iac-drift:<working_directory> -->` marker carried in the issue body, so
+exactly one open issue tracks each working directory. Issues carry the
+`iac-drift` label (auto-created on first use) so the lookup is a cheap labeled
+list, not a full-repo scan.
+
+**Lifecycle**:
+
+- exit 2 (drift) / exit 1 (plan error) → create the issue, or refresh the
+  existing one's "Last seen" timestamp in place. At most one heartbeat comment
+  per calendar day (prefer body edits over comment stacking).
+- exit 0 (clean) → comment "drift cleared" and close the open issue.
+
+**Public-repo leak safety**: the plan excerpt is **off by default**
+(`post_plan_excerpt: false`) because plan output can echo resource names and
+values. Callers opt in only on private repos.
+
+**Secrets**: `dopplerhq/secrets-fetch-action@v2` with `inject-env-vars: true`
+exposes every consumer-project secret as an env var to init/plan/notify, so the
+reusable never enumerates a consumer's `AWS_*` / `TF_VAR_*` names. Tradeoff:
+those env vars are visible to all later steps in the job — acceptable because
+the job runs only first-party plan/init plus the notify curl.
+
+**Gate**: consumers gate the drift jobs on a repo variable
+`IAC_DRIFT_ENABLED == 'true'` (a `::notice` fires when unset), so drift is
+turned off intentionally rather than silently. `tofu-github`'s
+`config/iac-drift.yml` sets that variable per opted-in repo.
+
+---
+
 ## Extracted Script Pattern
 
 Used when workflow logic exceeds the 5-line inline threshold.

--- a/examples/iac-drift-caller.yml
+++ b/examples/iac-drift-caller.yml
@@ -1,0 +1,86 @@
+# Example consumer caller for deterministic IaC drift detection.
+#
+# Drop this in your repo at .github/workflows/iac-drift.yml.
+#
+# What it does: on a daily schedule (and on demand), runs
+# `tofu`/`terragrunt plan -detailed-exitcode` against one or more stacks. Exit 2
+# (drift) or exit 1 (plan error) fails the job LOUDLY and opens/refreshes a
+# deduped `IaC drift detected: ...` issue (one per working directory). When a
+# later run comes back clean, the issue is commented and closed automatically.
+#
+# There is NO AI in this chain — drift detection is a deterministic plan exit
+# code, cheap to run on every tick.
+#
+# PREREQUISITES:
+#   - Repo secret DOPPLER_TOKEN (service token) whose project holds everything
+#     the stack needs as secrets: AWS_* backend creds, TF_VAR_* provider vars,
+#     and (optionally) NTFY_BASE_URL. secrets-fetch injects them as env vars.
+#   - A self-hosted runner if the stack targets a private/LAN API. Pass its
+#     labels as a JSON array string in runner_label.
+#
+# GATE: like the rest of the estate, drift is gated on a repo variable so it can
+# be turned off intentionally rather than silently. When IAC_DRIFT_ENABLED is
+# not 'true' the gate job emits a ::notice and the drift jobs are skipped.
+# (tofu-github's config/iac-drift.yml sets this variable per opted-in repo.)
+
+name: IaC Drift
+
+on:
+  schedule:
+    # Daily, off the :00 mark to dodge the cron thundering herd.
+    - cron: "17 9 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  # Distinct from the reusable's per-workdir group so the caller never holds a
+  # slot the reusable's jobs need.
+  group: iac-drift-caller-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  gate-check:
+    name: Check drift gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notice when IAC_DRIFT_ENABLED is not true
+        if: vars.IAC_DRIFT_ENABLED != 'true'
+        env:
+          GATE_MESSAGE: >-
+            IAC_DRIFT_ENABLED is not 'true' -- scheduled IaC drift detection is
+            OFF, so out-of-band infrastructure changes go unnoticed. Provision
+            the Doppler service token (repo secret DOPPLER_TOKEN) and set the
+            repo variable IAC_DRIFT_ENABLED=true to enable. Disable this
+            schedule intentionally if drift detection is meant to be off.
+        run: echo "::notice::${GATE_MESSAGE}"
+
+  # A plain tofu subdir stack on a self-hosted runner (LAN-reachable APIs).
+  drift-subdir:
+    name: Drift — infra subdir stack
+    needs: gate-check
+    if: vars.IAC_DRIFT_ENABLED == 'true'
+    uses: dryvist/ai-workflows/.github/workflows/_iac-drift.yml@main
+    secrets: inherit # zizmor: ignore[secrets-inherit]
+    with:
+      # JSON array string -> fromJSON-decoded to a multi-label self-hosted runner.
+      runner_label: '["self-hosted","Linux","terraform"]'
+      working_directory: servarr-config
+      tool: tofu
+      backend_config: "bucket=my-tf-state-bucket"
+      ntfy_topic: keystone
+      # post_plan_excerpt stays false (default): plan output can echo resource
+      # names/values and this repo is public.
+
+  # A terragrunt root on GitHub-hosted runners.
+  drift-terragrunt:
+    name: Drift — terragrunt root
+    needs: gate-check
+    if: vars.IAC_DRIFT_ENABLED == 'true'
+    uses: dryvist/ai-workflows/.github/workflows/_iac-drift.yml@main
+    secrets: inherit # zizmor: ignore[secrets-inherit]
+    with:
+      working_directory: live/prod
+      tool: terragrunt

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -33,6 +33,8 @@ function createMockGithub() {
     rest: {
       issues: {
         get: mock(),
+        create: mock(),
+        update: mock(),
         listComments: mock(),
         listCommentsForRepo: mock(),
         listForRepo: mock(),

--- a/tests/iac-drift-upsert.test.js
+++ b/tests/iac-drift-upsert.test.js
@@ -1,0 +1,148 @@
+const { describe, it, expect, beforeEach, afterEach } = require('bun:test');
+const { createMockCore, createMockContext, createMockGithub } = require('./helpers.js');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const run = require('../.github/scripts/iac-drift/upsert-drift-issue.js');
+
+const WORKDIR = 'infra/stack';
+const MARKER = `<!-- iac-drift:${WORKDIR} -->`;
+
+function ctx() {
+  return createMockContext({ serverUrl: 'https://github.com', runId: 4242 });
+}
+
+describe('iac-drift upsert-drift-issue', () => {
+  let core, context, github;
+
+  beforeEach(() => {
+    core = createMockCore();
+    context = ctx();
+    github = createMockGithub();
+    github.rest.issues.create.mockResolvedValue({ data: { number: 100 } });
+    github.rest.issues.update.mockResolvedValue({});
+    github.rest.issues.createComment.mockResolvedValue({});
+    process.env.WORKDIR = WORKDIR;
+    process.env.PLAN_FILE = '';
+    process.env.POST_PLAN_EXCERPT = 'false';
+  });
+
+  afterEach(() => {
+    delete process.env.PLAN_EXIT_CODE;
+    delete process.env.WORKDIR;
+    delete process.env.PLAN_FILE;
+    delete process.env.POST_PLAN_EXCERPT;
+  });
+
+  it('creates a drift issue on exit 2 when none exists', async () => {
+    process.env.PLAN_EXIT_CODE = '2';
+    github.paginate.mockResolvedValueOnce([]); // no open drift issues
+
+    await run({ github, context, core });
+
+    expect(github.rest.issues.create).toHaveBeenCalledTimes(1);
+    const arg = github.rest.issues.create.mock.calls[0][0];
+    expect(arg.title).toBe(`IaC drift detected: test-repo ${WORKDIR}`);
+    expect(arg.body).toContain(MARKER);
+    expect(arg.labels).toEqual(['iac-drift']);
+    expect(github.rest.issues.update).not.toHaveBeenCalled();
+  });
+
+  it('updates in place (no duplicate) when a drift issue already exists', async () => {
+    process.env.PLAN_EXIT_CODE = '2';
+    github.paginate
+      .mockResolvedValueOnce([{ number: 55, body: `intro\n${MARKER}\n`, pull_request: undefined }])
+      .mockResolvedValueOnce([]); // no comments yet today
+
+    await run({ github, context, core });
+
+    expect(github.rest.issues.create).not.toHaveBeenCalled();
+    expect(github.rest.issues.update).toHaveBeenCalledTimes(1);
+    expect(github.rest.issues.update.mock.calls[0][0].issue_number).toBe(55);
+    // First heartbeat of the day is posted.
+    expect(github.rest.issues.createComment).toHaveBeenCalledTimes(1);
+    expect(github.rest.issues.createComment.mock.calls[0][0].body).toContain('iac-drift-heartbeat');
+  });
+
+  it('does not stack a second heartbeat comment on the same day', async () => {
+    process.env.PLAN_EXIT_CODE = '2';
+    const today = new Date().toISOString().slice(0, 10);
+    github.paginate
+      .mockResolvedValueOnce([{ number: 55, body: MARKER }])
+      .mockResolvedValueOnce([{ body: '<!-- iac-drift-heartbeat -->\nStill', created_at: `${today}T01:00:00Z` }]);
+
+    await run({ github, context, core });
+
+    expect(github.rest.issues.update).toHaveBeenCalledTimes(1);
+    expect(github.rest.issues.createComment).not.toHaveBeenCalled();
+  });
+
+  it('comments and closes the open issue on exit 0 (clean)', async () => {
+    process.env.PLAN_EXIT_CODE = '0';
+    github.paginate.mockResolvedValueOnce([{ number: 77, body: MARKER }]);
+
+    await run({ github, context, core });
+
+    expect(github.rest.issues.createComment).toHaveBeenCalledTimes(1);
+    expect(github.rest.issues.createComment.mock.calls[0][0].body).toContain('Drift cleared');
+    expect(github.rest.issues.update).toHaveBeenCalledTimes(1);
+    expect(github.rest.issues.update.mock.calls[0][0].state).toBe('closed');
+  });
+
+  it('does nothing on exit 0 when there is no open drift issue', async () => {
+    process.env.PLAN_EXIT_CODE = '0';
+    github.paginate.mockResolvedValueOnce([]);
+
+    await run({ github, context, core });
+
+    expect(github.rest.issues.create).not.toHaveBeenCalled();
+    expect(github.rest.issues.update).not.toHaveBeenCalled();
+    expect(github.rest.issues.createComment).not.toHaveBeenCalled();
+  });
+
+  it('opens a PLAN FAILURE issue on exit 1', async () => {
+    process.env.PLAN_EXIT_CODE = '1';
+    github.paginate.mockResolvedValueOnce([]);
+
+    await run({ github, context, core });
+
+    const arg = github.rest.issues.create.mock.calls[0][0];
+    expect(arg.title).toBe(`IaC PLAN FAILURE: test-repo ${WORKDIR}`);
+    expect(arg.body).toContain('PLAN FAILURE');
+  });
+
+  it('suppresses the plan excerpt by default even when a plan file exists', async () => {
+    process.env.PLAN_EXIT_CODE = '2';
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'iac-drift-'));
+    const planPath = path.join(dir, 'plan.txt');
+    fs.writeFileSync(planPath, 'secret-bucket-name-should-not-leak\n');
+    process.env.PLAN_FILE = planPath;
+    process.env.POST_PLAN_EXCERPT = 'false';
+    github.paginate.mockResolvedValueOnce([]);
+
+    await run({ github, context, core });
+
+    const arg = github.rest.issues.create.mock.calls[0][0];
+    expect(arg.body).not.toContain('secret-bucket-name-should-not-leak');
+    expect(arg.body).not.toContain('Plan excerpt');
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('includes the plan excerpt when POST_PLAN_EXCERPT is true', async () => {
+    process.env.PLAN_EXIT_CODE = '2';
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'iac-drift-'));
+    const planPath = path.join(dir, 'plan.txt');
+    fs.writeFileSync(planPath, 'Plan: 1 to add, 0 to change, 0 to destroy.\n');
+    process.env.PLAN_FILE = planPath;
+    process.env.POST_PLAN_EXCERPT = 'true';
+    github.paginate.mockResolvedValueOnce([]);
+
+    await run({ github, context, core });
+
+    const arg = github.rest.issues.create.mock.calls[0][0];
+    expect(arg.body).toContain('Plan excerpt');
+    expect(arg.body).toContain('1 to add');
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
## What

Adds `_iac-drift.yml`, a **deterministic (no-AI)** reusable workflow for scheduled IaC drift detection, plus its reporting script, tests, example caller, and docs.

Generalizes the proven pattern in `terraform-proxmox/.github/workflows/servarr-config-drift.yml`.

## Files

- `.github/workflows/_iac-drift.yml` — reusable (`workflow_call` + `workflow_dispatch`). Inputs: `runner_label` (string or JSON-array string for self-hosted multi-label), `working_directory` (required), `tool` (`tofu`|`terragrunt`), `backend_config`, `plan_args`, `post_plan_excerpt`, `ntfy_topic`, `timeout_minutes`. Permissions `contents: read, issues: write`; per-workdir concurrency, `cancel-in-progress: false`.
- `.github/scripts/iac-drift/upsert-drift-issue.js` — marker-deduped issue upsert/close.
- `tests/iac-drift-upsert.test.js` — bun:test (8 cases). Adds `issues.create`/`issues.update` mocks to `tests/helpers.js`.
- `examples/iac-drift-caller.yml` — documented consumer caller (gate + subdir/terragrunt jobs + self-hosted runner example).
- `AGENTS.md`, `docs/PATTERNS.md` — documented as the "Drift Issue Pattern" exception to the all-workflows-use-Claude rule.

## Design decisions

- **Deterministic, no Claude.** Drift is a `plan -detailed-exitcode` result (0 sync / 2 drift / 1 error) — a precise, cheap signal that needs no model and no OIDC. The plan step captures the code with `set +e`; a later step fails the job on any non-zero code so drift is **loud, never a silent green**.
- **Marker dedupe.** A hidden `<!-- iac-drift:<workdir> -->` body marker + an `iac-drift` label keep exactly one open issue per working directory. Refresh edits the body "Last seen" in place; at most one heartbeat comment per day (no comment stacking). A clean run comments "drift cleared" and closes.
- **Excerpt off by default.** `post_plan_excerpt: false` — plan output can echo resource names/values, and consumers may be public. Callers opt in only on private repos.
- **Doppler `inject-env-vars: true`.** The reusable can't enumerate a consumer's `AWS_*` / `TF_VAR_*` secret names, so all project secrets are injected as env vars for init/plan/notify. Tradeoff documented in the workflow header (only first-party plan/init + notify curl run in the job).

## No dogfood caller

This repo has no IaC to plan, so there is intentionally no `iac-drift.yml` dogfood caller — noted in `AGENTS.md`. Consumers wire it via `examples/iac-drift-caller.yml`; `tofu-github`'s `config/iac-drift.yml` sets the `IAC_DRIFT_ENABLED` gate variable (separate PR).

## Verification

- `bun test` — 151 pass, 0 fail (8 new).
- `actionlint` — clean (SC2086 word-splits fixed with bash arrays, not suppressed).

The Doppler action's real inputs were verified from its README: `doppler-token`, `doppler-project`, `doppler-config`, `auth-method`, `doppler-identity-id`, `inject-env-vars`. Secrets are exposed as step outputs by default; `inject-env-vars: true` additionally injects them as env vars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)