### PR TITLE
feat: add cc-release-notes reusable workflow

### DIFF
--- a/.github/prompts/release-notes.md
+++ b/.github/prompts/release-notes.md
@@ -1,0 +1,31 @@
+Write human-readable release highlights for release-please PR #${PR_NUMBER}
+in this repository.
+
+Steps:
+
+1. Read the pending changelog: `gh pr view ${PR_NUMBER} --json title,body` and
+   `gh pr diff ${PR_NUMBER}` (the CHANGELOG.md delta lists every change).
+2. For anything unclear from the changelog entry alone, inspect the underlying
+   changes: `git log <last-tag>..HEAD --oneline` and `git diff <last-tag>..HEAD
+   -- <path>` (find the last tag with `git tag --sort=-creatordate`).
+3. Write the highlights to a file named `.claude-release-notes.md` (Write
+   tool) with exactly this structure:
+
+   ```markdown
+   ## Release Highlights (AI)
+
+   - 3-6 bullets, each describing USER-VISIBLE impact (what someone consuming
+     this repo gains, loses, or must do), not a restated commit list
+   - Lead with the most impactful change; call out anything breaking or
+     requiring migration with **Breaking:** or **Action needed:**
+   ```
+
+Rules:
+
+- Do NOT edit CHANGELOG.md, the PR body, or any repository file other than
+  `.claude-release-notes.md`. Do NOT post comments yourself — a workflow step
+  posts the file for you.
+- Skip pure-noise entries (version bumps of internal dev deps, CI plumbing)
+  unless they change consumer behavior.
+- If the release is trivial (e.g. one dependency bump), one or two honest
+  bullets beat six padded ones.

--- a/.github/scripts/release-notes/check-eligibility.js
+++ b/.github/scripts/release-notes/check-eligibility.js
@@ -1,0 +1,46 @@
+// Gate for cc-release-notes: run Claude once per release-please PR head SHA.
+// release-please refreshes its PR body on every push to main (a `synchronize`
+// storm), but the highlights only change when the head actually moves — the
+// SHA embedded in our sticky comment's marker makes every same-SHA re-run a
+// free skip.
+const MARKER_PREFIX = '<!-- cc-release-notes';
+
+module.exports = async ({ github, context, core }) => {
+  const skip = (message) => {
+    core.setOutput('should_run', 'false');
+    core.info(message);
+  };
+
+  const pr = context.payload.pull_request;
+  if (!pr) return skip('No pull_request payload — skipping');
+
+  const releaseBot = process.env.RELEASE_BOT || 'jacobpevans-release-please[bot]';
+  const login = pr.user && pr.user.login;
+  if (login !== releaseBot) return skip(`PR author "${login}" is not ${releaseBot} — skipping`);
+
+  const branchPrefix = process.env.BRANCH_PREFIX || 'release-please--';
+  const headRef = (pr.head && pr.head.ref) || '';
+  if (!headRef.startsWith(branchPrefix)) {
+    return skip(`Head branch "${headRef}" lacks prefix "${branchPrefix}" — skipping`);
+  }
+
+  const headSha = pr.head && pr.head.sha;
+  const { owner, repo } = context.repo;
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    owner,
+    repo,
+    issue_number: pr.number,
+    per_page: 100,
+  });
+  const existing = comments.find((c) => c.body && c.body.includes(MARKER_PREFIX));
+  if (existing && headSha && existing.body.includes(`sha:${headSha}`)) {
+    return skip(`Highlights already posted for head ${headSha} — skipping`);
+  }
+
+  core.setOutput('should_run', 'true');
+  core.setOutput('pr_number', String(pr.number));
+  core.setOutput('head_sha', headSha || '');
+  // The claude-code-action allowed_bots list wants the bare login, no [bot].
+  core.setOutput('release_bot_bare', releaseBot.replace(/\[bot\]$/, ''));
+  core.info(`Release PR #${pr.number} eligible — head=${headSha}`);
+};

