### PR TITLE
chore(renovate): thin to org default preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended",
-    "local>dryvist/.github"
-  ],
-  "packageRules": [
-    {
-      "matchPackageNames": ["anthropics/claude-code-base-action"],
-      "groupName": "claude-code-base-action"
-    }
-  ]
+  "extends": ["local>dryvist/.github"]
 }


### PR DESCRIPTION
Thins this repo's Renovate wrapper to just `["local>dryvist/.github"]`. That bare reference now resolves to the org `default.json`, which already provides `config:recommended` + the full master policy, so any extra `extends` entries were redundant. No behavioral change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CB5heppQHhv8xE1XWeeFVA