### PR TITLE
fix: issue workflows mint an App token instead of OIDC exchange

### DIFF
--- a/.github/workflows/issue-hygiene.yml
+++ b/.github/workflows/issue-hygiene.yml
@@ -60,12 +60,17 @@ jobs:
         id: prompt
         run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/issue-hygiene.md
 
-      - name: Execute Claude Code
-        uses: anthropics/claude-code-action@v1
+      # Use run-claude-code (mints a JacobPEvans-claude App token) instead of the
+      # raw action's OIDC exchange: that exchange 401s ("no write access") on
+      # private repos where the App has write but the OIDC identity does not.
+      - name: Run Claude Code
+        uses: dryvist/ai-workflows/.github/actions/run-claude-code@main
         with:
-          claude_code_oauth_token: ${{ secrets.GH_ACTION_AI_API_KEY }}
-          allowed_bots: "github-actions"
           prompt: ${{ steps.prompt.outputs.content }}
-          claude_args: >-
-            --allowedTools "Read,Glob,Grep,LS,Bash(gh issue:*),Bash(gh pr:*),Bash(gh search:*)"
-            --model ${{ vars.GH_ACTION_AI_MODEL_ISSUES || vars.GH_ACTION_AI_MODEL }}
+          model: ${{ vars.GH_ACTION_AI_MODEL_ISSUES || vars.GH_ACTION_AI_MODEL }}
+          allowed_tools: "Read,Glob,Grep,LS,Bash(gh issue:*),Bash(gh pr:*),Bash(gh search:*)"
+          claude_code_oauth_token: ${{ secrets.GH_ACTION_AI_API_KEY }}
+          app_id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
+          app_private_key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}
+          use_commit_signing: "false"
+          allowed_bots: "github-actions"

--- a/.github/workflows/issue-sweeper.yml
+++ b/.github/workflows/issue-sweeper.yml
@@ -59,12 +59,17 @@ jobs:
         id: prompt
         run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/issue-sweeper.md
 
-      - name: Execute Claude Code
-        uses: anthropics/claude-code-action@v1
+      # Use run-claude-code (mints a JacobPEvans-claude App token) instead of the
+      # raw action's OIDC exchange: that exchange 401s ("no write access") on
+      # private repos where the App has write but the OIDC identity does not.
+      - name: Run Claude Code
+        uses: dryvist/ai-workflows/.github/actions/run-claude-code@main
         with:
-          claude_code_oauth_token: ${{ secrets.GH_ACTION_AI_API_KEY }}
-          allowed_bots: "github-actions"
           prompt: ${{ steps.prompt.outputs.content }}
-          claude_args: >-
-            --allowedTools "Read,Glob,Grep,LS,Bash(gh issue:*),Bash(gh pr:*),Bash(gh search:*),Bash(gh api:*)"
-            --model ${{ vars.GH_ACTION_AI_MODEL_ISSUES || vars.GH_ACTION_AI_MODEL }}
+          model: ${{ vars.GH_ACTION_AI_MODEL_ISSUES || vars.GH_ACTION_AI_MODEL }}
+          allowed_tools: "Read,Glob,Grep,LS,Bash(gh issue:*),Bash(gh pr:*),Bash(gh search:*),Bash(gh api:*)"
+          claude_code_oauth_token: ${{ secrets.GH_ACTION_AI_API_KEY }}
+          app_id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
+          app_private_key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}
+          use_commit_signing: "false"
+          allowed_bots: "github-actions"

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -57,12 +57,17 @@ jobs:
           ISSUE_NUMBER: ${{ inputs.issue_number || '0' }}
         run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/issue-triage.md ISSUE_NUMBER
 
-      - name: Run Claude
-        uses: anthropics/claude-code-action@v1
+      # Use run-claude-code (mints a JacobPEvans-claude App token) instead of the
+      # raw action's OIDC exchange: that exchange 401s ("no write access") on
+      # private repos where the App has write but the OIDC identity does not.
+      - name: Run Claude Code
+        uses: dryvist/ai-workflows/.github/actions/run-claude-code@main
         with:
-          claude_code_oauth_token: ${{ secrets.GH_ACTION_AI_API_KEY }}
-          allowed_bots: "github-actions"
           prompt: ${{ steps.prompt.outputs.content }}
-          claude_args: >-
-            --allowedTools "Read,Glob,Grep,LS,Bash(gh issue:*),Bash(gh search:*)"
-            --model ${{ vars.GH_ACTION_AI_MODEL_ISSUES || vars.GH_ACTION_AI_MODEL }}
+          model: ${{ vars.GH_ACTION_AI_MODEL_ISSUES || vars.GH_ACTION_AI_MODEL }}
+          allowed_tools: "Read,Glob,Grep,LS,Bash(gh issue:*),Bash(gh search:*)"
+          claude_code_oauth_token: ${{ secrets.GH_ACTION_AI_API_KEY }}
+          app_id: ${{ vars.GH_APP_CLAUDE_BOT_ID }}
+          app_private_key: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}
+          use_commit_signing: "false"
+          allowed_bots: "github-actions"


### PR DESCRIPTION
## What

`issue-sweeper`, `issue-hygiene`, and `issue-triage` called `anthropics/claude-code-action@v1` **directly** with `claude_code_oauth_token` + `id-token: write`. That path's OIDC→app-token exchange returns:

```
App token exchange failed: 401 Unauthorized - User does not have write access on this repository
```

…on **private** repos (nix-screenpipe) while succeeding on public ones — the OIDC identity lacks write where the `JacobPEvans-claude` App has it.

This switches them to the **`run-claude-code` composite** (the same path every write-workflow already uses), which mints a `JacobPEvans-claude` installation token and passes it as `github_token`. Claude's `gh` then has write regardless of repo visibility.

## Why this way

- The App-install scope isn't Terraform-manageable (tofu-github has no app-install resource), and `JacobPEvans-claude` already has write on nix-screenpipe (Post-Merge reviews prove it) — so an explicit App token is the guaranteed, IaC-free fix.
- Callers already use `secrets: inherit`, so `GH_APP_CLAUDE_BOT_PRIVATE_KEY` flows through with **no caller change**.
- `use_commit_signing: "false"` — these workflows make no file commits (issue/PR ops only).

## Scope

`issue-backlog-sweep` is **intentionally left** on the raw action: not deployed on any private repo, works on its public consumers, and has its own downstream App-token/label step.

## Verification

- `actionlint` clean on all 3.
- `bun test` 182/0 (no JS touched).
- Post-merge: dispatch `issue-sweeper`/`issue-hygiene` on nix-screenpipe → "Run Claude Code" reaches the model with no 401; next scheduled runs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)