### PR TITLE
feat: add cc-dep-review reusable workflow

### DIFF
--- a/.github/prompts/dep-review.md
+++ b/.github/prompts/dep-review.md
@@ -1,0 +1,43 @@
+Review dependency update PR #${PR_NUMBER} in this repository. Renovate opened
+it; the highest version-bump type is: ${UPDATE_TYPE}.
+
+Steps:
+
+1. Read the PR: `gh pr view ${PR_NUMBER} --json title,body` (the body embeds
+   Renovate's release notes and compare links) and `gh pr diff ${PR_NUMBER}`.
+2. For each updated dependency, identify breaking changes and required
+   migrations. Use the release notes in the body first; if they are truncated
+   or missing, fetch the changelog/compare links with WebFetch or
+   `gh api repos/...` (releases, compare).
+3. Check how this repository actually uses each dependency (Grep/Read) so the
+   assessment reflects real impact, not a generic changelog summary.
+4. Write your assessment to a file named `.claude-dep-review.md` (Write tool)
+   with exactly this structure:
+
+   ```markdown
+   ## Dependency Review (AI)
+
+   **Verdict:** Merge | Merge with care | Hold — one-line reason
+
+   ### Breaking changes
+   - ... (or "None found")
+
+   ### Required migrations in this repo
+   - concrete file/config changes needed here, or "None"
+
+   ### Repo impact
+   - where/how this dependency is used in this repo
+
+   **Confidence:** high | medium | low — one-line reason
+   ```
+
+Rules:
+
+- Do NOT post any comment yourself and do NOT run any write commands — a
+  workflow step posts `.claude-dep-review.md` for you.
+- Keep it concise: this is a risk assessment, not a changelog reprint. Skip
+  changes that cannot affect this repository.
+- For grouped PRs (multiple dependencies), cover each dependency under the
+  same headings.
+- If you cannot determine impact (e.g. changelog unavailable), say so and set
+  confidence low rather than guessing.

--- a/.github/scripts/dep-review/check-eligibility.js
+++ b/.github/scripts/dep-review/check-eligibility.js
@@ -1,0 +1,69 @@
+// Gate for cc-dep-review: run Claude once per Renovate dependency PR whose
+// highest semver update type is in UPDATE_TYPES. Digest pins, lock-file
+// maintenance, and anything already reviewed (dedup marker) never reach the
+// paid Claude job.
+const MARKER = '<!-- cc-dep-review -->';
+const RANK = { major: 3, minor: 2, patch: 1 };
+
+// Renovate PR bodies carry a table whose Update column holds the bump type.
+// Only table rows are scanned so prose/release notes can't false-match.
+function parseUpdateTypes(body) {
+  const types = new Set();
+  for (const line of (body || '').split('\n')) {
+    if (!/^\s*\|/.test(line)) continue;
+    const match = line.match(/\|\s*(major|minor|patch|digest|pin|pinDigest|lockFileMaintenance)\s*\|/i);
+    if (match) types.add(match[1].toLowerCase());
+  }
+  return [...types];
+}
+
+function highestSemverType(types) {
+  return types.filter((t) => RANK[t]).sort((a, b) => RANK[b] - RANK[a])[0] || null;
+}
+
+module.exports = async ({ github, context, core }) => {
+  const skip = (message) => {
+    core.setOutput('should_run', 'false');
+    core.info(message);
+  };
+
+  const pr = context.payload.pull_request;
+  if (!pr) return skip('No pull_request payload — skipping');
+
+  const authors = (process.env.BOT_AUTHORS || 'renovate[bot]').split(',').map((s) => s.trim());
+  const login = pr.user && pr.user.login;
+  if (!authors.includes(login)) return skip(`PR author "${login}" is not a dependency bot — skipping`);
+
+  const requireLabel = process.env.REQUIRE_LABEL || '';
+  if (requireLabel && !(pr.labels || []).some((l) => l.name === requireLabel)) {
+    return skip(`PR lacks required label "${requireLabel}" — skipping`);
+  }
+
+  const updateTypes = (process.env.UPDATE_TYPES || 'major,minor')
+    .split(',')
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean);
+  const found = parseUpdateTypes(pr.body);
+  const top = highestSemverType(found);
+  if (!top) return skip(`No semver update type in the Renovate table (found: ${found.join(', ') || 'none'}) — skipping`);
+  if (!updateTypes.includes(top)) return skip(`Update type "${top}" not in [${updateTypes.join(', ')}] — skipping`);
+
+  const { owner, repo } = context.repo;
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    owner,
+    repo,
+    issue_number: pr.number,
+    per_page: 100,
+  });
+  if (comments.some((c) => c.body && c.body.includes(MARKER))) {
+    return skip('cc-dep-review comment already present — skipping');
+  }
+
+  core.setOutput('should_run', 'true');
+  core.setOutput('pr_number', String(pr.number));
+  core.setOutput('update_type', top);
+  core.info(`PR #${pr.number} eligible — update_type=${top}`);
+};
+
+module.exports.parseUpdateTypes = parseUpdateTypes;
+module.exports.highestSemverType = highestSemverType;

