### PR TITLE
feat: declare GH_APP_CLAUDE_BOT_PRIVATE_KEY on review-thread-resolver

### DIFF
--- a/.github/workflows/review-thread-resolver.yml
+++ b/.github/workflows/review-thread-resolver.yml
@@ -56,6 +56,14 @@ on:
         description: "Comma-separated repo names to sweep (org-sweep mode)"
         type: string
         default: ""
+    secrets:
+      GH_APP_CLAUDE_BOT_PRIVATE_KEY:
+        description: >-
+          JacobPEvans-claude App private key. Enables resolving bot-authored
+          threads, which the default GITHUB_TOKEN usually cannot. Pass it
+          explicitly (preferred, zizmor-clean) or via secrets: inherit. If
+          absent, the workflow falls back to GITHUB_TOKEN and warns per thread.
+        required: false
   workflow_dispatch:
     inputs:
       pr_number:
@@ -81,6 +89,10 @@ jobs:
     name: Resolve bot review threads
     runs-on: ${{ inputs.runner_label || 'ubuntu-latest' }}
     timeout-minutes: 10
+    # Map the secret to env so the mint steps can skip (and fall back to
+    # GITHUB_TOKEN) when a caller passes no App key, instead of hard-failing.
+    env:
+      APP_KEY: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}
     steps:
       - name: Checkout ai-workflows scripts
         uses: actions/checkout@v6
@@ -91,7 +103,7 @@ jobs:
 
       - name: Mint App token (single repo)
         id: app-token
-        if: vars.GH_APP_CLAUDE_BOT_ID != '' && inputs.sweep_repos == ''
+        if: vars.GH_APP_CLAUDE_BOT_ID != '' && env.APP_KEY != '' && inputs.sweep_repos == ''
         uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
@@ -99,7 +111,7 @@ jobs:
 
       - name: Mint App token (org sweep)
         id: app-token-sweep
-        if: vars.GH_APP_CLAUDE_BOT_ID != '' && inputs.sweep_repos != ''
+        if: vars.GH_APP_CLAUDE_BOT_ID != '' && env.APP_KEY != '' && inputs.sweep_repos != ''
         uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}

--- a/examples/review-thread-resolver-caller.yml
+++ b/examples/review-thread-resolver-caller.yml
@@ -1,13 +1,16 @@
 # Example consumer caller for review-thread-resolver (event-driven mode).
 #
-# Most repos do NOT need this file: the hub's scheduled org sweep
-# (dogfood-review-thread-sweep.yml in dryvist/ai-workflows) already covers
-# every repo listed in the org AI_SWEEP_REPOS variable. Add this caller only
-# when a busy repo wants instant resolution on PR events instead of waiting
-# for the hourly sweep.
+# Gives a repo INSTANT resolution of stale/failed bot review threads on PR
+# events, instead of waiting up to an hour for the hub's org sweep
+# (dogfood-review-thread-sweep.yml in dryvist/ai-workflows). Repos in the org
+# AI_SWEEP_REPOS list are covered by that sweep regardless; add this caller
+# when instant resolution is worth a per-repo file.
 #
-# No concurrency block on purpose: a caller sharing the reusable workflow's
-# exact concurrency group causes an opaque 0-job startup_failure.
+# Permissions are job-scoped and the App key is passed explicitly (not
+# `secrets: inherit`) so zizmor-audited repos stay clean. contents: write is
+# required by the resolveReviewThread GraphQL mutation. No concurrency block on
+# purpose: a caller sharing the reusable workflow's exact concurrency group
+# causes an opaque 0-job startup_failure.
 
 name: Review Thread Resolver
 
@@ -17,12 +20,11 @@ on:
   pull_request_review:
     types: [submitted]
 
-# contents: write is required by the resolveReviewThread GraphQL mutation.
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   resolve:
+    permissions:
+      contents: write
+      pull-requests: write
     uses: dryvist/ai-workflows/.github/workflows/review-thread-resolver.yml@main
-    secrets: inherit
+    secrets:
+      GH_APP_CLAUDE_BOT_PRIVATE_KEY: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

Prep for rolling the event-driven review-thread-resolver caller to zizmor-audited repos (nix-ai etc.).

- Declares `GH_APP_CLAUDE_BOT_PRIVATE_KEY` in `review-thread-resolver.yml`'s `workflow_call.secrets` so callers can pass it explicitly instead of `secrets: inherit` (which zizmor flags at medium).
- Mint steps now gate on the key being present (`env.APP_KEY != ''`) and fall back to `GITHUB_TOKEN` with per-thread warnings if absent, instead of hard-failing.
- Example caller updated to the canonical zizmor-clean shape: job-scoped `contents: write` + `pull-requests: write`, explicit secret.

Same pattern as #313 (dep-review / release-notes).

## Context

Verified today that the resolver resolves a real outdated gemini thread end-to-end (dispatched against a controlled test PR: `Resolved 1 thread(s)`, thread → resolved via the App token). This unblocks the fleet rollout of the instant-resolution caller.

## Test plan

- `bun test` green (no script changes).
- Reusable workflow + example only; dogfood sweep keeps working via `secrets: inherit` (inherit satisfies the now-declared optional secret).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JEgmkietfTQuv2tTfM4hD