### PR TITLE
fix: declare GH_ACTION_AI_API_KEY on comment workflows for explicit secret passing

### DIFF
--- a/.github/workflows/cc-dep-review.yml
+++ b/.github/workflows/cc-dep-review.yml
@@ -40,6 +40,10 @@ on:
         description: "Comma-separated bot logins whose PRs are reviewed"
         type: string
         default: "renovate[bot]"
+    secrets:
+      GH_ACTION_AI_API_KEY:
+        description: "AI provider API key (org secret); declared so callers can pass it explicitly instead of secrets: inherit"
+        required: true
 
 permissions:
   contents: read

--- a/.github/workflows/cc-release-notes.yml
+++ b/.github/workflows/cc-release-notes.yml
@@ -35,6 +35,10 @@ on:
         description: "Head-branch prefix identifying release PRs"
         type: string
         default: "release-please--"
+    secrets:
+      GH_ACTION_AI_API_KEY:
+        description: "AI provider API key (org secret); declared so callers can pass it explicitly instead of secrets: inherit"
+        required: true
 
 permissions:
   contents: read

--- a/.github/workflows/dogfood-dep-review.yml
+++ b/.github/workflows/dogfood-dep-review.yml
@@ -1,7 +1,9 @@
 # Dogfood: AI risk assessment on this repo's own Renovate PRs.
 #
-# No concurrency block on purpose: a caller sharing the reusable workflow's
-# exact concurrency group causes an opaque 0-job startup_failure.
+# Permissions are job-scoped and the secret is passed explicitly, matching
+# the consumer caller examples. No concurrency block on purpose: a caller
+# sharing the reusable workflow's exact concurrency group causes an opaque
+# 0-job startup_failure.
 
 name: Dogfood Dep Review
 
@@ -9,12 +11,12 @@ on:
   pull_request:
     types: [opened]
 
-permissions:
-  contents: read
-  id-token: write
-  pull-requests: write
-
 jobs:
   review:
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
     uses: ./.github/workflows/cc-dep-review.yml
-    secrets: inherit
+    secrets:
+      GH_ACTION_AI_API_KEY: ${{ secrets.GH_ACTION_AI_API_KEY }}

--- a/.github/workflows/dogfood-release-notes.yml
+++ b/.github/workflows/dogfood-release-notes.yml
@@ -1,7 +1,9 @@
 # Dogfood: AI release highlights on this repo's own release-please PRs.
 #
-# No concurrency block on purpose: a caller sharing the reusable workflow's
-# exact concurrency group causes an opaque 0-job startup_failure.
+# Permissions are job-scoped and the secret is passed explicitly, matching
+# the consumer caller examples. No concurrency block on purpose: a caller
+# sharing the reusable workflow's exact concurrency group causes an opaque
+# 0-job startup_failure.
 
 name: Dogfood Release Notes
 
@@ -9,12 +11,12 @@ on:
   pull_request:
     types: [opened, synchronize]
 
-permissions:
-  contents: read
-  id-token: write
-  pull-requests: write
-
 jobs:
   highlights:
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
     uses: ./.github/workflows/cc-release-notes.yml
-    secrets: inherit
+    secrets:
+      GH_ACTION_AI_API_KEY: ${{ secrets.GH_ACTION_AI_API_KEY }}

--- a/examples/dep-review-caller.yml
+++ b/examples/dep-review-caller.yml
@@ -4,8 +4,10 @@
 # `opened` only: Renovate force-pushes rebases constantly and the assessment
 # does not change; the dedup marker makes any re-run a cheap no-op anyway.
 #
-# No concurrency block on purpose: a caller sharing the reusable workflow's
-# exact concurrency group causes an opaque 0-job startup_failure.
+# Permissions are job-scoped and the secret is passed explicitly (not
+# `secrets: inherit`) so zizmor-audited repos stay clean. No concurrency
+# block on purpose: a caller sharing the reusable workflow's exact
+# concurrency group causes an opaque 0-job startup_failure.
 
 name: Dep Review
 
@@ -13,12 +15,12 @@ on:
   pull_request:
     types: [opened]
 
-permissions:
-  contents: read
-  id-token: write
-  pull-requests: write
-
 jobs:
   review:
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
     uses: dryvist/ai-workflows/.github/workflows/cc-dep-review.yml@main
-    secrets: inherit
+    secrets:
+      GH_ACTION_AI_API_KEY: ${{ secrets.GH_ACTION_AI_API_KEY }}

--- a/examples/release-notes-caller.yml
+++ b/examples/release-notes-caller.yml
@@ -4,8 +4,10 @@
 # PRs, refreshed only when the head SHA changes. Non-release PRs are skipped
 # by the gate at negligible cost.
 #
-# No concurrency block on purpose: a caller sharing the reusable workflow's
-# exact concurrency group causes an opaque 0-job startup_failure.
+# Permissions are job-scoped and the secret is passed explicitly (not
+# `secrets: inherit`) so zizmor-audited repos stay clean. No concurrency
+# block on purpose: a caller sharing the reusable workflow's exact
+# concurrency group causes an opaque 0-job startup_failure.
 
 name: Release Notes
 
@@ -13,12 +15,12 @@ on:
   pull_request:
     types: [opened, synchronize]
 
-permissions:
-  contents: read
-  id-token: write
-  pull-requests: write
-
 jobs:
   highlights:
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
     uses: dryvist/ai-workflows/.github/workflows/cc-release-notes.yml@main
-    secrets: inherit
+    secrets:
+      GH_ACTION_AI_API_KEY: ${{ secrets.GH_ACTION_AI_API_KEY }}


### PR DESCRIPTION
## Summary

- Consumer-repo rollout of the ai-pr-care caller hit nix-ai's **zizmor** pre-commit hook: `secrets: inherit` fails at medium severity and workflow-level `id-token: write`/`pull-requests: write` at high.
- Fix for real (no suppressions): declare `GH_ACTION_AI_API_KEY` in `on.workflow_call.secrets` of `cc-dep-review.yml` and `cc-release-notes.yml` so callers can pass it explicitly; `secrets: inherit` callers keep working unchanged.
- Examples + dogfood callers updated to the canonical zizmor-clean shape: job-scoped permissions, explicit secret.

## Test plan

- `bun test` green (no script changes).
- Verified against a real zizmor v1.22.0 run in nix-ai: job-scoped permissions clear the high findings; explicit secrets clear the medium ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JEgmkietfTQuv2tTfM4hD