--- a/.github/scripts/shared/sticky-comment.js
+++ b/.github/scripts/shared/sticky-comment.js
@@ -1,0 +1,60 @@
+// Upsert a single marker-keyed comment on a PR/issue from a file Claude wrote.
+//
+// MARKER_MATCH identifies an existing comment (a stable prefix like
+// "<!-- cc-dep-review"); MARKER_WRITE (default: MARKER_MATCH) is what gets
+// embedded in the new body, letting callers carry state in the marker (e.g. a
+// head SHA) while still matching on the stable prefix. No body file → Claude
+// declined → clean no-op, mirroring pr-from-file.js semantics.
+const fs = require('fs');
+
+module.exports = async ({ github, context, core }) => {
+  const bodyFile = process.env.BODY_FILE;
+  const markerMatch = process.env.MARKER_MATCH;
+  const markerWrite = process.env.MARKER_WRITE || markerMatch;
+  if (!bodyFile || !markerMatch) {
+    core.setFailed('BODY_FILE and MARKER_MATCH env vars are required');
+    return;
+  }
+  const issueNumber = Number(
+    process.env.PR_NUMBER || (context.payload.pull_request && context.payload.pull_request.number)
+  );
+  if (!issueNumber) {
+    core.setFailed('PR_NUMBER env var or pull_request payload is required');
+    return;
+  }
+  if (!fs.existsSync(bodyFile)) {
+    core.info(`Claude wrote no ${bodyFile} — nothing to post.`);
+    core.setOutput('posted', 'false');
+    return;
+  }
+  const content = fs.readFileSync(bodyFile, 'utf8').trim();
+  if (!content) {
+    core.info(`${bodyFile} is empty — nothing to post.`);
+    core.setOutput('posted', 'false');
+    return;
+  }
+
+  const provenance = process.env.RUN_URL
+    ? `\n\n> **AI Provenance** | Workflow: \`${process.env.WORKFLOW_NAME || ''}\` | ` +
+      `[Run](${process.env.RUN_URL}) | Event: \`${process.env.EVENT_NAME || ''}\` | ` +
+      `Actor: \`${process.env.TRIGGER_ACTOR || ''}\``
+    : '';
+  const body = `${markerWrite}\n${content}${provenance}`;
+
+  const { owner, repo } = context.repo;
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    owner,
+    repo,
+    issue_number: issueNumber,
+    per_page: 100,
+  });
+  const existing = comments.find((c) => c.body && c.body.includes(markerMatch));
+  if (existing) {
+    await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+    core.info(`Updated existing comment ${existing.id} on #${issueNumber}`);
+  } else {
+    await github.rest.issues.createComment({ owner, repo, issue_number: issueNumber, body });
+    core.info(`Created comment on #${issueNumber}`);
+  }
+  core.setOutput('posted', 'true');
+};

