### PR TITLE
docs(dep-review): reframe as advisory-only after auto-merge removal

### DIFF
--- a/.github/prompts/dep-review.md
+++ b/.github/prompts/dep-review.md
@@ -1,17 +1,20 @@
-# Dependency Update Risk Review (untrusted tier)
+# Dependency Update Risk Review (advisory)
 
 Review dependency update PR #${PR_NUMBER} in this repository. A dependency bot
 (Renovate or Dependabot) opened it; the highest version-bump type is
-`${UPDATE_TYPE}`. The package is in the **untrusted tier** of the dryvist
-dependency-freshness model (dryvist/.github → SECURITY.md → Dependency Trust) —
-it is NOT on the trusted-org allowlist, so it does not auto-merge on trust
-alone. Assess the risk of this specific update, record a verdict label, and
+`${UPDATE_TYPE}`. This review is **advisory only** — it runs under the separate
+AI Merge Gate and reports a risk signal for a maintainer; it never merges,
+approves, or gates anything. Renovate owns all dependency merging under the org's
+publisher-agnostic freshness model (dryvist/.github → SECURITY.md → Dependency
+Trust). Assess the risk of this specific update, record a verdict label, and
 write a short advisory for the maintainer.
 
-You are ONE signal among several. A separate native gate (GitHub Dependency
-Review) independently blocks vulnerable or disallowed dependencies and you
-cannot override it; auto-merge (when a repo enables it) only ever fires on your
-`risk:low` verdict AFTER that native gate has already passed.
+You are ONE signal among several — advisory, not a gate. A separate, deterministic
+native gate (GitHub Dependency Review) independently blocks vulnerable or
+disallowed dependencies and you cannot override it. You have no ability to
+trigger, block, or influence auto-merge in either direction: Renovate merges (or
+doesn't) on its own schedule, independent of the label or comment you produce
+here.
 
 ## Non-negotiable safety rules
 
@@ -58,8 +61,9 @@ when the PR body's release notes are truncated or missing) to establish:
 
 - **`risk:low`** — patch or minor update, established package, changelog present
   and benign, diff consistent with the version bump, no install-time scripts, no
-  native/blob/permission changes, no maintainer or provenance anomalies. Eligible
-  for auto-merge only if the native gate also passes.
+  native/blob/permission changes, no maintainer or provenance anomalies. Signals a
+  routine update to the maintainer — advisory only, it does not trigger or gate
+  Renovate's merge.
 - **`risk:medium`** — a major update, OR anything unverifiable or mildly unusual:
   thin/missing changelog, new maintainer, added scripts you judge benign, a
   larger-than-expected diff, new transitive deps. Needs a human.

--- a/.github/workflows/cc-dep-review.yml
+++ b/.github/workflows/cc-dep-review.yml
@@ -1,11 +1,13 @@
-# CC Dep Review — the untrusted-tier dependency gate.
+# CC Dep Review — supply-chain defense in depth for dependency-bot PRs.
 #
 # The INVERSE of Layer 3 (docs/PATTERNS.md → "Dependency bot filtering"): every
 # other AI workflow SKIPS renovate/dependabot PRs; this one runs ONLY on them.
-# It is the untrusted-tier reviewer in the org dependency-freshness model
-# (dryvist/.github → SECURITY.md → Dependency Trust): Renovate auto-merges
-# first-party + trusted minor/patch and opens trusted majors for a human; the
-# untrusted long tail — everything else — lands here.
+# It runs on EVERY Renovate/Dependabot PR (not a trust-tier subset), reported
+# under the separate AI Merge Gate. Renovate owns all merging under the org
+# dependency-freshness model (dryvist/.github → SECURITY.md → Dependency
+# Trust): minor/patch auto-merges publisher-agnostically after a 3-day soak +
+# green CI; majors open for review. This workflow NEVER merges: it is a
+# deterministic native gate plus an advisory AI signal.
 #
 # Defense in depth, two layers. The DETERMINISTIC native gate is authoritative;
 # the AI is one added signal that CANNOT override it:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Reusable AI agent workflows for GitHub Actions. Each workflow is a
 |----------|---------|----------|--------------|
 | `best-practices.yml` | `workflow_call` | Wed 3am UTC | Weekly audit creating actionable best-practices recommendations |
 | `cc-ci-fix.yml` | `workflow_run` | On CI failure | Analyzes failed CI logs and pushes fixes (max 2 attempts per PR) |
-| `cc-dep-review.yml` | `pull_request: [opened]` | On Renovate PR | Native Dependency Review + AI `risk:*` label + sticky comment; opt-in auto-merge |
+| `cc-dep-review.yml` | `pull_request: [opened]` | On Renovate PR | Native Dependency Review (authoritative) + advisory AI `risk:*` label + sticky comment — never merges; Renovate owns merging |
 | `cc-code-simplifier.yml` | `workflow_call` | Daily 4am UTC | Simplifies recently changed code for clarity and maintainability (functionality preserved); opens a PR |
 | `cc-release-notes.yml` | `pull_request` | On release PR | Posts sticky AI release-highlights comment on release-please PRs (refreshed per head SHA) |
 | `issue-hygiene.yml` | `workflow_call` | Mon 7am UTC | Detects duplicates, links merged PRs, flags stale issues |

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -385,10 +385,11 @@ Loop prevention is handled by the attempt counter (`check-attempts.js`, max 2 at
 ### Inverse of Layer 3: the dependency-review gate
 
 `cc-dep-review.yml` is the deliberate **inverse** of Layer 3 — it runs ONLY on
-dependency-bot PRs and skips everything else. It is the untrusted-tier reviewer in the org
-dependency-freshness model (dryvist/.github → SECURITY.md → Dependency Trust): Renovate
-auto-merges first-party + trusted minor/patch and opens trusted majors for a human; the
-untrusted long tail lands in this workflow.
+dependency-bot PRs and skips everything else. It is two layers, reported under the
+separate AI Merge Gate (dryvist/.github → SECURITY.md → Dependency Trust): a
+deterministic native gate and an advisory AI review. Renovate owns all merging under
+its publisher-agnostic freshness model; this workflow has no internal auto-merge — it
+only labels and comments.
 
 A `check-eligibility` job is the inverse gate: it runs the paid Claude review ONLY when the
 PR author is a dependency bot (`bot_authors`), the highest bump type is in scope
@@ -401,9 +402,9 @@ if (!authors.includes(login)) return skip(`author "${login}" is not a dependency
 ```
 
 Defense in depth: a native `actions/dependency-review-action` job is authoritative (fails
-closed on vulnerable/transitive deps, AI-independent); the Claude reviewer is one added
-signal that applies a `risk:*` label and posts one sticky advisory comment; opt-in
-auto-merge fires only on `risk:low` + native-gate-green + non-major.
+closed on vulnerable/transitive deps, AI-independent); the Claude reviewer is one added,
+advisory-only signal that applies a `risk:*` label and posts one sticky comment — it has
+no merge or auto-merge authority of any kind.
 
 ### Layer 4: Post-merge commit-author check (JS scripts)
 


### PR DESCRIPTION
## Summary

- `.github/prompts/dep-review.md` — retitled and reframed the review as advisory-only, running under the separate AI Merge Gate; it never merges, approves, or gates. Dropped the "untrusted tier" / "auto-merge only fires on risk:low" framing. The risk-label rubric (low/medium/high) is unchanged — still a signal for the maintainer, no longer described as an auto-merge trigger.
- `README.md` — corrected the `cc-dep-review.yml` workflow-table row: was "opt-in auto-merge", now states the native gate is authoritative and the AI review is advisory (no internal auto-merge; Renovate owns merging).
- `docs/PATTERNS.md` — rewrote the "Inverse of Layer 3: the dependency-review gate" section to describe two layers (deterministic native gate + advisory AI review) instead of the removed opt-in auto-merge mechanism.

Follows #337, which removed cc-dep-review's internal auto-merge job (the workflow YAML itself). This PR only touches docs/prompt text.

## Test plan

- [x] `grep -niE 'risk:low subset|opt-in auto-merge|does not auto-merge on trust|untrusted tier' .github/prompts/dep-review.md README.md docs/PATTERNS.md` → zero matches