### PR TITLE
fix: responder commits via shared verified-commit (native signing is dead in reusable)

### DIFF
--- a/.github/workflows/cc-pr-review-responder.yml
+++ b/.github/workflows/cc-pr-review-responder.yml
@@ -83,7 +83,8 @@ jobs:
           INPUT_PR: ${{ inputs.pr_number }}
         run: |
           echo "number=$INPUT_PR" >> "$GITHUB_OUTPUT"
-          echo "sha=$(gh pr view "$INPUT_PR" --repo "$GITHUB_REPOSITORY" --json headRefOid --jq .headRefOid)" >> "$GITHUB_OUTPUT"
+          gh pr view "$INPUT_PR" --repo "$GITHUB_REPOSITORY" --json headRefOid,headRefName \
+            --jq '"sha=\(.headRefOid)\nref=\(.headRefName)"' >> "$GITHUB_OUTPUT"
 
       - name: Checkout PR head
         uses: actions/checkout@v6
@@ -107,10 +108,12 @@ jobs:
           REPO_CONTEXT: ${{ inputs.repo_context }}
         run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/pr-review-responder.md PR_NUMBER REPO_CONTEXT
 
-      # Claude edits files (committed NATIVELY to the PR branch via use_commit_signing)
-      # and drives reply + resolveReviewThread through `gh api graphql`. The App token
-      # minted by run-claude-code backs both the verified commit and Claude's gh calls
-      # (the default GITHUB_TOKEN is often rejected resolving bot-authored threads).
+      # Claude only EDITS files + drives reply/resolveReviewThread via `gh api graphql`;
+      # it does NOT commit. Native use_commit_signing cannot resolve a branch on a
+      # review-triggered reusable (observed base_branch:"" → committed nothing), so a
+      # separate step commits Claude's edits via the shared verified-commit helper —
+      # the same path cc-ci-fix uses. app_id/app_private_key here give Claude's `gh`
+      # the App token (the default GITHUB_TOKEN is often rejected resolving bot threads).
       - name: Run Claude Code
         uses: dryvist/ai-workflows/.github/actions/run-claude-code@main
         with:
@@ -120,5 +123,26 @@ jobs:
           claude_code_oauth_token: ${{ secrets.GH_ACTION_AI_API_KEY }}
           app_id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
           app_private_key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}
-          use_commit_signing: "true"
+          use_commit_signing: "false"
           allowed_bots: "gemini-code-assist,copilot-pull-request-reviewer,github-actions"
+
+      # Mint an App token so the commit is GitHub-VERIFIED + bot-attributed
+      # (satisfies required_signatures, re-triggers CI). Reuses cc-ci-fix's commit
+      # wrapper → shared verified-commit.js; no responder-specific code.
+      - name: Mint commit token
+        id: commit-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
+          private-key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}
+
+      - name: Commit fixes to PR branch
+        uses: actions/github-script@v9
+        env:
+          HEAD_BRANCH: ${{ github.event.pull_request.head.ref || steps.pr.outputs.ref }}
+          COMMIT_MESSAGE: "fix: address review feedback (AI responder)"
+        with:
+          github-token: ${{ steps.commit-token.outputs.token }}
+          script: |
+            const run = require('./.ai-workflows/.github/scripts/ci-fix/commit-fix.js');
+            await run({ github, context, core });

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ docs/PATTERNS.md "Non-AI Utility Workflow Pattern".
 - Static prompts: most workflows
 - Dynamic prompts (ci-fix, post-merge-tests, post-merge-docs-review): `render-prompt.sh` with named env vars
 - Write workflows (code-simplifier, next-steps, post-merge-*, ci-fix,
-  issue-resolver): Claude only EDITS files (`use_commit_signing: "false"`, no
+  issue-resolver, pr-review-responder): Claude only EDITS files (`use_commit_signing: "false"`, no
   git-write/`gh pr`/`gh api` write tools); a workflow step lands a GitHub-VERIFIED
   commit/PR via `createCommitOnBranch` (shared `scripts/shared/verified-commit.js`).
   This is mandatory — native `use_commit_signing` cannot target a branch on our

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -717,18 +717,21 @@ verified-commit wrapper). All of it collapsed into configuration by switching to
 | Fork guard + own-bot loop guard + attempt cap | One job-level **`if:`** (same-repo head + sender not our bot) |
 | Fetch review threads (GraphQL) | `Bash(gh api graphql)` **in the prompt** |
 | Reply + `resolveReviewThread` | `gh api graphql` **in the prompt** (no native action support for this) |
