### PR TITLE
fix: validate check-runs API response in _ai-merge-gate

### DIFF
--- a/.github/workflows/_ai-merge-gate.yml
+++ b/.github/workflows/_ai-merge-gate.yml
@@ -35,8 +35,18 @@ jobs:
     steps:
       - name: Verify Copilot agent checks
         run: |
-          FAILED=$(gh api "repos/${{ github.repository }}/commits/${HEAD_SHA}/check-runs" \
-            --jq '[.check_runs[] | select(.app.slug | test("copilot"; "i")) | select(.conclusion == "failure" or .conclusion == "timed_out")] | length')
+          # The API occasionally returns a transient HTML error page; piping it
+          # straight into --jq crashed the gate (false-negative merge block).
+          # Retry with backoff and require a numeric answer before judging.
+          for i in 1 2 3; do
+            FAILED=$(gh api "repos/${{ github.repository }}/commits/${HEAD_SHA}/check-runs" \
+              --jq '[.check_runs[] | select(.app.slug | test("copilot"; "i")) | select(.conclusion == "failure" or .conclusion == "timed_out")] | length') && break
+            sleep $((i * 5))
+          done
+          if ! [[ "$FAILED" =~ ^[0-9]+$ ]]; then
+            echo "::error::check-runs API unreadable after retries"
+            exit 1
+          fi
           echo "Copilot agent failures: $FAILED"
           if [ "$FAILED" -gt "0" ]; then
             echo "::error::$FAILED Copilot agent check(s) failed"


### PR DESCRIPTION
## Summary

- Applies the fix prescribed in #302: retry the `check-runs` API call 3× with linear backoff, and treat a non-numeric/empty `$FAILED` as an explicit "API unreadable" error instead of letting a transient HTML error page crash `--jq` and false-negative-block the merge.

Fixes #302

## Test plan

- Inline bash logic (retry loop + numeric guard) matches the shape verified in the issue against run 28615346011's failure mode; gate behavior unchanged on valid responses (0 failures → pass, N>0 → fail with count).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JEgmkietfTQuv2tTfM4hD