### PR TITLE
chore(security): SHA-pin third-party actions (partial #344)

### DIFF
--- a/.github/workflows/best-practices.yml
+++ b/.github/workflows/best-practices.yml
@@ -116,7 +116,7 @@ jobs:
         run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/best-practices.md
 
       - name: Run Claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@536f2c32a39763739000b0e1ac69ca2647d97ce9 # v1.0.170
         with:
           claude_code_oauth_token: ${{ secrets.GH_ACTION_AI_API_KEY }}
           allowed_bots: "github-actions"

--- a/.github/workflows/cc-next-steps.yml
+++ b/.github/workflows/cc-next-steps.yml
@@ -120,7 +120,7 @@ jobs:
       # issue for Option B). For Option A it writes .claude-pr.md; the steps below open a
       # VERIFIED PR from it. gh issue:* stays allowed for the issue-creation path.
       - name: Execute Claude Code
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@536f2c32a39763739000b0e1ac69ca2647d97ce9 # v1.0.170
         with:
           claude_code_oauth_token: ${{ secrets.GH_ACTION_AI_API_KEY }}
           allowed_bots: "github-actions"

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -18,4 +18,4 @@ jobs:
     runs-on: ${{ inputs.runner_label }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0

--- a/.github/workflows/gh-aw-sync-upstream.yml
+++ b/.github/workflows/gh-aw-sync-upstream.yml
@@ -65,7 +65,7 @@ jobs:
         run: gh aw compile --action-tag v0.68.1
 
       - name: Open PR on drift
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           branch: gh-aw/sync-upstream
           delete-branch: true

--- a/.github/workflows/issue-backlog-sweep.yml
+++ b/.github/workflows/issue-backlog-sweep.yml
@@ -127,7 +127,7 @@ jobs:
       # Claude only JUDGES (read-only + writes the JSON verdict file). It applies no
       # labels — the App-token step below does that so `ai:ready` fires the resolver.
       - name: Execute Claude Code
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@536f2c32a39763739000b0e1ac69ca2647d97ce9 # v1.0.170
         with:
           claude_code_oauth_token: ${{ secrets.GH_ACTION_AI_API_KEY }}
           allowed_bots: "github-actions"

--- a/.github/workflows/issue-linker.yml
+++ b/.github/workflows/issue-linker.yml
@@ -110,7 +110,7 @@ jobs:
           github.event.pull_request.user.type != 'Bot' ||
           contains(inputs.allowed_bots, github.event.pull_request.user.login) ||
           contains(inputs.allowed_bots, '*')
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@536f2c32a39763739000b0e1ac69ca2647d97ce9 # v1.0.170
         with:
           claude_code_oauth_token: ${{ secrets.GH_ACTION_AI_API_KEY }}
           allowed_bots: "github-actions"

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -52,7 +52,7 @@ jobs:
         run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/label-sync.md
 
       - name: Run Claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@536f2c32a39763739000b0e1ac69ca2647d97ce9 # v1.0.170
         with:
           claude_code_oauth_token: ${{ secrets.GH_ACTION_AI_API_KEY }}
           allowed_bots: "github-actions"

--- a/.github/workflows/repo-orchestrator.yml
+++ b/.github/workflows/repo-orchestrator.yml
@@ -52,7 +52,7 @@ jobs:
         run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/repo-orchestrator.md
 
       - name: Run Claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@536f2c32a39763739000b0e1ac69ca2647d97ce9 # v1.0.170
         with:
           claude_code_oauth_token: ${{ secrets.GH_ACTION_AI_API_KEY }}
           allowed_bots: "github-actions"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,5 +20,5 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
       - run: bun test

--- a/.github/workflows/update-version-tags.yml
+++ b/.github/workflows/update-version-tags.yml
@@ -15,4 +15,4 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: cssnr/update-version-tags-action@v2
+      - uses: cssnr/update-version-tags-action@dc7077eaec04b8fd61f7b7e6d4830564cfd12382 # v2.1.1


### PR DESCRIPTION
## What

SHA-pin all hand-authored third-party GitHub Actions flagged by zizmor `unpinned-uses` to 40-hex commit SHAs (with precise `# vX.Y.Z` comments):

- `anthropics/claude-code-action@v1` → `536f2c3…` v1.0.170 (×6: best-practices, cc-next-steps, issue-backlog-sweep, issue-linker, label-sync, repo-orchestrator)
- `oven-sh/setup-bun@v2` → `0c5077e…` v2.2.0 (copilot-setup-steps, test)
- `peter-evans/create-pull-request@v8` → `5f6978f…` v8.1.1 (gh-aw-sync-upstream)
- `cssnr/update-version-tags-action@v2` → `dc7077e…` v2.1.1 (update-version-tags)

These publishers are not in the central `zizmor.yml` ref-pin allowlist, so the blanket hash-pin policy applies.

## Scope / partial fix

**The zizmor gate stays disabled** (`ci-gate.yml` `zizmor: false` is untouched). This PR does NOT close #344. The remaining findings are `ref-version-mismatch` in gh-aw-generated `.lock.yml` files, which need a pin *re-resolution* via the repo's own `gh-aw-pin-refresh.yml` (dispatched separately) — recompiling with the pinned gh-aw version alone reproduces the same mismatches. `excessive-permissions`, `github-app`, and `dangerous-triggers` findings are held for separate review.

Related #344

Assisted-by: Claude:claude-opus-4-8