### PR TITLE
feat: add review-thread-resolver reusable workflow

### DIFF
--- a/.github/scripts/review-thread-resolver/resolve-threads.js
+++ b/.github/scripts/review-thread-resolver/resolve-threads.js
@@ -1,0 +1,148 @@
+// Resolves review threads left by bot reviewers when the thread is outdated
+// or the bot reported a failed review run. A thread containing even one
+// non-bot comment is never touched, so substantive human discussion always
+// survives. Runs in two modes: single PR (event / dispatch) or org sweep
+// (SWEEP_REPOS csv — every open PR in each repo).
+//
+// resolveReviewThread requires a token with contents read-write; the default
+// GITHUB_TOKEN is often rejected for bot-authored threads in non-interactive
+// runs, so the workflow prefers a GitHub App installation token.
+
+const THREAD_QUERY = `
+  query ($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $number) {
+        reviewThreads(first: 100, after: $cursor) {
+          pageInfo { hasNextPage endCursor }
+          nodes {
+            id
+            isResolved
+            isOutdated
+            path
+            comments(first: 100) {
+              pageInfo { hasNextPage }
+              nodes { body author { login __typename } }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+const RESOLVE_MUTATION = `
+  mutation ($threadId: ID!) {
+    resolveReviewThread(input: { threadId: $threadId }) { thread { id } }
+  }
+`;
+
+const DEFAULT_BOT_REVIEWERS = 'gemini-code-assist,copilot-pull-request-reviewer';
+const DEFAULT_FAILURE_PATTERNS =
+  'startup[_ ]?failure|encountered an error|unable to (process|generate|review)|try again by commenting';
+
+function parseConfig(env) {
+  const csv = (value) => (value || '').split(',').map((s) => s.trim()).filter(Boolean);
+  return {
+    botReviewers: csv(env.BOT_REVIEWERS || DEFAULT_BOT_REVIEWERS),
+    resolveOutdated: (env.RESOLVE_OUTDATED || 'true') === 'true',
+    resolveBotFailures: (env.RESOLVE_BOT_FAILURES || 'true') === 'true',
+    failureRegex: new RegExp(env.FAILURE_PATTERNS || DEFAULT_FAILURE_PATTERNS, 'i'),
+    prNumber: env.PR_NUMBER ? Number(env.PR_NUMBER) : null,
+    sweepRepos: csv(env.SWEEP_REPOS),
+  };
+}
+
+// Returns a resolution reason ('outdated' | 'bot-failure') or null.
+function decideThread(thread, config) {
+  const comments = (thread.comments && thread.comments.nodes) || [];
+  if (comments.length === 0) return null;
+  // A truncated comment list could hide a human reply — leave the thread alone.
+  if (thread.comments.pageInfo && thread.comments.pageInfo.hasNextPage) return null;
+  const fromAllowedBot = (comment) =>
+    comment.author &&
+    comment.author.__typename === 'Bot' &&
+    config.botReviewers.includes(comment.author.login.replace(/\[bot\]$/, ''));
+  if (!comments.every(fromAllowedBot)) return null;
+  if (config.resolveBotFailures && comments.some((c) => config.failureRegex.test(c.body || ''))) {
+    return 'bot-failure';
+  }
+  if (config.resolveOutdated && thread.isOutdated) return 'outdated';
+  return null;
+}
+
+async function fetchThreads(github, owner, repo, number) {
+  const threads = [];
+  let cursor = null;
+  do {
+    const result = await github.graphql(THREAD_QUERY, { owner, repo, number, cursor });
+    const connection = result.repository.pullRequest.reviewThreads;
+    threads.push(...connection.nodes);
+    cursor = connection.pageInfo.hasNextPage ? connection.pageInfo.endCursor : null;
+  } while (cursor);
+  return threads;
+}
+
+module.exports = async ({ github, context, core }) => {
+  const config = parseConfig(process.env);
+  const owner = context.repo.owner;
+
+  const targets = [];
+  if (config.sweepRepos.length > 0) {
+    for (const repo of config.sweepRepos) {
+      try {
+        const prs = await github.paginate(github.rest.pulls.list, {
+          owner,
+          repo,
+          state: 'open',
+          per_page: 100,
+        });
+        for (const pr of prs) targets.push({ repo, number: pr.number });
+      } catch (error) {
+        core.warning(`Could not list open PRs for ${owner}/${repo}: ${error.message}`);
+      }
+    }
+  } else {
+    const number =
+      config.prNumber || (context.payload.pull_request && context.payload.pull_request.number);
+    if (!number) {
+      core.info('No PR number and no sweep_repos — nothing to do');
+      core.setOutput('resolved_count', '0');
+      return;
+    }
+    targets.push({ repo: context.repo.repo, number });
+  }
+
+  let resolved = 0;
+  for (const target of targets) {
+    let threads;
+    try {
+      threads = await fetchThreads(github, owner, target.repo, target.number);
+    } catch (error) {
+      core.warning(
+        `Could not fetch review threads for ${owner}/${target.repo}#${target.number}: ${error.message}`
+      );
+      continue;
+    }
+    for (const thread of threads) {
+      if (thread.isResolved) continue;
+      const reason = decideThread(thread, config);
+      if (!reason) continue;
+      try {
+        await github.graphql(RESOLVE_MUTATION, { threadId: thread.id });
+        resolved += 1;
+        core.info(`Resolved ${reason} thread on ${owner}/${target.repo}#${target.number} (${thread.path})`);
+      } catch (error) {
+        core.warning(
+          `Could not resolve thread on ${owner}/${target.repo}#${target.number} (${thread.path}): ` +
+            `${error.message} — resolveReviewThread needs contents read-write; ` +
+            'configure GH_APP_CLAUDE_BOT_ID / GH_APP_CLAUDE_BOT_PRIVATE_KEY'
+        );
+      }
+    }
+  }
+  core.setOutput('resolved_count', String(resolved));
+  core.info(`Resolved ${resolved} thread(s) across ${targets.length} PR(s)`);
+};
+
+module.exports.parseConfig = parseConfig;
+module.exports.decideThread = decideThread;