--- a/.github/workflows/cc-dep-review.yml
+++ b/.github/workflows/cc-dep-review.yml
@@ -1,0 +1,139 @@
+# CC Dep Review
+#
+# Reusable workflow: Claude posts ONE concise risk assessment comment on
+# Renovate dependency PRs (major/minor by default) — breaking changes,
+# required migrations, repo impact, and a merge/hold verdict. Comment-only:
+# Claude never commits, and the comment is posted deterministically by a
+# workflow step (sticky-comment.js), not by Claude.
+#
+# Cost bounds are structural: consumer callers trigger on
+# `pull_request: [opened]` only, the gate skips digest pins / lock-file
+# maintenance / patch bumps, and a dedup marker guarantees at most one Claude
+# run per PR. No check-daily-limit job (actions:read under cross-repo
+# workflow_call causes startup_failure — see issue-backlog-sweep history).
+
+name: CC Dep Review
+
+on:
+  workflow_call:
+    inputs:
+      runner_label:
+        description: >-
+          GitHub Actions runner label to run the job(s) on. Defaults to
+          ubuntu-latest.
+        type: string
+        required: false
+        default: ubuntu-latest
+      model:
+        description: "Claude model to use (overrides GH_ACTION_AI_MODEL_CODE and GH_ACTION_AI_MODEL vars)"
+        type: string
+        default: ""
+      update_types:
+        description: "Comma-separated Renovate update types to review"
+        type: string
+        default: "major,minor"
+      require_label:
+        description: "Only review PRs carrying this label (empty = no label gate)"
+        type: string
+        default: ""
+      bot_authors:
+        description: "Comma-separated bot logins whose PRs are reviewed"
+        type: string
+        default: "renovate[bot]"
+
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: write
+
+concurrency:
+  group: cc-dep-review-${{ github.repository }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: false  # Never cancel — queue instead to avoid wasting AI tokens
+
+jobs:
+  check-eligibility:
+    name: Check eligibility
+    runs-on: ${{ inputs.runner_label || 'ubuntu-latest' }}
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      should_run: ${{ steps.check.outputs.should_run }}
+      pr_number: ${{ steps.check.outputs.pr_number }}
+      update_type: ${{ steps.check.outputs.update_type }}
+    steps:
+      - name: Checkout ai-workflows scripts
+        uses: actions/checkout@v6
+        with:
+          repository: dryvist/ai-workflows
+          sparse-checkout: .github/scripts
+          path: .ai-workflows
+
+      - name: Check eligibility
+        id: check
+        uses: actions/github-script@v9
+        env:
+          UPDATE_TYPES: ${{ inputs.update_types }}
+          REQUIRE_LABEL: ${{ inputs.require_label }}
+          BOT_AUTHORS: ${{ inputs.bot_authors }}
+        with:
+          script: |
+            const run = require('./.ai-workflows/.github/scripts/dep-review/check-eligibility.js');
+            await run({ github, context, core });
+
+  review:
+    name: Review dependency update
+    needs: check-eligibility
+    if: needs.check-eligibility.outputs.should_run == 'true'
+    runs-on: ${{ inputs.runner_label || 'ubuntu-latest' }}
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+    timeout-minutes: 15
+    env:
+      ANTHROPIC_BASE_URL: ${{ vars.GH_ACTION_AI_BASE_URL }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Checkout ai-workflows
+        uses: actions/checkout@v6
+        with:
+          repository: dryvist/ai-workflows
+          sparse-checkout: |
+            .github/prompts
+            .github/scripts
+          path: .ai-workflows
+
+      - name: Render prompt
+        id: prompt
+        env:
+          PR_NUMBER: ${{ needs.check-eligibility.outputs.pr_number }}
+          UPDATE_TYPE: ${{ needs.check-eligibility.outputs.update_type }}
+        run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/dep-review.md PR_NUMBER UPDATE_TYPE
+
+      - name: Run Claude Code
+        uses: dryvist/ai-workflows/.github/actions/run-claude-code@main
+        with:
+          prompt: ${{ steps.prompt.outputs.content }}
+          model: ${{ inputs.model || vars.GH_ACTION_AI_MODEL_CODE || vars.GH_ACTION_AI_MODEL }}
+          allowed_tools: "Read,Glob,Grep,LS,Write,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh api repos/*),WebFetch(domain:github.com)"
+          claude_code_oauth_token: ${{ secrets.GH_ACTION_AI_API_KEY }}
+          allowed_bots: "github-actions,renovate"
+          use_commit_signing: "false"
+
+      - name: Post review comment
+        uses: actions/github-script@v9
+        env:
+          BODY_FILE: .claude-dep-review.md
+          MARKER_MATCH: "<!-- cc-dep-review -->"
+          PR_NUMBER: ${{ needs.check-eligibility.outputs.pr_number }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          EVENT_NAME: ${{ github.event_name }}
+          TRIGGER_ACTOR: ${{ github.triggering_actor }}
+        with:
+          script: |
+            const run = require('./.ai-workflows/.github/scripts/shared/sticky-comment.js');
+            await run({ github, context, core });

--- a/.github/workflows/dogfood-dep-review.yml
+++ b/.github/workflows/dogfood-dep-review.yml
@@ -1,0 +1,20 @@
+# Dogfood: AI risk assessment on this repo's own Renovate PRs.
+#
+# No concurrency block on purpose: a caller sharing the reusable workflow's
+# exact concurrency group causes an opaque 0-job startup_failure.
+
+name: Dogfood Dep Review
+
+on:
+  pull_request:
+    types: [opened]
+
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: write
+
+jobs:
+  review:
+    uses: ./.github/workflows/cc-dep-review.yml
+    secrets: inherit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ repos invoke via `uses: dryvist/ai-workflows/.github/workflows/<name>.yml@main`.
     best-practices/                 # Extracted JS scripts per workflow
     ci-fail-issue/
     ci-fix/
+    dep-review/
     issue-backlog-sweep/
     issue-linker/
     issue-resolver/

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Reusable AI agent workflows for GitHub Actions. Each workflow is a
 |----------|---------|----------|--------------|
 | `best-practices.yml` | `workflow_call` | Wed 3am UTC | Weekly audit creating actionable best-practices recommendations |
 | `cc-ci-fix.yml` | `workflow_run` | On CI failure | Analyzes failed CI logs and pushes fixes (max 2 attempts per PR) |
+| `cc-dep-review.yml` | `pull_request: [opened]` | On Renovate PR | Posts one AI risk-assessment comment on major/minor dependency PRs (breaking changes, migrations, verdict) |
 | `cc-code-simplifier.yml` | `workflow_call` | Daily 4am UTC | Simplifies recently changed code for clarity and maintainability (functionality preserved); opens a PR |
 | `issue-hygiene.yml` | `workflow_call` | Mon 7am UTC | Detects duplicates, links merged PRs, flags stale issues |
 | `cc-issue-resolver.yml` | `issues: [opened]` | On issue open | Creates draft PRs for simple, well-scoped issues |

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -191,7 +191,7 @@ The prompt file uses `${MERGE_SHA}` and `${REPO_FULL_NAME}` as placeholders.
 Used by workflows with a pre-check job that decides whether to run the expensive Claude step.
 
 **Workflows**: best-practices (check-recent-activity), post-merge-docs-review (check-relevance), post-merge-tests (check-test-infra),
-ci-fix (should-fix), issue-resolver (eligibility check)
+ci-fix (should-fix), issue-resolver (eligibility check), cc-dep-review (eligibility check)
 
 **Structure**: Two jobs — a lightweight gating job followed by the Claude job that only runs if the gate passes:
 
@@ -578,6 +578,37 @@ env:
 
 **Why prompt-based** (not a post-step): `claude-code-action@v1` doesn't expose a PR number output, making post-creation API appends fragile.
 The prompt approach fits the existing `render-prompt.sh` + `envsubst` pattern with no additional steps.
+
+Comment-posting workflows (cc-dep-review) get the same footer from
+`sticky-comment.js` instead, which already knows the PR number — see the
+Sticky Comment Pattern below.
+
+---
+
+## Sticky Comment Pattern
+
+Comment-only AI workflows (cc-dep-review) post exactly ONE marker-keyed
+comment per PR and update it in place on re-runs instead of stacking
+duplicates.
+
+**How it works**: Claude only WRITES its output to a file (no `gh pr comment`
+tool access — deterministic posting beats prompting). A final
+`actions/github-script` step runs `.github/scripts/shared/sticky-comment.js`:
+
+- `BODY_FILE`: the file Claude wrote; missing/empty file → Claude declined →
+  clean no-op (mirrors `pr-from-file.js`).
+- `MARKER_MATCH`: stable HTML-comment prefix identifying the workflow's
+  comment (e.g. `<!-- cc-dep-review -->`); also doubles as the gate's dedup
+  marker.
+- `MARKER_WRITE` (optional): full marker embedded in the new body, letting a
+  workflow carry state in the marker (e.g. a head SHA) while still matching
+  the stable prefix.
+- Provenance: when `RUN_URL` is set, the AI Provenance footer is appended
+  automatically.
+
+**Why comments, not body edits**: bot-owned PR bodies (Renovate,
+release-please) are overwritten by their owners on every refresh; a comment
+survives and keeps authorship clean.
 
 ---
 

--- a/examples/dep-review-caller.yml
+++ b/examples/dep-review-caller.yml
@@ -1,0 +1,24 @@
+# Example consumer caller for cc-dep-review.
+#
+# Claude posts one risk-assessment comment on Renovate major/minor PRs.
+# `opened` only: Renovate force-pushes rebases constantly and the assessment
+# does not change; the dedup marker makes any re-run a cheap no-op anyway.
+#
+# No concurrency block on purpose: a caller sharing the reusable workflow's
+# exact concurrency group causes an opaque 0-job startup_failure.
+
+name: Dep Review
+
+on:
+  pull_request:
+    types: [opened]
+
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: write
+
+jobs:
+  review:
+    uses: dryvist/ai-workflows/.github/workflows/cc-dep-review.yml@main
+    secrets: inherit

--- a/tests/dep-review-check-eligibility.test.js
+++ b/tests/dep-review-check-eligibility.test.js
@@ -1,0 +1,114 @@
+const { describe, it, expect, beforeEach, afterEach } = require('bun:test');
+const { createMockCore, createMockContext, createMockGithub } = require('./helpers.js');
+const run = require('../.github/scripts/dep-review/check-eligibility.js');
+const { parseUpdateTypes, highestSemverType } = run;
+
+const ENV_KEYS = ['UPDATE_TYPES', 'REQUIRE_LABEL', 'BOT_AUTHORS'];
+
+function renovateBody(updateType) {
+  return [
+    'This PR contains the following updates:',
+    '',
+    '| Package | Type | Update | Change |',
+    '|---|---|---|---|',
+    `| [some-dep](https://example.test) | action | ${updateType} | \`v1.0.0\` → \`v2.0.0\` |`,
+    '',
+    '### Release Notes',
+    'The word major appears in prose but only table rows count.',
+  ].join('\n');
+}
+
+function makePayload({ login = 'renovate[bot]', body = renovateBody('major'), labels = [], number = 9 } = {}) {
+  return { pull_request: { number, body, labels, user: { login, type: 'Bot' } } };
+}
+
+describe('dep-review/parseUpdateTypes', () => {
+  it('reads types from table rows only', () => {
+    expect(parseUpdateTypes(renovateBody('minor'))).toEqual(['minor']);
+  });
+
+  it('collects multiple types from grouped PRs and ranks major highest', () => {
+    const grouped = renovateBody('patch') + '\n| [other-dep](x) | action | major | `v1` → `v2` |';
+    const types = parseUpdateTypes(grouped);
+    expect(types).toContain('patch');
+    expect(types).toContain('major');
+    expect(highestSemverType(types)).toBe('major');
+  });
+
+  it('returns no semver type for digest/lockfile rows', () => {
+    expect(highestSemverType(parseUpdateTypes(renovateBody('digest')))).toBe(null);
+    expect(highestSemverType(parseUpdateTypes(renovateBody('lockFileMaintenance')))).toBe(null);
+  });
+});
+
+describe('dep-review/check-eligibility', () => {
+  let core, context, github;
+
+  beforeEach(() => {
+    core = createMockCore();
+    context = createMockContext({ payload: makePayload() });
+    github = createMockGithub();
+    github.paginate.mockResolvedValue([]);
+    for (const key of ENV_KEYS) delete process.env[key];
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) delete process.env[key];
+  });
+
+  it('happy path: renovate major bump passes all gates', async () => {
+    await run({ github, context, core });
+    expect(core.getOutput('should_run')).toBe('true');
+    expect(core.getOutput('pr_number')).toBe('9');
+    expect(core.getOutput('update_type')).toBe('major');
+  });
+
+  it('skip: human-authored PR', async () => {
+    context.payload = makePayload({ login: 'some-user' });
+    await run({ github, context, core });
+    expect(core.getOutput('should_run')).toBe('false');
+  });
+
+  it('skip: patch bump under default update_types', async () => {
+    context.payload = makePayload({ body: renovateBody('patch') });
+    await run({ github, context, core });
+    expect(core.getOutput('should_run')).toBe('false');
+  });
+
+  it('skip: digest-only PR has no semver type', async () => {
+    context.payload = makePayload({ body: renovateBody('digest') });
+    await run({ github, context, core });
+    expect(core.getOutput('should_run')).toBe('false');
+  });
+
+  it('honors a custom update_types list', async () => {
+    process.env.UPDATE_TYPES = 'major,minor,patch';
+    context.payload = makePayload({ body: renovateBody('patch') });
+    await run({ github, context, core });
+    expect(core.getOutput('should_run')).toBe('true');
+    expect(core.getOutput('update_type')).toBe('patch');
+  });
+
+  it('skip: required label missing; run when present', async () => {
+    process.env.REQUIRE_LABEL = 'dependencies';
+    await run({ github, context, core });
+    expect(core.getOutput('should_run')).toBe('false');
+
+    core = createMockCore();
+    context.payload = makePayload({ labels: [{ name: 'dependencies' }] });
+    await run({ github, context, core });
+    expect(core.getOutput('should_run')).toBe('true');
+  });
+
+  it('skip: dedup marker already present', async () => {
+    github.paginate.mockResolvedValue([{ body: 'earlier run\n<!-- cc-dep-review -->' }]);
+    await run({ github, context, core });
+    expect(core.getOutput('should_run')).toBe('false');
+  });
+
+  it('skip: no pull_request payload', async () => {
+    context.payload = {};
+    await run({ github, context, core });
+    expect(core.getOutput('should_run')).toBe('false');
+  });
+});

--- a/tests/shared-sticky-comment.test.js
+++ b/tests/shared-sticky-comment.test.js
@@ -1,0 +1,100 @@
+const { describe, it, expect, beforeEach, afterEach, mock } = require('bun:test');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { createMockCore, createMockContext, createMockGithub } = require('./helpers.js');
+const run = require('../.github/scripts/shared/sticky-comment.js');
+
+const ENV_KEYS = ['BODY_FILE', 'MARKER_MATCH', 'MARKER_WRITE', 'PR_NUMBER', 'WORKFLOW_NAME', 'RUN_URL', 'EVENT_NAME', 'TRIGGER_ACTOR'];
+
+describe('shared/sticky-comment', () => {
+  let core, context, github, tmpDir;
+
+  beforeEach(() => {
+    core = createMockCore();
+    context = createMockContext({ payload: { pull_request: { number: 5 } } });
+    github = createMockGithub();
+    github.rest.issues.updateComment = mock();
+    github.paginate.mockResolvedValue([]);
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sticky-'));
+    for (const key of ENV_KEYS) delete process.env[key];
+    process.env.MARKER_MATCH = '<!-- cc-dep-review -->';
+    process.env.BODY_FILE = path.join(tmpDir, 'body.md');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    for (const key of ENV_KEYS) delete process.env[key];
+  });
+
+  it('creates a comment when none matches the marker', async () => {
+    fs.writeFileSync(process.env.BODY_FILE, '## Dependency Review (AI)\nAll clear.');
+    await run({ github, context, core });
+
+    expect(core.getOutput('posted')).toBe('true');
+    expect(github.rest.issues.createComment).toHaveBeenCalledTimes(1);
+    const call = github.rest.issues.createComment.mock.calls[0][0];
+    expect(call.issue_number).toBe(5);
+    expect(call.body.startsWith('<!-- cc-dep-review -->')).toBe(true);
+  });
+
+  it('updates the existing marker comment instead of duplicating', async () => {
+    fs.writeFileSync(process.env.BODY_FILE, 'updated content');
+    github.paginate.mockResolvedValue([
+      { id: 11, body: 'unrelated' },
+      { id: 22, body: '<!-- cc-dep-review -->\nold content' },
+    ]);
+
+    await run({ github, context, core });
+
+    expect(github.rest.issues.updateComment).toHaveBeenCalledTimes(1);
+    expect(github.rest.issues.updateComment.mock.calls[0][0].comment_id).toBe(22);
+    expect(github.rest.issues.createComment).not.toHaveBeenCalled();
+  });
+
+  it('matches on MARKER_MATCH prefix but writes MARKER_WRITE', async () => {
+    process.env.MARKER_MATCH = '<!-- cc-release-notes';
+    process.env.MARKER_WRITE = '<!-- cc-release-notes sha:abc123 -->';
+    fs.writeFileSync(process.env.BODY_FILE, 'highlights');
+    github.paginate.mockResolvedValue([{ id: 7, body: '<!-- cc-release-notes sha:old456 -->\nstale' }]);
+
+    await run({ github, context, core });
+
+    const body = github.rest.issues.updateComment.mock.calls[0][0].body;
+    expect(body.startsWith('<!-- cc-release-notes sha:abc123 -->')).toBe(true);
+  });
+
+  it('is a clean no-op when the body file does not exist', async () => {
+    await run({ github, context, core });
+    expect(core.getOutput('posted')).toBe('false');
+    expect(github.rest.issues.createComment).not.toHaveBeenCalled();
+  });
+
+  it('appends the AI provenance footer when RUN_URL is set', async () => {
+    fs.writeFileSync(process.env.BODY_FILE, 'content');
+    process.env.RUN_URL = 'https://example.test/run/1';
+    process.env.WORKFLOW_NAME = 'CC Dep Review';
+
+    await run({ github, context, core });
+
+    const body = github.rest.issues.createComment.mock.calls[0][0].body;
+    expect(body).toContain('AI Provenance');
+    expect(body).toContain('https://example.test/run/1');
+  });
+
+  it('fails when required env vars are missing', async () => {
+    delete process.env.MARKER_MATCH;
+    await run({ github, context, core });
+    expect(core.failures.length).toBe(1);
+  });
+
+  it('takes PR number from env when payload lacks it', async () => {
+    context.payload = {};
+    process.env.PR_NUMBER = '31';
+    fs.writeFileSync(process.env.BODY_FILE, 'content');
+
+    await run({ github, context, core });
+
+    expect(github.rest.issues.createComment.mock.calls[0][0].issue_number).toBe(31);
+  });
+});


### PR DESCRIPTION
## Summary

- New reusable workflow `cc-dep-review.yml`: Claude posts **one** concise risk-assessment comment on Renovate dependency PRs — breaking changes, required migrations in the consuming repo, repo impact, and a Merge / Merge-with-care / Hold verdict with confidence.
- Gate (`dep-review/check-eligibility.js`): author must be `renovate[bot]` (input-extensible), update type parsed from the Renovate table (major/minor by default; digest pins & lock-file maintenance never reach Claude), optional `require_label`, dedup via `<!-- cc-dep-review -->` marker → at most one Claude run per PR.
- New shared helper `sticky-comment.js`: upserts a single marker-keyed comment from a Claude-written file (missing file = clean no-op), appends the AI Provenance footer, supports a `MARKER_MATCH`/`MARKER_WRITE` split so future workflows (cc-release-notes) can carry state in the marker.
- Deliberately comment-only (bot-owned PR bodies get overwritten by Renovate) and no `check-daily-limit` job (`actions: read` under cross-repo `workflow_call` causes startup_failure).
- Dogfood caller on this repo's own Renovate PRs; example consumer caller; PATTERNS.md gains the Sticky Comment Pattern.

## Test plan

- `bun test`: full suite green (18 new tests: table parsing incl. grouped PRs and prose false-match guard, author/label/dedup gates, sticky create-vs-update, marker prefix matching, provenance footer, env-driven PR number).
- After merge: wait for the next real Renovate major/minor PR (or retitle-dispatch one) and verify exactly one comment appears and updates in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JEgmkietfTQuv2tTfM4hD