### PR TITLE
fix: responder forwards explicit secrets, not inherit

### DIFF
--- a/.github/workflows/cc-pr-review-responder.yml
+++ b/.github/workflows/cc-pr-review-responder.yml
@@ -36,7 +36,19 @@ on:
         description: "Additional allowed tools beyond defaults (e.g., Bash(tofu:*))"
         type: string
         default: ""
-    # No `secrets:` block: callers forward org-level secrets via `secrets: inherit`.
+    secrets:
+      GH_ACTION_AI_API_KEY:
+        description: >-
+          Provider-agnostic AI key mapped to the action's
+          claude_code_oauth_token. Required — the action errors without it.
+        required: true
+      GH_APP_CLAUDE_BOT_PRIVATE_KEY:
+        description: >-
+          JacobPEvans-claude App private key. Mints the App token used for the
+          verified commit and for resolving bot-authored threads (the default
+          GITHUB_TOKEN usually cannot). Pass it explicitly (preferred,
+          zizmor-clean) rather than via secrets: inherit.
+        required: false
   workflow_dispatch:
     inputs:
       pr_number:

--- a/.github/workflows/dogfood-pr-review-responder.yml
+++ b/.github/workflows/dogfood-pr-review-responder.yml
@@ -19,4 +19,6 @@ jobs:
     uses: ./.github/workflows/cc-pr-review-responder.yml
     with:
       repo_context: "Reusable AI agent workflows for GitHub Actions; consumer repos call these with thin callers."
-    secrets: inherit # zizmor: ignore[secrets-inherit]
+    secrets:
+      GH_ACTION_AI_API_KEY: ${{ secrets.GH_ACTION_AI_API_KEY }}
+      GH_APP_CLAUDE_BOT_PRIVATE_KEY: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}

--- a/examples/pr-review-responder-caller.yml
+++ b/examples/pr-review-responder-caller.yml
@@ -34,6 +34,8 @@ jobs:
     # with:
     #   repo_context: "Terraform modules for the homelab Proxmox cluster."
     #
-    # Org-level secrets can only be forwarded via `inherit`. zizmor's secrets-inherit
-    # audit is a false positive here (this is a first-party reusable).
-    secrets: inherit # zizmor: ignore[secrets-inherit]
+    # Forward only the two secrets the reusable declares — explicit and
+    # zizmor-clean, no `secrets: inherit`.
+    secrets:
+      GH_ACTION_AI_API_KEY: ${{ secrets.GH_ACTION_AI_API_KEY }}
+      GH_APP_CLAUDE_BOT_PRIVATE_KEY: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
## What

Give `cc-pr-review-responder.yml` a `workflow_call.secrets` block declaring the two secrets it actually consumes:

- `GH_ACTION_AI_API_KEY` (required — the AI action errors without it)
- `GH_APP_CLAUDE_BOT_PRIVATE_KEY` (optional — mints the App token for the verified commit + bot-thread resolution)

Every caller (`examples/pr-review-responder-caller.yml`, `dogfood-pr-review-responder.yml`) now forwards those two **by name** instead of `secrets: inherit`, and the `# zizmor: ignore[secrets-inherit]` suppressions are gone.

## Why

A consumer repo's zizmor pre-commit hook blocks bare `secrets: inherit`. Rather than copy the ignore-comment into every consumer, this fixes the root cause: the reusable now supports explicit secret forwarding — the same pattern the sibling `review-thread-resolver.yml` already documents as *"preferred, zizmor-clean."* No check is silenced; the finding is eliminated.

## Unblocks

The `dryvist/nix-screenpipe` responder caller (separate PR), which must forward named secrets to stay zizmor-clean. **Merge this first** — the consumer caller references `@main` and named-secret forwarding requires the reusable to declare them.

## Verification

- `actionlint` clean on both changed workflows (dogfood's local `uses:` cross-checks the new secrets block).
- `bun test` 182/0 (no JS touched).
- Pre-commit zizmor passes with no secrets-inherit finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)