### PR TITLE
feat(reusables): derive repo_context/workflow_name from github.* context

### DIFF
--- a/.github/workflows/cc-ci-fix.yml
+++ b/.github/workflows/cc-ci-fix.yml
@@ -24,9 +24,12 @@ on:
         type: string
         default: "5"
       repo_context:
-        description: "Brief description of the repository"
+        description: >-
+          Brief description of the repository. Optional — defaults to the
+          repo's own GitHub description (github.event.repository.description).
         type: string
-        required: true
+        required: false
+        default: ""
       ci_structure:
         description: "Description of CI workflows and what they check"
         type: string
@@ -216,7 +219,7 @@ jobs:
       - name: Render prompt
         id: prompt
         env:
-          REPO_CONTEXT: ${{ inputs.repo_context }}
+          REPO_CONTEXT: ${{ inputs.repo_context || github.event.repository.description }}
           CI_STRUCTURE: ${{ inputs.ci_structure }}
           FAILURE_LOGS: ${{ needs.get-failure-details.outputs.failure_logs }}
         run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/ci-fix.md FAILURE_LOGS REPO_CONTEXT CI_STRUCTURE

--- a/.github/workflows/cc-issue-resolver.yml
+++ b/.github/workflows/cc-issue-resolver.yml
@@ -18,9 +18,12 @@ on:
         required: false
         default: ubuntu-latest
       repo_context:
-        description: "Brief description of the repository for Claude's context"
+        description: >-
+          Brief description of the repository for Claude's context. Optional —
+          defaults to the repo's GitHub description (github.event.repository.description).
         type: string
-        required: true
+        required: false
+        default: ""
       extra_tools:
         description: "Additional allowed tools beyond defaults (e.g., Bash(tofu:*))"
         type: string
@@ -130,7 +133,7 @@ jobs:
       - name: Render prompt
         id: prompt
         env:
-          REPO_CONTEXT: ${{ inputs.repo_context }}
+          REPO_CONTEXT: ${{ inputs.repo_context || github.event.repository.description }}
           ISSUE_NUMBER: ${{ needs.eligibility-check.outputs.issue_number }}
           ISSUE_TITLE: ${{ needs.eligibility-check.outputs.issue_title }}
           ISSUE_BODY: ${{ needs.eligibility-check.outputs.issue_body }}

--- a/.github/workflows/cc-pr-review-responder.yml
+++ b/.github/workflows/cc-pr-review-responder.yml
@@ -118,7 +118,7 @@ jobs:
         id: prompt
         env:
           PR_NUMBER: ${{ github.event.pull_request.number || steps.pr.outputs.number }}
-          REPO_CONTEXT: ${{ inputs.repo_context }}
+          REPO_CONTEXT: ${{ inputs.repo_context || github.event.repository.description }}
         run: bash .ai-workflows/.github/scripts/render-prompt.sh .ai-workflows/.github/prompts/pr-review-responder.md PR_NUMBER REPO_CONTEXT
 
       # Claude only EDITS files + drives reply/resolveReviewThread via `gh api graphql`;

--- a/.github/workflows/ci-fail-issue.yml
+++ b/.github/workflows/ci-fail-issue.yml
@@ -24,9 +24,13 @@ on:
         required: false
         default: ubuntu-latest
       workflow_name:
-        description: "Name of the CI workflow that failed"
+        description: >-
+          Name of the CI workflow that failed. Optional — defaults to the
+          triggering workflow's name (github.event.workflow_run.name, falling
+          back to github.workflow).
         type: string
-        required: true
+        required: false
+        default: ""
   workflow_dispatch:
 
 # Workflow-level permissions set the maximum for all jobs.
@@ -89,7 +93,7 @@ jobs:
         env:
           COMMIT_SHA: ${{ needs.should-create.outputs.commit_sha }}
           RUN_URL: ${{ needs.should-create.outputs.run_url }}
-          WORKFLOW_NAME: ${{ inputs.workflow_name }}
+          WORKFLOW_NAME: ${{ inputs.workflow_name || github.event.workflow_run.name || github.workflow }}
         with:
           script: |
             const run = require('./.ai-workflows/.github/scripts/ci-fail-issue/create-failure-issue.js');

--- a/.github/workflows/suite-ci.yml
+++ b/.github/workflows/suite-ci.yml
@@ -29,17 +29,23 @@ on:
         required: false
         default: ubuntu-latest
       repo_context:
-        description: "Brief description of the repository"
+        description: >-
+          Brief description of the repository. Optional — defaults to the repo's
+          own GitHub description (github.event.repository.description).
         type: string
-        required: true
+        required: false
+        default: ""
       ci_structure:
         description: "Description of CI workflows and what they check"
         type: string
         required: true
       workflow_name:
-        description: "Name of the CI workflow that failed (for issue creation)"
+        description: >-
+          Name of the CI workflow that failed (for issue creation). Optional —
+          defaults to the triggering workflow's name (github.event.workflow_run.name).
         type: string
-        required: true
+        required: false
+        default: ""
       extra_tools:
         description: "Additional allowed tools beyond defaults (e.g., Bash(tofu:*))"
         type: string


### PR DESCRIPTION
## Summary

First step in eliminating the per-repo AI Actions variables (`AI_REPO_CONTEXT`, `AI_CI_WORKFLOW_NAME`, …). Those 33 Terraform-managed variables across ~12 repos are a DRY violation — `AI_REPO_CONTEXT` is just a hand-maintained (and drifting) copy of each repo's own GitHub description, and the workflow name is already in the event.

This makes the reusables derive those values from the `github.*` context themselves, **backward-compatibly**.

## Changes

- `repo_context` → defaults to `${{ github.event.repository.description }}` when the input is empty — `cc-ci-fix.yml`, `cc-issue-resolver.yml`, `cc-pr-review-responder.yml`.
- `workflow_name` → defaults to `${{ github.event.workflow_run.name || github.workflow }}` — `ci-fail-issue.yml`.
- Both inputs (and the `suite-ci.yml` facade's) become `required: false, default: ""`.

## Backward compatible

A caller that still passes `repo_context`/`workflow_name` is unchanged (the input is honored when non-empty). So this merges safely **before** the per-repo callers are trimmed and the Terraform `github_actions_variable.ai` resource is deleted (which will obsolete the pending `Variables: write` requirement, dryvist/tofu-github#37).

## Safety

The description flows through the existing `env` → `render-prompt.sh` (`envsubst`) path — the safe pattern, never raw into a `run:` — and is repo-owner-controlled, the same trust boundary as the string it replaces. No new injection surface.

## Test plan

After merge, trigger a real AI-CI run on one consumer repo that no longer passes `repo_context` and confirm `REPO_CONTEXT` resolves to the repo's description in the rendered prompt. `actionlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)