--- a/.github/workflows/cc-release-notes.yml
+++ b/.github/workflows/cc-release-notes.yml
@@ -1,0 +1,136 @@
+# CC Release Notes
+#
+# Reusable workflow: Claude reads a release-please PR's changelog delta and
+# posts 3-6 human-readable, user-impact highlight bullets as ONE sticky
+# comment. It never edits the PR body or branch — release-please force-pushes
+# its branch and round-trips its body into the GitHub Release, so a comment is
+# the only shape that survives; a human copies highlights into the body if
+# wanted (release-please preserves edits between its markers).
+#
+# Cost bound: the gate embeds the head SHA in the comment marker, so the
+# `synchronize` storm from release-please's body refreshes only pays for
+# Claude when the head actually moved.
+
+name: CC Release Notes
+
+on:
+  workflow_call:
+    inputs:
+      runner_label:
+        description: >-
+          GitHub Actions runner label to run the job(s) on. Defaults to
+          ubuntu-latest.
+        type: string
+        required: false
+        default: ubuntu-latest
+      model:
+        description: "Claude model to use (overrides GH_ACTION_AI_MODEL vars)"
+        type: string
+        default: ""
+      release_bot:
+        description: "Login of the release-please App bot authoring release PRs"
+        type: string
+        default: "jacobpevans-release-please[bot]"
+      branch_prefix:
+        description: "Head-branch prefix identifying release PRs"
+        type: string
+        default: "release-please--"
+
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: write
+
+concurrency:
+  group: cc-release-notes-${{ github.repository }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: false  # Never cancel — queue instead to avoid wasting AI tokens
+
+jobs:
+  check-eligibility:
+    name: Check eligibility
+    runs-on: ${{ inputs.runner_label || 'ubuntu-latest' }}
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      should_run: ${{ steps.check.outputs.should_run }}
+      pr_number: ${{ steps.check.outputs.pr_number }}
+      head_sha: ${{ steps.check.outputs.head_sha }}
+      release_bot_bare: ${{ steps.check.outputs.release_bot_bare }}
+    steps:
+      - name: Checkout ai-workflows scripts
+        uses: actions/checkout@v6
+        with:
+          repository: dryvist/ai-workflows
+          sparse-checkout: .github/scripts
+          path: .ai-workflows
+
+      - name: Check eligibility
+        id: check
+        uses: actions/github-script@v9
+        env:
+          RELEASE_BOT: ${{ inputs.release_bot }}
+          BRANCH_PREFIX: ${{ inputs.branch_prefix }}
+        with:
+          script: |
+            const run = require('./.ai-workflows/.github/scripts/release-notes/check-eligibility.js');
+            await run({ github, context, core });
+
+  highlights:
+    name: Write release highlights
+    needs: check-eligibility
+    if: needs.check-eligibility.outputs.should_run == 'true'
+    runs-on: ${{ inputs.runner_label || 'ubuntu-latest' }}
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+    timeout-minutes: 15
+    env:
+      ANTHROPIC_BASE_URL: ${{ vars.GH_ACTION_AI_BASE_URL }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0  # Claude diffs the last tag against HEAD
+
+      - name: Checkout ai-workflows
+        uses: actions/checkout@v6
+        with:
+          repository: dryvist/ai-workflows
+          sparse-checkout: |
+            .github/prompts
+            .github/scripts
+          path: .ai-workflows
+
+      - name: Render prompt
+        id: prompt
+        env:
+          PR_NUMBER: ${{ needs.check-eligibility.outputs.pr_number }}
+        run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/release-notes.md PR_NUMBER
+
+      - name: Run Claude Code
+        uses: dryvist/ai-workflows/.github/actions/run-claude-code@main
+        with:
+          prompt: ${{ steps.prompt.outputs.content }}
+          model: ${{ inputs.model || vars.GH_ACTION_AI_MODEL }}
+          allowed_tools: "Read,Glob,Grep,LS,Write,Bash(git log:*),Bash(git diff:*),Bash(git tag:*),Bash(gh pr view:*),Bash(gh pr diff:*)"
+          claude_code_oauth_token: ${{ secrets.GH_ACTION_AI_API_KEY }}
+          allowed_bots: "github-actions,${{ needs.check-eligibility.outputs.release_bot_bare }}"
+          use_commit_signing: "false"
+
+      - name: Post highlights comment
+        uses: actions/github-script@v9
+        env:
+          BODY_FILE: .claude-release-notes.md
+          MARKER_MATCH: "<!-- cc-release-notes"
+          MARKER_WRITE: "<!-- cc-release-notes sha:${{ needs.check-eligibility.outputs.head_sha }} -->"
+          PR_NUMBER: ${{ needs.check-eligibility.outputs.pr_number }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          EVENT_NAME: ${{ github.event_name }}
+          TRIGGER_ACTOR: ${{ github.triggering_actor }}
+        with:
+          script: |
+            const run = require('./.ai-workflows/.github/scripts/shared/sticky-comment.js');
+            await run({ github, context, core });

--- a/.github/workflows/dogfood-release-notes.yml
+++ b/.github/workflows/dogfood-release-notes.yml
@@ -1,0 +1,20 @@
+# Dogfood: AI release highlights on this repo's own release-please PRs.
+#
+# No concurrency block on purpose: a caller sharing the reusable workflow's
+# exact concurrency group causes an opaque 0-job startup_failure.
+
+name: Dogfood Release Notes
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: write
+
+jobs:
+  highlights:
+    uses: ./.github/workflows/cc-release-notes.yml
+    secrets: inherit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ repos invoke via `uses: dryvist/ai-workflows/.github/workflows/<name>.yml@main`.
     notification/
     post-merge-docs-review/
     post-merge-tests/
+    release-notes/
     review-thread-resolver/
     shared/
     verification/

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Reusable AI agent workflows for GitHub Actions. Each workflow is a
 | `cc-ci-fix.yml` | `workflow_run` | On CI failure | Analyzes failed CI logs and pushes fixes (max 2 attempts per PR) |
 | `cc-dep-review.yml` | `pull_request: [opened]` | On Renovate PR | Posts one AI risk-assessment comment on major/minor dependency PRs (breaking changes, migrations, verdict) |
 | `cc-code-simplifier.yml` | `workflow_call` | Daily 4am UTC | Simplifies recently changed code for clarity and maintainability (functionality preserved); opens a PR |
+| `cc-release-notes.yml` | `pull_request` | On release PR | Posts sticky AI release-highlights comment on release-please PRs (refreshed per head SHA) |
 | `issue-hygiene.yml` | `workflow_call` | Mon 7am UTC | Detects duplicates, links merged PRs, flags stale issues |
 | `cc-issue-resolver.yml` | `issues: [opened]` | On issue open | Creates draft PRs for simple, well-scoped issues |
 | `issue-backlog-sweep.yml` | `workflow_call` | Weekly (consumer) | Labels the oldest untriaged issues so `ai:ready` ones enter the resolver — shrinks a pre-existing backlog |

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -191,7 +191,7 @@ The prompt file uses `${MERGE_SHA}` and `${REPO_FULL_NAME}` as placeholders.
 Used by workflows with a pre-check job that decides whether to run the expensive Claude step.
 
 **Workflows**: best-practices (check-recent-activity), post-merge-docs-review (check-relevance), post-merge-tests (check-test-infra),
-ci-fix (should-fix), issue-resolver (eligibility check), cc-dep-review (eligibility check)
+ci-fix (should-fix), issue-resolver (eligibility check), cc-dep-review (eligibility check), cc-release-notes (head-SHA dedup)
 
 **Structure**: Two jobs — a lightweight gating job followed by the Claude job that only runs if the gate passes:
 
@@ -587,7 +587,7 @@ Sticky Comment Pattern below.
 
 ## Sticky Comment Pattern
 
-Comment-only AI workflows (cc-dep-review) post exactly ONE marker-keyed
+Comment-only AI workflows (cc-dep-review, cc-release-notes) post exactly ONE marker-keyed
 comment per PR and update it in place on re-runs instead of stacking
 duplicates.
 

--- a/examples/release-notes-caller.yml
+++ b/examples/release-notes-caller.yml
@@ -1,0 +1,24 @@
+# Example consumer caller for cc-release-notes.
+#
+# Claude posts one sticky "Release Highlights (AI)" comment on release-please
+# PRs, refreshed only when the head SHA changes. Non-release PRs are skipped
+# by the gate at negligible cost.
+#
+# No concurrency block on purpose: a caller sharing the reusable workflow's
+# exact concurrency group causes an opaque 0-job startup_failure.
+
+name: Release Notes
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: write
+
+jobs:
+  highlights:
+    uses: dryvist/ai-workflows/.github/workflows/cc-release-notes.yml@main
+    secrets: inherit

--- a/tests/release-notes-check-eligibility.test.js
+++ b/tests/release-notes-check-eligibility.test.js
@@ -1,0 +1,73 @@
+const { describe, it, expect, beforeEach, afterEach } = require('bun:test');
+const { createMockCore, createMockContext, createMockGithub } = require('./helpers.js');
+const run = require('../.github/scripts/release-notes/check-eligibility.js');
+
+const ENV_KEYS = ['RELEASE_BOT', 'BRANCH_PREFIX'];
+const BOT = 'jacobpevans-release-please[bot]';
+
+function makePayload({ login = BOT, ref = 'release-please--branches--main', sha = 'abc123', number = 12 } = {}) {
+  return { pull_request: { number, user: { login, type: 'Bot' }, head: { ref, sha } } };
+}
+
+describe('release-notes/check-eligibility', () => {
+  let core, context, github;
+
+  beforeEach(() => {
+    core = createMockCore();
+    context = createMockContext({ payload: makePayload() });
+    github = createMockGithub();
+    github.paginate.mockResolvedValue([]);
+    for (const key of ENV_KEYS) delete process.env[key];
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) delete process.env[key];
+  });
+
+  it('happy path: release-please PR with no prior comment runs', async () => {
+    await run({ github, context, core });
+    expect(core.getOutput('should_run')).toBe('true');
+    expect(core.getOutput('pr_number')).toBe('12');
+    expect(core.getOutput('head_sha')).toBe('abc123');
+    expect(core.getOutput('release_bot_bare')).toBe('jacobpevans-release-please');
+  });
+
+  it('skip: wrong author', async () => {
+    context.payload = makePayload({ login: 'renovate[bot]' });
+    await run({ github, context, core });
+    expect(core.getOutput('should_run')).toBe('false');
+  });
+
+  it('skip: wrong branch prefix', async () => {
+    context.payload = makePayload({ ref: 'feat/something' });
+    await run({ github, context, core });
+    expect(core.getOutput('should_run')).toBe('false');
+  });
+
+  it('skip: highlights already posted for this head SHA', async () => {
+    github.paginate.mockResolvedValue([{ body: '<!-- cc-release-notes sha:abc123 -->\nhighlights' }]);
+    await run({ github, context, core });
+    expect(core.getOutput('should_run')).toBe('false');
+  });
+
+  it('runs again when the head SHA moved past the posted comment', async () => {
+    github.paginate.mockResolvedValue([{ body: '<!-- cc-release-notes sha:old999 -->\nstale highlights' }]);
+    await run({ github, context, core });
+    expect(core.getOutput('should_run')).toBe('true');
+  });
+
+  it('honors custom RELEASE_BOT and BRANCH_PREFIX', async () => {
+    process.env.RELEASE_BOT = 'custom-releaser[bot]';
+    process.env.BRANCH_PREFIX = 'rel/';
+    context.payload = makePayload({ login: 'custom-releaser[bot]', ref: 'rel/main' });
+    await run({ github, context, core });
+    expect(core.getOutput('should_run')).toBe('true');
+    expect(core.getOutput('release_bot_bare')).toBe('custom-releaser');
+  });
+
+  it('skip: no pull_request payload', async () => {
+    context.payload = {};
+    await run({ github, context, core });
+    expect(core.getOutput('should_run')).toBe('false');
+  });
+});


### PR DESCRIPTION
## Summary

- New reusable workflow `cc-release-notes.yml`: Claude reads the release-please PR's changelog delta (+ `git log/diff` since the last tag when entries are unclear) and posts **one** sticky "Release Highlights (AI)" comment — 3-6 user-impact bullets, breaking changes flagged.
- Deliberately never edits the PR body or CHANGELOG: release-please force-pushes its branch and round-trips its body into the GitHub Release; a human can copy highlights into the body (release-please preserves edits between its markers).
- Gate (`release-notes/check-eligibility.js`): author must be the release-please App bot (default `jacobpevans-release-please[bot]`, confirmed from live release PRs; input-overridable), head branch must match `release-please--`, and the head SHA embedded in the sticky marker makes every same-SHA `synchronize` re-run a free skip — release-please's body-refresh storm never pays for Claude twice.
- Reuses `sticky-comment.js` from #307 (the `MARKER_MATCH`/`MARKER_WRITE` split exists for exactly this SHA-in-marker case).
- Dogfood caller on this repo's own release PRs; example consumer caller; PATTERNS.md lists updated.

## Test plan

- `bun test`: 182 pass (7 new gate tests: author/branch/SHA-dedup/SHA-moved/custom-bot/no-payload).
- After merge: the next release-please PR here gets a highlights comment; a subsequent release commit refreshes it in place (same comment id).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JEgmkietfTQuv2tTfM4hD