-| Verified commit via `createCommitOnBranch` | `claude-code-action`'s **native** `use_commit_signing: "true"` — see below |
+| Verified commit | Claude edits only; a step commits via the **shared** `verified-commit.js` (reused `ci-fix/commit-fix.js`) |
 
-**Why native commit works here (and not for the write-workflows above).** The
-Verified Commit Pattern exists because `workflow_run`/`issues`/`schedule`/`dispatch`
-triggers give the action no branch to resolve. Review events
-(`pull_request_review`, `pull_request_review_comment`) **carry open-PR context**, so
-`use_commit_signing: "true"` pushes a GitHub-verified commit **straight to the PR
-branch** (docs: *"On open PRs: always pushes directly to the existing PR branch"*).
-That satisfies `required_signatures` and re-triggers CI with no `verified-commit.js`.
-The App token minted by `run-claude-code` (pass `app_id` + `app_private_key`) backs
-both that commit **and** Claude's `gh api graphql` calls — the default `GITHUB_TOKEN`
-is often rejected resolving bot-authored threads (needs Contents-RW).
+**Why NOT native commit here (learned by E2E, 2026-07-03).** `claude-code-action`'s
+docs say `use_commit_signing: "true"` pushes to the PR branch "on open PRs", so the
+first cut relied on it. A live E2E proved it **does not work** when the responder is
+a `workflow_call` reusable triggered by a review event: the action logged
+`base_branch: ""` and committed **nothing**, while Claude still replied and resolved
+the thread — a silent false-positive (thread resolved, fix never landed). The
+open-PR-context branch resolution evidently does not survive the reusable/review-event
+indirection (same class as the `workflow_run` dead-end the Verified Commit Pattern
+documents). So the responder uses the **standard** path: Claude edits + replies +
+resolves; then a `Mint commit token` + `Commit fixes` step lands the working-tree
+edits via the shared `verified-commit.js` (through `ci-fix/commit-fix.js`) — no
+responder-specific code. `app_id`/`app_private_key` on `run-claude-code` still give
+Claude's `gh` the App token needed to resolve bot-authored threads.
 
 **Consumer caller** (`examples/pr-review-responder-caller.yml`): triggers on
 `pull_request_review: [submitted]` + `pull_request_review_comment: [created]`. No


### PR DESCRIPTION
## Why

The just-merged `cc-pr-review-responder` relied on `claude-code-action` **native** `use_commit_signing: "true"` to commit fixes to the PR branch. A live E2E on a real `pull_request_review_comment` event proved that **does not work** when the responder is a `workflow_call` reusable triggered by a review event:

- The action logged `base_branch: ""` and committed **nothing**.
- Claude still replied and resolved the thread → **silent false positive** (thread resolved, fix never landed, file unchanged).

Same class of dead-end the Verified Commit Pattern already documents for `workflow_run` — the open-PR-context branch resolution doesn't survive the reusable/review-event indirection.

## Fix (no new code)

Claude edits + replies + resolves (unchanged); then a `Mint commit token` + `Commit fixes` step lands the working-tree edits via the **shared** `verified-commit.js` (reusing `ci-fix/commit-fix.js`). Also resolves the head `ref` for the dispatch path (needed as the commit branch) and corrects the docs.

## E2E validation (this fix)

Dispatched the fixed reusable at PR #324 (unresolved thread requesting PENDING→VALIDATED):
- ✅ Verified bot commit `e3d647c` (`jacobpevans-claude[bot]`, verified=true) landed on the branch
- ✅ File actually changed to `VALIDATED`
- ✅ Thread resolved (Claude even self-corrected the prior false-positive reply)
- ✅ PR not merged

Event trigger, loop guard, concurrency dedup, and gh-graphql reply/resolve were all validated in the first (native) run; only the commit path needed this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)