--- a/.github/workflows/dogfood-review-thread-sweep.yml
+++ b/.github/workflows/dogfood-review-thread-sweep.yml
@@ -1,0 +1,27 @@
+# Dogfood: hourly org-wide sweep resolving stale bot review threads.
+#
+# Runs from this hub repo only — consumer repos need no caller for sweep
+# coverage. The repo list comes from the org-level AI_SWEEP_REPOS Actions
+# variable (managed in tofu-github from config/ai-callers.yml), with an inline
+# fallback until that variable is applied.
+#
+# No concurrency block on purpose: a caller sharing the reusable workflow's
+# exact concurrency group causes an opaque 0-job startup_failure.
+
+name: Dogfood Review Thread Sweep
+
+on:
+  schedule:
+    - cron: "17 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sweep:
+    uses: ./.github/workflows/review-thread-resolver.yml
+    with:
+      sweep_repos: ${{ vars.AI_SWEEP_REPOS || 'ai-workflows,nix-darwin,nix-ai,nix-claude-code,nix-home,terraform-proxmox,ansible-proxmox,ansible-proxmox-apps,ansible-splunk,claude-code-plugins,ai-assistant-instructions' }}
+    secrets: inherit

--- a/.github/workflows/review-thread-resolver.yml
+++ b/.github/workflows/review-thread-resolver.yml
@@ -1,0 +1,122 @@
+# Review Thread Resolver
+#
+# Reusable workflow: resolves review threads left by bot reviewers when the
+# thread is outdated or the bot reported a failed review run. Threads with any
+# human comment are never touched. Non-AI utility workflow — plain
+# actions/github-script, no AI tokens.
+#
+# Why: the org branch ruleset requires every review thread to be resolved
+# before merge, and bot reviewers routinely leave threads (including failed-run
+# notices) that otherwise need a manual GraphQL mutation per thread.
+#
+# Two modes:
+#   - Single PR: call from pull_request / pull_request_review events, or pass
+#     pr_number via dispatch.
+#   - Org sweep: pass sweep_repos (comma-separated repo names); every open PR
+#     in each repo is processed. Consumer repos need no files for this mode.
+#
+# Token note: resolveReviewThread requires CONTENTS read-write, and the default
+# GITHUB_TOKEN is often rejected for bot-authored threads in non-interactive
+# runs. When the GH_APP_CLAUDE_BOT_ID var is configured, a GitHub App token is
+# minted (org-wide in sweep mode) and used instead.
+
+name: Review Thread Resolver
+
+on:
+  workflow_call:
+    inputs:
+      runner_label:
+        description: >-
+          GitHub Actions runner label to run the job(s) on. Defaults to
+          ubuntu-latest.
+        type: string
+        required: false
+        default: ubuntu-latest
+      bot_reviewers:
+        description: "Comma-separated bot logins whose threads may be auto-resolved"
+        type: string
+        default: "gemini-code-assist,copilot-pull-request-reviewer"
+      resolve_outdated:
+        description: "Resolve bot-only threads whose code has changed underneath them"
+        type: string
+        default: "true"
+      resolve_bot_failures:
+        description: "Resolve bot-only threads whose body matches failure_patterns"
+        type: string
+        default: "true"
+      failure_patterns:
+        description: "Case-insensitive regex marking failed-review notices (empty = built-in default)"
+        type: string
+        default: ""
+      pr_number:
+        description: "PR number override (single-PR mode)"
+        type: string
+        default: ""
+      sweep_repos:
+        description: "Comma-separated repo names to sweep (org-sweep mode)"
+        type: string
+        default: ""
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number (single-PR mode)"
+        type: string
+        default: ""
+      sweep_repos:
+        description: "Comma-separated repo names to sweep (org-sweep mode)"
+        type: string
+        default: ""
+
+# contents: write is required by the resolveReviewThread GraphQL mutation.
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: review-thread-resolver-${{ github.repository }}-${{ github.event.pull_request.number || inputs.pr_number || github.run_id }}
+  cancel-in-progress: false  # Never cancel — queue instead
+
+jobs:
+  resolve:
+    name: Resolve bot review threads
+    runs-on: ${{ inputs.runner_label || 'ubuntu-latest' }}
+    timeout-minutes: 10
+    steps:
+      - name: Checkout ai-workflows scripts
+        uses: actions/checkout@v6
+        with:
+          repository: dryvist/ai-workflows
+          sparse-checkout: .github/scripts
+          path: .ai-workflows
+
+      - name: Mint App token (single repo)
+        id: app-token
+        if: vars.GH_APP_CLAUDE_BOT_ID != '' && inputs.sweep_repos == ''
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
+          private-key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}
+
+      - name: Mint App token (org sweep)
+        id: app-token-sweep
+        if: vars.GH_APP_CLAUDE_BOT_ID != '' && inputs.sweep_repos != ''
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
+          private-key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Resolve threads
+        uses: actions/github-script@v9
+        env:
+          BOT_REVIEWERS: ${{ inputs.bot_reviewers }}
+          RESOLVE_OUTDATED: ${{ inputs.resolve_outdated }}
+          RESOLVE_BOT_FAILURES: ${{ inputs.resolve_bot_failures }}
+          FAILURE_PATTERNS: ${{ inputs.failure_patterns }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          SWEEP_REPOS: ${{ inputs.sweep_repos }}
+        with:
+          github-token: ${{ steps.app-token-sweep.outputs.token || steps.app-token.outputs.token || github.token }}
+          script: |
+            const run = require('./.ai-workflows/.github/scripts/review-thread-resolver/resolve-threads.js');
+            await run({ github, context, core });

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ repos invoke via `uses: dryvist/ai-workflows/.github/workflows/<name>.yml@main`.
     notification/
     post-merge-docs-review/
     post-merge-tests/
+    review-thread-resolver/
     shared/
     verification/
   workflows/
@@ -33,7 +34,10 @@ repos invoke via `uses: dryvist/ai-workflows/.github/workflows/<name>.yml@main`.
 
 ### Workflow Types
 
-**All workflows use `claude-code-action@v1`** with OIDC auth (`id-token: write`).
+**All AI workflows use `claude-code-action@v1`** with OIDC auth (`id-token: write`).
+Non-AI utility workflows (`notify-ai-pr`, `ci-fail-issue`,
+`review-thread-resolver`) use plain `actions/github-script` — see
+docs/PATTERNS.md "Non-AI Utility Workflow Pattern".
 
 - Prompts rendered via `render-prompt.sh` + step output (envsubst)
 - Static prompts: most workflows

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Reusable AI agent workflows for GitHub Actions. Each workflow is a
 | `pr-issue-linker.yml` | `pull_request` | On PR open/close | Auto-links PRs to referenced issues via Development sidebar |
 | `project-router.yml` | `workflow_call` | On issue/PR events | Routes items to GitHub Projects with smart field assignment |
 | `repo-orchestrator.yml` | `workflow_call` | On-demand | Hub-and-spoke multi-repo workflow dispatcher |
+| `review-thread-resolver.yml` | `workflow_call` | Hourly org sweep (hub) | Resolves outdated/failed bot review threads so thread-resolution rules stop blocking merges — no AI tokens |
 
 ---
 

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -675,3 +675,41 @@ jobs:
 
 **Implementation**: Extracted script at `.github/scripts/notification/send-slack-pr-notify.js`.
 Parses the AI Provenance footer from the PR body using regex to populate the Slack message fields.
+
+## Non-AI Utility Workflow Pattern
+
+Not every reusable workflow needs Claude. When the job is deterministic
+(GraphQL mutations, notifications, labeling), a plain `actions/github-script`
+workflow is cheaper, faster, and immune to AI-token limits. Current members:
+`notify-ai-pr.yml`, `ci-fail-issue.yml`, `review-thread-resolver.yml`.
+
+**Review Thread Resolver** (`review-thread-resolver.yml`) exists because the
+org branch ruleset enforces `required_review_thread_resolution`: bot reviewers
+(gemini-code-assist, Copilot) leave review threads — including failed-run
+notices — that block merges until someone manually runs a
+`resolveReviewThread` GraphQL mutation per thread.
+
+**Safety invariant**: a thread is only ever auto-resolved when EVERY comment
+in it was authored by an allow-listed bot (`__typename == 'Bot'`, login in
+`bot_reviewers`) AND the thread is either outdated (code changed underneath
+it) or matches `failure_patterns`. One human reply anywhere means the thread
+is never touched. Substantive bot feedback that is still current also
+survives — responding to that is `cc-pr-review-responder`'s job, not this
+workflow's.
+
+**Two modes**:
+
+- *Single PR* — consumer caller on `pull_request: [synchronize]` +
+  `pull_request_review: [submitted]` for instant cleanup.
+- *Org sweep* — the hub's `dogfood-review-thread-sweep.yml` runs hourly over
+  the repos in the org-level `AI_SWEEP_REPOS` variable (managed by
+  tofu-github). Consumer repos need **zero files** for sweep coverage.
+
+**Token requirement** (hard-won): `resolveReviewThread` requires a token with
+**Contents read-write** — `pull-requests: write` alone is not enough — and the
+default `GITHUB_TOKEN` is often rejected (`Resource not accessible by
+integration`) for bot-authored threads in non-interactive runs. The workflow
+mints a GitHub App installation token from `GH_APP_CLAUDE_BOT_ID` /
+`GH_APP_CLAUDE_BOT_PRIVATE_KEY` when available (org-wide in sweep mode) and
+falls back to `GITHUB_TOKEN` with a per-thread warning instead of a run
+failure.

--- a/examples/review-thread-resolver-caller.yml
+++ b/examples/review-thread-resolver-caller.yml
@@ -1,0 +1,28 @@
+# Example consumer caller for review-thread-resolver (event-driven mode).
+#
+# Most repos do NOT need this file: the hub's scheduled org sweep
+# (dogfood-review-thread-sweep.yml in dryvist/ai-workflows) already covers
+# every repo listed in the org AI_SWEEP_REPOS variable. Add this caller only
+# when a busy repo wants instant resolution on PR events instead of waiting
+# for the hourly sweep.
+#
+# No concurrency block on purpose: a caller sharing the reusable workflow's
+# exact concurrency group causes an opaque 0-job startup_failure.
+
+name: Review Thread Resolver
+
+on:
+  pull_request:
+    types: [synchronize]
+  pull_request_review:
+    types: [submitted]
+
+# contents: write is required by the resolveReviewThread GraphQL mutation.
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  resolve:
+    uses: dryvist/ai-workflows/.github/workflows/review-thread-resolver.yml@main
+    secrets: inherit

--- a/tests/review-thread-resolver-resolve-threads.test.js
+++ b/tests/review-thread-resolver-resolve-threads.test.js
@@ -1,0 +1,225 @@
+const { describe, it, expect, beforeEach, afterEach, mock } = require('bun:test');
+const { createMockCore, createMockContext, createMockGithub } = require('./helpers.js');
+const run = require('../.github/scripts/review-thread-resolver/resolve-threads.js');
+const { parseConfig, decideThread } = run;
+
+const ENV_KEYS = [
+  'BOT_REVIEWERS',
+  'RESOLVE_OUTDATED',
+  'RESOLVE_BOT_FAILURES',
+  'FAILURE_PATTERNS',
+  'PR_NUMBER',
+  'SWEEP_REPOS',
+];
+
+function botComment(login, body = 'looks fine') {
+  return { body, author: { login, __typename: 'Bot' } };
+}
+
+function humanComment(login = 'some-user', body = 'thanks') {
+  return { body, author: { login, __typename: 'User' } };
+}
+
+function makeThread({ id = 'T_1', isResolved = false, isOutdated = false, comments = [], hasMoreComments = false } = {}) {
+  return {
+    id,
+    isResolved,
+    isOutdated,
+    path: 'src/example.js',
+    comments: { pageInfo: { hasNextPage: hasMoreComments }, nodes: comments },
+  };
+}
+
+function threadPage(threads, { hasNextPage = false, endCursor = null } = {}) {
+  return {
+    repository: {
+      pullRequest: {
+        reviewThreads: { pageInfo: { hasNextPage, endCursor }, nodes: threads },
+      },
+    },
+  };
+}
+
+describe('review-thread-resolver/decideThread', () => {
+  const config = parseConfig({});
+
+  it('resolves an outdated all-bot thread', () => {
+    const thread = makeThread({ isOutdated: true, comments: [botComment('gemini-code-assist')] });
+    expect(decideThread(thread, config)).toBe('outdated');
+  });
+
+  it('does not resolve outdated threads when resolve_outdated is false', () => {
+    const cfg = parseConfig({ RESOLVE_OUTDATED: 'false' });
+    const thread = makeThread({ isOutdated: true, comments: [botComment('gemini-code-assist')] });
+    expect(decideThread(thread, cfg)).toBe(null);
+  });
+
+  it('resolves a failure-notice thread even when not outdated', () => {
+    const thread = makeThread({
+      comments: [botComment('gemini-code-assist', 'The review run hit a startup_failure, try again by commenting')],
+    });
+    expect(decideThread(thread, config)).toBe('bot-failure');
+  });
+
+  it('never resolves a thread containing a human comment', () => {
+    const thread = makeThread({
+      isOutdated: true,
+      comments: [botComment('gemini-code-assist', 'startup_failure'), humanComment()],
+    });
+    expect(decideThread(thread, config)).toBe(null);
+  });
+
+  it('never resolves threads from bots outside bot_reviewers', () => {
+    const thread = makeThread({ isOutdated: true, comments: [botComment('some-other-bot')] });
+    expect(decideThread(thread, config)).toBe(null);
+  });
+
+  it('strips a [bot] suffix before matching the login', () => {
+    const thread = makeThread({ isOutdated: true, comments: [botComment('gemini-code-assist[bot]')] });
+    expect(decideThread(thread, config)).toBe('outdated');
+  });
+
+  it('leaves threads with a truncated comment list alone', () => {
+    const thread = makeThread({
+      isOutdated: true,
+      comments: [botComment('gemini-code-assist')],
+      hasMoreComments: true,
+    });
+    expect(decideThread(thread, config)).toBe(null);
+  });
+
+  it('leaves empty threads alone', () => {
+    expect(decideThread(makeThread({ isOutdated: true }), config)).toBe(null);
+  });
+});
+
+describe('review-thread-resolver/run', () => {
+  let core, context, github;
+
+  beforeEach(() => {
+    core = createMockCore();
+    context = createMockContext({ payload: { pull_request: { number: 7 } } });
+    github = createMockGithub();
+    github.graphql = mock();
+    core.warning = mock();
+    for (const key of ENV_KEYS) delete process.env[key];
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) delete process.env[key];
+  });
+
+  it('no PR context and no sweep_repos is a clean no-op', async () => {
+    context.payload = {};
+    await run({ github, context, core });
+    expect(core.getOutput('resolved_count')).toBe('0');
+    expect(github.graphql).not.toHaveBeenCalled();
+  });
+
+  it('resolves matching threads and skips resolved/human ones', async () => {
+    github.graphql.mockImplementation((query, vars) => {
+      if (query.includes('resolveReviewThread')) return Promise.resolve({});
+      return Promise.resolve(
+        threadPage([
+          makeThread({ id: 'T_out', isOutdated: true, comments: [botComment('gemini-code-assist')] }),
+          makeThread({ id: 'T_done', isResolved: true, isOutdated: true, comments: [botComment('gemini-code-assist')] }),
+          makeThread({ id: 'T_human', isOutdated: true, comments: [botComment('gemini-code-assist'), humanComment()] }),
+        ])
+      );
+    });
+
+    await run({ github, context, core });
+
+    expect(core.getOutput('resolved_count')).toBe('1');
+    const mutationCalls = github.graphql.mock.calls.filter(([q]) => q.includes('resolveReviewThread'));
+    expect(mutationCalls.length).toBe(1);
+    expect(mutationCalls[0][1]).toEqual({ threadId: 'T_out' });
+  });
+
+  it('warns and continues when a mutation is rejected', async () => {
+    let failedOnce = false;
+    github.graphql.mockImplementation((query, vars) => {
+      if (query.includes('resolveReviewThread')) {
+        if (!failedOnce) {
+          failedOnce = true;
+          return Promise.reject(new Error('Resource not accessible by integration'));
+        }
+        return Promise.resolve({});
+      }
+      return Promise.resolve(
+        threadPage([
+          makeThread({ id: 'T_1', isOutdated: true, comments: [botComment('gemini-code-assist')] }),
+          makeThread({ id: 'T_2', isOutdated: true, comments: [botComment('gemini-code-assist')] }),
+        ])
+      );
+    });
+
+    await run({ github, context, core });
+
+    expect(core.getOutput('resolved_count')).toBe('1');
+    expect(core.warning).toHaveBeenCalled();
+  });
+
+  it('paginates across review-thread pages', async () => {
+    let queryCount = 0;
+    github.graphql.mockImplementation((query) => {
+      if (query.includes('resolveReviewThread')) return Promise.resolve({});
+      queryCount += 1;
+      if (queryCount === 1) {
+        return Promise.resolve(
+          threadPage([makeThread({ id: 'T_p1', isOutdated: true, comments: [botComment('gemini-code-assist')] })], {
+            hasNextPage: true,
+            endCursor: 'CUR',
+          })
+        );
+      }
+      return Promise.resolve(
+        threadPage([makeThread({ id: 'T_p2', isOutdated: true, comments: [botComment('gemini-code-assist')] })])
+      );
+    });
+
+    await run({ github, context, core });
+
+    expect(core.getOutput('resolved_count')).toBe('2');
+    expect(queryCount).toBe(2);
+  });
+
+  it('sweep mode processes every open PR in every listed repo and survives a bad repo', async () => {
+    process.env.SWEEP_REPOS = 'repo-a,repo-b';
+    context.payload = {};
+    github.paginate.mockImplementation((fn, opts) => {
+      if (opts.repo === 'repo-a') return Promise.resolve([{ number: 1 }, { number: 2 }]);
+      return Promise.reject(new Error('Not Found'));
+    });
+    github.graphql.mockImplementation((query) => {
+      if (query.includes('resolveReviewThread')) return Promise.resolve({});
+      return Promise.resolve(
+        threadPage([makeThread({ id: 'T_s', isOutdated: true, comments: [botComment('gemini-code-assist')] })])
+      );
+    });
+
+    await run({ github, context, core });
+
+    expect(core.getOutput('resolved_count')).toBe('2');
+    expect(core.warning).toHaveBeenCalledTimes(1);
+  });
+
+  it('honors a custom bot_reviewers list from env', async () => {
+    process.env.BOT_REVIEWERS = 'custom-reviewer';
+    github.graphql.mockImplementation((query) => {
+      if (query.includes('resolveReviewThread')) return Promise.resolve({});
+      return Promise.resolve(
+        threadPage([
+          makeThread({ id: 'T_custom', isOutdated: true, comments: [botComment('custom-reviewer')] }),
+          makeThread({ id: 'T_gemini', isOutdated: true, comments: [botComment('gemini-code-assist')] }),
+        ])
+      );
+    });
+
+    await run({ github, context, core });
+
+    const mutationCalls = github.graphql.mock.calls.filter(([q]) => q.includes('resolveReviewThread'));
+    expect(mutationCalls.length).toBe(1);
+    expect(mutationCalls[0][1]).toEqual({ threadId: 'T_custom' });
+  });
+});


### PR DESCRIPTION
## Summary

- New non-AI reusable workflow `review-thread-resolver.yml`: resolves review threads left by bot reviewers (gemini-code-assist, Copilot) when the thread is **outdated** or contains a **failed-review notice** — the two classes that block merges via `required_review_thread_resolution` without carrying actionable feedback.
- **Safety invariant**: a thread is only touched when *every* comment is from an allow-listed bot. One human reply anywhere → never resolved. Substantive, still-current bot feedback also survives (that's cc-pr-review-responder's job, #303).
- **Org-sweep mode**: `dogfood-review-thread-sweep.yml` runs hourly from this hub over the org `AI_SWEEP_REPOS` variable (inline fallback list until tofu-github lands it) — every fleet repo gets coverage with zero consumer files. Event-driven consumer caller in `examples/` for repos that want instant cleanup.
- Token handling: `resolveReviewThread` needs Contents read-write and often rejects `GITHUB_TOKEN` for bot threads; the workflow prefers a GitHub App installation token (org-wide in sweep mode) and degrades to per-thread warnings.
- Docs: new "Non-AI Utility Workflow Pattern" section in PATTERNS.md; README row; AGENTS.md wording fix ("all workflows use claude-code-action" → "all AI workflows").

## Test plan

- `bun test`: 157 pass (14 new — safety invariant incl. human-comment case, \[bot\] suffix stripping, truncated-comment conservatism, pagination, permission-error continuation, sweep mode with failing repo, custom bot list).
- After merge: dispatch `Dogfood Review Thread Sweep` and verify it resolves a real stale bot thread while leaving human-commented threads untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JEgmkietfTQuv2tTfM4hD